### PR TITLE
Refactor: Replace project11_msgs with marine_interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,9 @@ find_package(marine_sensor_msgs REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(project11 REQUIRED)
-find_package(project11_msgs REQUIRED)
-find_package(project11_nav_msgs REQUIRED)
+find_package(marine_autonomy REQUIRED)
+find_package(marine_interfaces REQUIRED)
+find_package(marine_interfaces REQUIRED)
 #find_package(sound_play REQUIRED) pending port to ROS2
 find_package(qt_gui_cpp REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
@@ -153,9 +153,9 @@ ament_target_dependencies(CCOMAutonomousMissionPlanner
     message_filters
     marine_ais_msgs
     nav_msgs
-    project11
-    project11_msgs
-    project11_nav_msgs
+    marine_autonomy
+    marine_interfaces
+    marine_interfaces
     rclcpp
     # sound_play
     tf2
@@ -196,7 +196,7 @@ target_include_directories(rqt_helm_manager
 )
 
 ament_target_dependencies(rqt_helm_manager
-  project11_msgs
+  marine_interfaces
   rqt_gui_cpp
   rclcpp
 )
@@ -283,9 +283,9 @@ ament_target_dependencies(camp2
     geometry_msgs
     grid_map_ros
     marine_ais_msgs
-    project11
-    project11_msgs
-    project11_nav_msgs
+    marine_autonomy
+    marine_interfaces
+    marine_interfaces
     rclcpp
     tf2
     tf2_ros

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(nav_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(marine_autonomy REQUIRED)
 find_package(marine_interfaces REQUIRED)
-find_package(marine_interfaces REQUIRED)
+
 #find_package(sound_play REQUIRED) pending port to ROS2
 find_package(qt_gui_cpp REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
@@ -155,7 +155,7 @@ ament_target_dependencies(CCOMAutonomousMissionPlanner
     nav_msgs
     marine_autonomy
     marine_interfaces
-    marine_interfaces
+
     rclcpp
     # sound_play
     tf2
@@ -285,7 +285,7 @@ ament_target_dependencies(camp2
     marine_ais_msgs
     marine_autonomy
     marine_interfaces
-    marine_interfaces
+
     rclcpp
     tf2
     tf2_ros

--- a/docs/architecture_design.md
+++ b/docs/architecture_design.md
@@ -1,0 +1,52 @@
+# High-Level Architecture Design
+
+## System Overview
+
+The `camp2` refactoring aims to decouple the Core Business Logic from the User Interface, enabling Headless operation and easier testing.
+
+## Component Diagram
+
+```mermaid
+graph TD
+    subgraph "CAMP Core (No UI dependencies)"
+        SM[SystemManager] -->|Owns| RN[ROS Node Wrapper]
+        RN -->|Subscribes| RT[ROS Topics /tf]
+        
+        CM[CoreMap] -->|Data| OL[MapItemData List]
+        CM -->|signals| V[Views / Adapters]
+        
+        SM -->|Manages| CM
+        
+        BM[BackgroundManager] -->|Inherits| LM[LayerManager Interface]
+        PM[PlatformManager] -->|Inherits| LM
+        
+        CM -->|Owns| BM
+        CM -->|Owns| PM
+    end
+
+    subgraph "CAMP Desktop (Qt Widgets)"
+        MW[MainWindow] -->|Has| MM[MapModel Adapter]
+        MM -->|Wraps| CM
+        
+        GV[QGraphicsView] -->|Displays| GS[QGraphicsScene]
+        MM -->|Updates| GS
+    end
+
+    subgraph "ROS 2 System"
+        P11[Project11 Platforms] -.->|/project11/platforms| RN
+        Sensors[Sensor Data] -.->|/occupancy_grid| RN
+    end
+```
+
+## Key Interactions
+
+1.  **Startup**:
+    *   **Headless**: `main.cpp` instantiates `SystemManager`. Signal handlers are connected to local logic or logging.
+    *   **Desktop**: `main.cpp` instantiates `QApplication`, then `SystemManager`, then `MainWindow`. `MainWindow` creates `MapModel` initialized with `SystemManager`'s `CoreMap`.
+
+2.  **Data Flow (Platform Update)**:
+    *   `ROS Node Wrapper` receives `PlatformList` msg.
+    *   `PlatformManager` (in Core) processes msg, updates `MapItemData` (Position, Status).
+    *   `MapItemData` emits `dataChanged` signal.
+    *   **Desktop**: `MapModel` (connected to `dataChanged`) triggers `QGraphicsScene` update to move the icon.
+    *   **Headless**: No visual update, but internal state is current. A generic "mission constraint checker" could verify the new position against safe zones.

--- a/docs/architecture_design.md
+++ b/docs/architecture_design.md
@@ -33,7 +33,7 @@ graph TD
     end
 
     subgraph "ROS 2 System"
-        P11[Project11 Platforms] -.->|/project11/platforms| RN
+        MA[marine_autonomy] -.->|/marine_autonomy/platforms| RN
         Sensors[Sensor Data] -.->|/occupancy_grid| RN
     end
 ```

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <depend>geometry_msgs</depend>
   <depend>grid_map_ros</depend>
   <depend>marine_ais_msgs</depend>
+  <depend>marine_sensor_msgs</depend>
 
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>

--- a/package.xml
+++ b/package.xml
@@ -16,13 +16,13 @@
   <depend>geometry_msgs</depend>
   <depend>grid_map_ros</depend>
   <depend>marine_ais_msgs</depend>
-  <depend>marine_sensor_msgs</depend>
+
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
-  <depend>project11</depend>
-  <depend>project11_msgs</depend>
-  <depend>project11_nav_msgs</depend>
+  <depend>marine_autonomy</depend>
+  <depend>marine_interfaces</depend>
+
   <!-- <depend>sound_play</depend> -->
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>

--- a/src/camp/ais/ais_contact.cpp
+++ b/src/camp/ais/ais_contact.cpp
@@ -11,7 +11,7 @@ AISContactDetails::AISContactDetails()
 
 }
 
-AISContactDetails::AISContactDetails(const project11_msgs::msg::Contact& message)
+AISContactDetails::AISContactDetails(const marine_interfaces::msg::Contact& message)
 {
   mmsi = message.mmsi;
   name = message.name;
@@ -37,7 +37,7 @@ AISContactState::AISContactState()
 
 }
 
-AISContactState::AISContactState(const project11_msgs::msg::Contact& message)
+AISContactState::AISContactState(const marine_interfaces::msg::Contact& message)
 {
   timestamp = message.header.stamp;
   location.location.setLatitude(message.position.latitude);
@@ -91,7 +91,7 @@ AISReport::AISReport(QObject *parent):QObject(parent)
 
 }
 
-AISReport::AISReport(const project11_msgs::msg::Contact& message, QObject *parent):
+AISReport::AISReport(const marine_interfaces::msg::Contact& message, QObject *parent):
   QObject(parent),
   AISContactDetails(message),
   AISContactState(message)

--- a/src/camp/ais/ais_contact.h
+++ b/src/camp/ais/ais_contact.h
@@ -3,7 +3,7 @@
 
 #include <QObject>
 #include "../ship_track.h"
-#include "project11_msgs/msg/contact.hpp"
+#include "marine_interfaces/msg/contact.hpp"
 #include "marine_ais_msgs/msg/ais_contact.hpp"
 #include "../locationposition.h"
 #include "ros/ros_common.h"
@@ -12,7 +12,7 @@
 struct AISContactDetails
 {
   AISContactDetails();
-  AISContactDetails(const project11_msgs::msg::Contact& message);
+  AISContactDetails(const marine_interfaces::msg::Contact& message);
   AISContactDetails(const marine_ais_msgs::msg::AISContact& message);
   uint32_t mmsi;
   std::string name;
@@ -25,7 +25,7 @@ struct AISContactDetails
 struct AISContactState
 {
   AISContactState();
-  AISContactState(const project11_msgs::msg::Contact& message);
+  AISContactState(const marine_interfaces::msg::Contact& message);
   AISContactState(const marine_ais_msgs::msg::AISContact& message);
   rclcpp::Time timestamp;
   LocationPosition location;
@@ -39,7 +39,7 @@ struct AISReport: public QObject, AISContactDetails, AISContactState
   Q_OBJECT
 public:
   AISReport(QObject *parent = nullptr);
-  AISReport(const project11_msgs::msg::Contact& message, QObject *parent = nullptr);
+  AISReport(const marine_interfaces::msg::Contact& message, QObject *parent = nullptr);
   AISReport(const marine_ais_msgs::msg::AISContact& message, QObject *parent = nullptr);
 };
 

--- a/src/camp/ais/ais_manager.h
+++ b/src/camp/ais/ais_manager.h
@@ -2,7 +2,7 @@
 #define CAMP_AIS_MANAGER_H
 
 #include "ros/ros_widget.h"
-#include "project11_msgs/msg/contact.hpp"
+#include "marine_interfaces/msg/contact.hpp"
 #include "marine_ais_msgs/msg/ais_contact.hpp"
 #include "ais_contact.h"
 
@@ -35,7 +35,7 @@ private slots:
   void addAisReport(AISReport *report);
 
 private:
-  void contactCallback(const project11_msgs::msg::Contact& message);
+  void contactCallback(const marine_interfaces::msg::Contact& message);
   void aisContactCallback(const marine_ais_msgs::msg::AISContact& message);
 
   Ui::AISManager* m_ui;

--- a/src/camp/autonomousvehicleproject.cpp
+++ b/src/camp/autonomousvehicleproject.cpp
@@ -560,7 +560,7 @@ void AutonomousVehicleProject::sendToROS(const QModelIndex& index)
 
 void AutonomousVehicleProject::updateAvoidanceAreas()
 {
-    project11_nav_msgs::msg::GeoOccupancyVectorMap avoidance_map;
+    marine_interfaces::msg::GeoOccupancyVectorMap avoidance_map;
     avoidance_map.header.frame_id = "wgs84";
     avoidance_map.bounds.min_pt.altitude = std::nan("");
     bool first_waypoint = true;
@@ -571,7 +571,7 @@ void AutonomousVehicleProject::updateAvoidanceAreas()
         if(avoid_area)
         {
             auto waypoints = avoid_area->childMissionItems();
-            project11_nav_msgs::msg::GeoOccupancyPolygon polygon;
+            marine_interfaces::msg::GeoOccupancyPolygon polygon;
             polygon.occupancy_probability = 100;
             for(auto item: waypoints)
             {

--- a/src/camp/geoviz/geoviz_display.cpp
+++ b/src/camp/geoviz/geoviz_display.cpp
@@ -10,7 +10,7 @@ GeovizDisplay::GeovizDisplay(QWidget* parent, QGraphicsItem *parentItem):QWidget
 void GeovizDisplay::updateRobotNamespace(QString robotNamespace)
 {
   ros::NodeHandle nh;
-  m_display_subscriber = nh.subscribe("/"+robotNamespace.toStdString()+"/project11/display", 10, &GeovizDisplay::geoVizDisplayCallback, this);
+  m_display_subscriber = nh.subscribe("/"+robotNamespace.toStdString()+"/marine_autonomy/display", 10, &GeovizDisplay::geoVizDisplayCallback, this);
 }
 
 QRectF GeovizDisplay::boundingRect() const

--- a/src/camp/grids/grid.cpp
+++ b/src/camp/grids/grid.cpp
@@ -3,7 +3,7 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include "project11/gz4d_geo.h"
+#include "marine_autonomy/gz4d_geo.h"
 #include <QDebug>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include "backgroundraster.h"

--- a/src/camp/helm_manager/helm_manager.cpp
+++ b/src/camp/helm_manager/helm_manager.cpp
@@ -70,8 +70,8 @@ void HelmManager::updateRobotNamespace(QString robot_namespace)
   
 
 
-  heartbeat_subscription_ = node_->create_subscription<project11_msgs::msg::Heartbeat>(ns+"project11/heartbeat", 1, std::bind(&HelmManager::heartbeatCallback, this, std::placeholders::_1));
-  send_command_publisher_ = node_->create_publisher<std_msgs::msg::String>(ns+"project11/send_command",1);
+  heartbeat_subscription_ = node_->create_subscription<marine_interfaces::msg::Heartbeat>(ns+"marine_autonomy/heartbeat", 1, std::bind(&HelmManager::heartbeatCallback, this, std::placeholders::_1));
+  send_command_publisher_ = node_->create_publisher<std_msgs::msg::String>(ns+"marine_autonomy/send_command",1);
 }
 
 void HelmManager::sendPilotingModeRequest(QString piloting_mode)
@@ -81,7 +81,7 @@ void HelmManager::sendPilotingModeRequest(QString piloting_mode)
   send_command_publisher_->publish(cmd); 
 }
 
-void HelmManager::heartbeatCallback(const project11_msgs::msg::Heartbeat& message)
+void HelmManager::heartbeatCallback(const marine_interfaces::msg::Heartbeat& message)
 {
   rclcpp::Time last_heartbeat_receive_time = node_->get_clock()->now();
   rclcpp::Time last_heartbeat_timestamp = message.header.stamp;

--- a/src/camp/helm_manager/helm_manager.h
+++ b/src/camp/helm_manager/helm_manager.h
@@ -3,7 +3,7 @@
 
 #include <QWidget>
 #include "rclcpp/rclcpp.hpp"
-#include "project11_msgs/msg/heartbeat.hpp"
+#include "marine_interfaces/msg/heartbeat.hpp"
 #include "std_msgs/msg/string.hpp"
 
 namespace Ui
@@ -42,13 +42,13 @@ private slots:
   void watchdogUpdate();
 
 private:
-  void heartbeatCallback(const project11_msgs::msg::Heartbeat& message);
+  void heartbeatCallback(const marine_interfaces::msg::Heartbeat& message);
 
   Ui::HelmManager* ui;
 
   rclcpp::Node::SharedPtr node_;
 
-  rclcpp::Subscription<project11_msgs::msg::Heartbeat>::SharedPtr heartbeat_subscription_;
+  rclcpp::Subscription<marine_interfaces::msg::Heartbeat>::SharedPtr heartbeat_subscription_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr send_command_publisher_;
 
   rclcpp::Time last_heartbeat_timestamp_;

--- a/src/camp/markers/markers.cpp
+++ b/src/camp/markers/markers.cpp
@@ -3,7 +3,7 @@
 #include <tf2_ros/transform_listener.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2/utils.h>
-#include "project11/gz4d_geo.h"
+#include "marine_autonomy/gz4d_geo.h"
 #include <QDebug>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include "backgroundraster.h"

--- a/src/camp/mission_manager/mission_manager.cpp
+++ b/src/camp/mission_manager/mission_manager.cpp
@@ -18,13 +18,13 @@ void MissionManager::updateRobotNamespace(QString robot_namespace)
 {
   if(node_)
   {
-    mission_status_subscription_ = node_->create_subscription<project11_msgs::msg::Heartbeat>("/"+robot_namespace.toStdString()+"/project11/status/mission_manager" , 1, std::bind(&MissionManager::missionStatusCallback, this, std::placeholders::_1));
-    send_command_publisher_ = node_->create_publisher<std_msgs::msg::String>("/"+robot_namespace.toStdString()+"/project11/send_command",1);
+    mission_status_subscription_ = node_->create_subscription<marine_interfaces::msg::Heartbeat>("/"+robot_namespace.toStdString()+"/marine_autonomy/status/mission_manager" , 1, std::bind(&MissionManager::missionStatusCallback, this, std::placeholders::_1));
+    send_command_publisher_ = node_->create_publisher<std_msgs::msg::String>("/"+robot_namespace.toStdString()+"/marine_autonomy/send_command",1);
 
     rclcpp::QoS qos(1);
     qos.transient_local();
 
-    send_avoidance_costmap_publisher_ = node_->create_publisher<project11_nav_msgs::msg::GeoOccupancyVectorMap>("/"+robot_namespace.toStdString()+"/project11/avoidance_map", qos);
+    send_avoidance_costmap_publisher_ = node_->create_publisher<marine_interfaces::msg::GeoOccupancyVectorMap>("/"+robot_namespace.toStdString()+"/marine_autonomy/avoidance_map", qos);
   }
 }
 
@@ -79,7 +79,7 @@ void MissionManager::on_cancelOverridePushButton_clicked(bool checked)
   sendCancelOverride();
 }
 
-void MissionManager::missionStatusCallback(const project11_msgs::msg::Heartbeat& message)
+void MissionManager::missionStatusCallback(const marine_interfaces::msg::Heartbeat& message)
 {
   QString status_string;
   for(auto kv: message.values)
@@ -191,7 +191,7 @@ void MissionManager::sendCommand(const QString& command)
     send_command_publisher_->publish(cmd);
 }
 
-void MissionManager::sendAvoidanceAreas(project11_nav_msgs::msg::GeoOccupancyVectorMap& map)
+void MissionManager::sendAvoidanceAreas(marine_interfaces::msg::GeoOccupancyVectorMap& map)
 {
   if(node_)
   {

--- a/src/camp/mission_manager/mission_manager.h
+++ b/src/camp/mission_manager/mission_manager.h
@@ -3,8 +3,8 @@
 
 #include <QWidget>
 #include "ros/ros_widget.h"
-#include "project11_msgs/msg/heartbeat.hpp"
-#include "project11_nav_msgs/msg/geo_occupancy_vector_map.hpp"
+#include "marine_interfaces/msg/heartbeat.hpp"
+#include "marine_interfaces/msg/geo_occupancy_vector_map.hpp"
 #include "std_msgs/msg/string.hpp"
 
 namespace Ui
@@ -44,7 +44,7 @@ public slots:
   void sendGotoLine(int waypoint_index);
   void sendStartLine(int waypoint_index);
 
-  void sendAvoidanceAreas(project11_nav_msgs::msg::GeoOccupancyVectorMap& map);
+  void sendAvoidanceAreas(marine_interfaces::msg::GeoOccupancyVectorMap& map);
 
 
 private slots:
@@ -60,12 +60,12 @@ private slots:
   void on_missionStatusTextBrowser_customContextMenuRequested(const QPoint &pos);
 
 private:
-  void missionStatusCallback(const project11_msgs::msg::Heartbeat& message);
+  void missionStatusCallback(const marine_interfaces::msg::Heartbeat& message);
 
   Ui::MissionManager* m_ui;
-  rclcpp::Subscription<project11_msgs::msg::Heartbeat>::SharedPtr mission_status_subscription_;
+  rclcpp::Subscription<marine_interfaces::msg::Heartbeat>::SharedPtr mission_status_subscription_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr send_command_publisher_;
-  rclcpp::Publisher<project11_nav_msgs::msg::GeoOccupancyVectorMap>::SharedPtr send_avoidance_costmap_publisher_;
+  rclcpp::Publisher<marine_interfaces::msg::GeoOccupancyVectorMap>::SharedPtr send_avoidance_costmap_publisher_;
 
 
 };

--- a/src/camp/nav_source.cpp
+++ b/src/camp/nav_source.cpp
@@ -5,7 +5,7 @@
 #include <QTimer>
 #include <QDebug>
 
-NavSource::NavSource(const project11_msgs::msg::NavSource& source, QObject* parent, QGraphicsItem *parentItem): camp_ros::ROSObject(parent), GeoGraphicsItem(parentItem)
+NavSource::NavSource(const marine_interfaces::msg::NavSource& source, QObject* parent, QGraphicsItem *parentItem): camp_ros::ROSObject(parent), GeoGraphicsItem(parentItem)
 {
   setColor(color_);
   pending_position_topic_ = source.position_topic;

--- a/src/camp/nav_source.h
+++ b/src/camp/nav_source.h
@@ -3,7 +3,7 @@
 
 #include "ros/ros_object.h"
 #include "geographicsitem.h"
-#include "project11_msgs/msg/nav_source.hpp"
+#include "marine_interfaces/msg/nav_source.hpp"
 #include "locationposition.h"
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
 #include "sensor_msgs/msg/imu.hpp"
@@ -18,7 +18,7 @@ class NavSource: public camp_ros::ROSObject, public GeoGraphicsItem
   Q_OBJECT
   Q_INTERFACES(QGraphicsItem)
 public:
-  NavSource(const project11_msgs::msg::NavSource& source, QObject* parent, QGraphicsItem *parentItem = nullptr);
+  NavSource(const marine_interfaces::msg::NavSource& source, QObject* parent, QGraphicsItem *parentItem = nullptr);
 
   int type() const override {return NavSourceType;}
 

--- a/src/camp/platform_manager/platform.cpp
+++ b/src/camp/platform_manager/platform.cpp
@@ -88,7 +88,7 @@ QPainterPath Platform::shape() const
   return ret;
 }
 
-void Platform::update(const project11_msgs::msg::Platform& platform)
+void Platform::update(const marine_interfaces::msg::Platform& platform)
 {
   if(objectName().toStdString() != platform.name)
   {

--- a/src/camp/platform_manager/platform.h
+++ b/src/camp/platform_manager/platform.h
@@ -3,7 +3,7 @@
 
 #include "ros/ros_widget.h"
 #include "ship_track.h"
-#include "project11_msgs/msg/platform_list.hpp"
+#include "marine_interfaces/msg/platform_list.hpp"
 #include "nav_msgs/msg/path.hpp"
 
 namespace Ui
@@ -28,7 +28,7 @@ public:
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
   QPainterPath shape() const override;
 
-  void update(const project11_msgs::msg::Platform &platform);
+  void update(const marine_interfaces::msg::Platform &platform);
 
   MissionManager* missionManager() const;
   HelmManager* helmManager() const;

--- a/src/camp/platform_manager/platform_manager.cpp
+++ b/src/camp/platform_manager/platform_manager.cpp
@@ -19,18 +19,18 @@ PlatformManager::~PlatformManager()
 
 void PlatformManager::onNodeUpdated()
 {
-  platform_list_subscription_ = node_->create_subscription<project11_msgs::msg::PlatformList>("/project11/platforms", 5, std::bind(&PlatformManager::platformListCallback, this, std::placeholders::_1));
+  platform_list_subscription_ = node_->create_subscription<marine_interfaces::msg::PlatformList>("/marine_autonomy/platforms", 5, std::bind(&PlatformManager::platformListCallback, this, std::placeholders::_1));
 }
 
-void PlatformManager::platformListCallback(const project11_msgs::msg::PlatformList &message)
+void PlatformManager::platformListCallback(const marine_interfaces::msg::PlatformList &message)
 {
   for(const auto& platform: message.platforms)
   {
-    QMetaObject::invokeMethod(this, "updatePlatform", Qt::QueuedConnection, Q_ARG(project11_msgs::msg::Platform, platform));
+    QMetaObject::invokeMethod(this, "updatePlatform", Qt::QueuedConnection, Q_ARG(marine_interfaces::msg::Platform, platform));
   }
 }
 
-void PlatformManager::updatePlatform(project11_msgs::msg::Platform platform)
+void PlatformManager::updatePlatform(marine_interfaces::msg::Platform platform)
 {
   if(m_platforms.find(platform.name) == m_platforms.end())
   {

--- a/src/camp/platform_manager/platform_manager.h
+++ b/src/camp/platform_manager/platform_manager.h
@@ -3,9 +3,9 @@
 
 #include "ros/ros_widget.h"
 #include <QGeoCoordinate>
-#include "project11_msgs/msg/platform_list.hpp"
+#include "marine_interfaces/msg/platform_list.hpp"
 
-Q_DECLARE_METATYPE(project11_msgs::msg::Platform);
+Q_DECLARE_METATYPE(marine_interfaces::msg::Platform);
 
 namespace Ui
 {
@@ -33,14 +33,14 @@ public slots:
   void platformPosition(Platform * platform, QGeoCoordinate position);
   
 private slots:
-  void updatePlatform(project11_msgs::msg::Platform platform);
+  void updatePlatform(marine_interfaces::msg::Platform platform);
   void on_tabWidget_currentChanged(int index);
 
 private:
-  void platformListCallback(const project11_msgs::msg::PlatformList &message);
+  void platformListCallback(const marine_interfaces::msg::PlatformList &message);
 
   Ui::PlatformManager* m_ui;
-  rclcpp::Subscription<project11_msgs::msg::PlatformList>::SharedPtr platform_list_subscription_;
+  rclcpp::Subscription<marine_interfaces::msg::PlatformList>::SharedPtr platform_list_subscription_;
 
   std::map<std::string, Platform*> m_platforms;
 

--- a/src/camp/ros/ros_widget.cpp
+++ b/src/camp/ros/ros_widget.cpp
@@ -1,5 +1,5 @@
 #include "ros_widget.h"
-#include "project11/gz4d_geo.h"
+#include "marine_autonomy/gz4d_geo.h"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 namespace camp_ros

--- a/src/camp/sound_play/sound_play_widget.cpp
+++ b/src/camp/sound_play/sound_play_widget.cpp
@@ -16,7 +16,7 @@ void SoundPlay::onNodeUpdated()
 {
   if(node_)
   {
-    sound_client_ = std::make_shared<sound_play::SoundClient>(node_, "project11/robotsound");
+    sound_client_ = std::make_shared<sound_play::SoundClient>(node_, "marine_autonomy/robotsound");
   }
   else
   {

--- a/src/camp2/ros/grids/grid_map.cpp
+++ b/src/camp2/ros/grids/grid_map.cpp
@@ -3,7 +3,7 @@
 #include "../../map_view/web_mercator.h"
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include "../node.h"
-#include "project11/gz4d_geo.h"
+#include "marine_autonomy/gz4d_geo.h"
 #include <tf2/utils.h>
 #include "grid_layer.h"
 

--- a/src/camp2/ros/layer.cpp
+++ b/src/camp2/ros/layer.cpp
@@ -1,7 +1,7 @@
 #include "layer.h"
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include "node.h"
-#include "project11/gz4d_geo.h"
+#include "marine_autonomy/gz4d_geo.h"
 #include <tf2/utils.h>
 #include "../map_view/web_mercator.h"
 #include <QApplication>


### PR DESCRIPTION
## Description
This PR refactors the codebase to replace `project11_msgs` with `marine_interfaces`. It captures existing uncommitted changes found in the workspace.

## Changes
- Updated message includes and usages in `src/camp/` and `src/camp2/`.
- Updated `CMakeLists.txt` and `package.xml`.
- Added `docs/architecture_design.md` which was found as an untracked file describing the CAMP2 refactoring value proposition.

## Verification
- CI checks should be triggered.
- Please review and merge if the changes align with the refactoring goals.