### PR TITLE
fix: correct platforms topic name in PlatformManager

### DIFF
--- a/src/camp/platform_manager/platform_manager.cpp
+++ b/src/camp/platform_manager/platform_manager.cpp
@@ -19,7 +19,7 @@ PlatformManager::~PlatformManager()
 
 void PlatformManager::onNodeUpdated()
 {
-  platform_list_subscription_ = node_->create_subscription<marine_interfaces::msg::PlatformList>("/marine_autonomy/platforms", 5, std::bind(&PlatformManager::platformListCallback, this, std::placeholders::_1));
+  platform_list_subscription_ = node_->create_subscription<marine_interfaces::msg::PlatformList>("/marine/platforms", 5, std::bind(&PlatformManager::platformListCallback, this, std::placeholders::_1));
 }
 
 void PlatformManager::platformListCallback(const marine_interfaces::msg::PlatformList &message)


### PR DESCRIPTION
## Summary

- Fix `PlatformManager` subscription topic from `/marine_autonomy/platforms` to `/marine/platforms`
- `platform_sender` publishes to `/marine/platforms`, so CAMP was never receiving platform data

See #44 for follow-up to use topic discovery by message type instead of a hardcoded topic name.

Closes #43

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
