### PR TITLE
fix: correct marine_autonomy/ topic names to marine/ in helm and mission managers

### DIFF
--- a/src/camp/helm_manager/helm_manager.cpp
+++ b/src/camp/helm_manager/helm_manager.cpp
@@ -70,8 +70,8 @@ void HelmManager::updateRobotNamespace(QString robot_namespace)
   
 
 
-  heartbeat_subscription_ = node_->create_subscription<marine_interfaces::msg::Heartbeat>(ns+"marine_autonomy/heartbeat", 1, std::bind(&HelmManager::heartbeatCallback, this, std::placeholders::_1));
-  send_command_publisher_ = node_->create_publisher<std_msgs::msg::String>(ns+"marine_autonomy/send_command",1);
+  heartbeat_subscription_ = node_->create_subscription<marine_interfaces::msg::Heartbeat>(ns+"marine/heartbeat", 1, std::bind(&HelmManager::heartbeatCallback, this, std::placeholders::_1));
+  send_command_publisher_ = node_->create_publisher<std_msgs::msg::String>(ns+"marine/send_command",1);
 }
 
 void HelmManager::sendPilotingModeRequest(QString piloting_mode)

--- a/src/camp/mission_manager/mission_manager.cpp
+++ b/src/camp/mission_manager/mission_manager.cpp
@@ -18,13 +18,13 @@ void MissionManager::updateRobotNamespace(QString robot_namespace)
 {
   if(node_)
   {
-    mission_status_subscription_ = node_->create_subscription<marine_interfaces::msg::Heartbeat>("/"+robot_namespace.toStdString()+"/marine_autonomy/status/mission_manager" , 1, std::bind(&MissionManager::missionStatusCallback, this, std::placeholders::_1));
-    send_command_publisher_ = node_->create_publisher<std_msgs::msg::String>("/"+robot_namespace.toStdString()+"/marine_autonomy/send_command",1);
+    mission_status_subscription_ = node_->create_subscription<marine_interfaces::msg::Heartbeat>("/"+robot_namespace.toStdString()+"/marine/status/mission_manager" , 1, std::bind(&MissionManager::missionStatusCallback, this, std::placeholders::_1));
+    send_command_publisher_ = node_->create_publisher<std_msgs::msg::String>("/"+robot_namespace.toStdString()+"/marine/send_command",1);
 
     rclcpp::QoS qos(1);
     qos.transient_local();
 
-    send_avoidance_costmap_publisher_ = node_->create_publisher<marine_interfaces::msg::GeoOccupancyVectorMap>("/"+robot_namespace.toStdString()+"/marine_autonomy/avoidance_map", qos);
+    send_avoidance_costmap_publisher_ = node_->create_publisher<marine_interfaces::msg::GeoOccupancyVectorMap>("/"+robot_namespace.toStdString()+"/marine/avoidance_map", qos);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes remaining `marine_autonomy/` → `marine/` topic name mismatches in CAMP after the package rename.

- **`helm_manager.cpp`**: Fix `heartbeat` subscription and `send_command` publisher topic names
- **`mission_manager.cpp`**: Fix `status/mission_manager` subscription, `send_command` publisher, and `avoidance_map` publisher topic names

## Changes

5 string replacements across 2 files — all `marine_autonomy/` prefixes in ROS topic strings changed to `marine/`. C++ `#include` directives using the package name are unchanged (those are correct).

## Test plan

- [x] `colcon build --packages-select camp` succeeds
- [ ] With simulation running, verify topic connections:
  - `ros2 topic info /ben/marine/heartbeat` — camp appears as subscriber
  - `ros2 topic info /ben/marine/send_command` — camp appears as publisher
  - `ros2 topic info /ben/marine/status/mission_manager` — camp appears as subscriber
  - `ros2 topic info /ben/marine/avoidance_map` — camp appears as publisher

Closes #43

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`