### PR TITLE
TopicBridge + executor contract (#48)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,13 @@ if(CMAKE_VERSION VERSION_LESS "3.7.0")
     set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()
 
-find_package(Qt5 COMPONENTS Core Widgets Test Concurrent Positioning Network Svg Xml)
+find_package(Qt5 5.15 COMPONENTS Core Widgets Test Concurrent Positioning Network Svg Xml)
 
 if (Qt5Widgets_FOUND)
-    if (Qt5Widgets_VERSION VERSION_LESS 5.6.0)
-        message(FATAL_ERROR "Minimum supported Qt5 version is 5.6!")
+    if (Qt5Widgets_VERSION VERSION_LESS 5.15.0)
+        message(FATAL_ERROR "Minimum supported Qt5 version is 5.15 "
+            "(camp_ros bridges use the Qt 5.10+ functor overload of "
+            "QMetaObject::invokeMethod; ROS 2 Jazzy ships Qt 5.15).")
     endif()
 else()
     message(SEND_ERROR "The Qt5Widgets library could not be found!")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(SOURCES
     src/camp/platform_manager/platform_manager.cpp
     src/camp/projectview.cpp
     src/camp/ros/node_thread.cpp
+    src/camp/ros/ros_context.cpp
     src/camp/ros/ros_object.cpp
     src/camp/ros/ros_widget.cpp
     src/camp/searchpattern.cpp
@@ -314,6 +315,62 @@ install (DIRECTORY launch
 
 install (DIRECTORY workspace
     DESTINATION share/${PROJECT_NAME})
+
+
+# ----------------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------------
+# Tests for the camp_ros bridge templates and the ports built on them.
+# See docs/decisions/0001-topicbridge-and-executor-contract.md for the
+# threading/TF contract these tests pin down.
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(visualization_msgs REQUIRED)
+  find_package(std_msgs REQUIRED)
+
+  # TopicBridge / TfDispatcher / RosContext
+  ament_add_gtest(test_topic_bridge
+    test/test_topic_bridge.cpp
+    src/camp/ros/ros_context.cpp
+  )
+  target_include_directories(test_topic_bridge PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp
+  )
+  ament_target_dependencies(test_topic_bridge
+    rclcpp
+    tf2_ros
+    tf2_geometry_msgs
+    message_filters
+    std_msgs
+    geometry_msgs
+    visualization_msgs
+  )
+  target_link_libraries(test_topic_bridge
+    Qt5::Core
+    Qt5::Test
+  )
+
+  # Marker converter unit tests
+  ament_add_gtest(test_markers_converter
+    test/test_markers_converter.cpp
+  )
+  target_include_directories(test_markers_converter PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp
+  )
+  ament_target_dependencies(test_markers_converter
+    rclcpp
+    tf2
+    tf2_ros
+    tf2_geometry_msgs
+    geometry_msgs
+    visualization_msgs
+    marine_autonomy
+  )
+  target_link_libraries(test_markers_converter
+    Qt5::Core
+    Qt5::Positioning
+  )
+endif()
 
 
 ament_package(

--- a/docs/decisions/0001-topicbridge-and-executor-contract.md
+++ b/docs/decisions/0001-topicbridge-and-executor-contract.md
@@ -63,8 +63,9 @@ multiple inheritance.
 
 If a message has a header with a `frame_id`, its bridge wraps a `MessageFilter`
 keyed on the target frame. By the time the converter runs, the transform is
-already in the buffer; lookups inside the converter use `tf2::TimePointZero`
-and **no timeout**. No callback ever blocks waiting on TF.
+already in the buffer; lookups inside the converter pass the message stamp
+(or `tf2::TimePointZero` when the latest transform is genuinely intended) and
+use **no timeout**. No callback ever blocks waiting on TF.
 
 `ROSWidget::getGeoCoordinate()` and its `Grid::getGeoCoordinate()` clone are
 deleted **once all consumers are ported**. While ports are in flight (this PR

--- a/docs/decisions/0001-topicbridge-and-executor-contract.md
+++ b/docs/decisions/0001-topicbridge-and-executor-contract.md
@@ -56,8 +56,12 @@ exposes the same TF-gated dispatch pipeline without owning a subscription —
 callers feed it messages by hand.
 
 Bridges are **owned by the consuming Qt class as a member**, not inherited.
-The class hierarchy stops mixing ROS concerns and Qt scene concerns through
-multiple inheritance.
+The class hierarchy is being migrated away from mixing ROS concerns and Qt
+scene concerns through multiple inheritance; each port moves the consumer
+toward composition until the old `ROSWidget` / `GeoGraphicsItem` pattern
+disappears entirely. (The `Markers` exemplar in this PR still inherits both
+bases — that wider hierarchy cleanup is part of the migration plan below,
+not this PR.)
 
 ### 2. TF policy is expressed through `MessageFilter`, not through timeouts.
 
@@ -111,11 +115,14 @@ construction; the default for TF-gated bridges is **scene**.
 ### Supporting change: `RosContext`
 
 Replaces the manual `nodeStarted(node, buffer)` propagation through Qt parent
-chains. `RosContext` is a small process-singleton (set once during startup by
-`ROSLink`) that exposes the node, the TF buffer, and the named callback
-groups. Bridges discover their dependencies on construction; the
-`ROSClient::onNodeUpdated()` plumbing can be retired once all consumers have
-moved off it.
+chains. `RosContext` is a small process-singleton whose lifetime is owned by
+the ROS node thread: it is set during `camp_ros::NodeThread::start()`
+(immediately before the executor begins spinning) and cleared when the
+executor returns at shutdown. `ROSLink` only spawns the `NodeThread`; it
+does not own the singleton. `RosContext` exposes the node, the TF buffer,
+and the named callback groups. Bridges discover their dependencies on
+construction; the `ROSClient::onNodeUpdated()` plumbing can be retired once
+all consumers have moved off it.
 
 ## Consequences
 

--- a/docs/decisions/0001-topicbridge-and-executor-contract.md
+++ b/docs/decisions/0001-topicbridge-and-executor-contract.md
@@ -1,0 +1,186 @@
+# ADR-0001: `TopicBridge` and the executor contract
+
+## Status
+
+Accepted
+
+## Context
+
+`camp` predates most of the Project11 framework. It has accumulated structural
+drift in how it crosses the ROS-callback / Qt-main-thread boundary and how it
+consumes TF. The drift produces concrete user-visible problems:
+
+- TF lookups happen synchronously inside ROS subscriber callbacks. The shared
+  helper `ROSWidget::getGeoCoordinate()` (`src/camp/ros/ros_widget.cpp:14`) uses
+  a 1.5 s timeout. `Grid` reimplements it with a 0.5 s timeout and a different
+  exception policy (`src/camp/grids/grid.cpp:152`). When upstream TF stops, each
+  callback can block for the full timeout per call.
+- All camp subscriptions register on the node's default callback group
+  (`MutuallyExclusive`). One stalled callback queues every other camp
+  subscriber behind it, including heartbeat and nav. The `helm_manager`
+  watchdog then turns red because *its* callback can't fire — not because the
+  publisher is gone.
+- Several callbacks touch Qt scene APIs from the executor thread.
+  `Platform::pathCallback` (`src/camp/platform_manager/platform.cpp:241`) calls
+  `findParentBackgroundRaster()` and emits scene-related signals from the
+  executor; this has been latent-buggy for a long time.
+- Subscriber implementations duplicate the same skeleton (subscription
+  lifecycle, optional `MessageFilter`, optional try/catch, optional
+  cross-thread emit) with subtle drift each time. `Markers` does it correctly
+  via `tf2_ros::MessageFilter`; `Platform`'s path subscription does it raw,
+  with no try/catch, looping `getGeoCoordinate` per pose.
+- Class hierarchies mix ROS and Qt scene concerns by inheritance
+  (`ROSWidget` + `GeoGraphicsItem`). Adding a new TF-consuming widget means
+  understanding both halves and the seam between them.
+
+The pattern is strong enough that fixing it once class-by-class will keep
+regenerating warts. The codebase needs an explicit contract that names the
+right abstractions and makes the wrong patterns uncompilable.
+
+## Decision
+
+Adopt four interlocking conventions for any ROS-driven Qt component in `camp`.
+
+### 1. `TopicBridge<MsgT, PayloadT>` is the only sanctioned subscription path.
+
+`TopicBridge` is a header-only template that owns the `rclcpp::Subscription`,
+optionally wraps a `tf2_ros::MessageFilter`, runs a converter to produce a
+value-typed `PayloadT`, and dispatches the payload to a `QObject*` receiver via
+`QMetaObject::invokeMethod(..., Qt::QueuedConnection)`. It is **not** a
+`QObject` itself — using a non-`QObject` template avoids the moc-on-templates
+problem cleanly and lets a single template instance work for any payload type.
+
+For sub-stream cases (e.g. `MarkerArray` containing many stamped `Marker`s
+with different frame_ids), a sibling primitive `TfDispatcher<MsgT, PayloadT>`
+exposes the same TF-gated dispatch pipeline without owning a subscription —
+callers feed it messages by hand.
+
+Bridges are **owned by the consuming Qt class as a member**, not inherited.
+The class hierarchy stops mixing ROS concerns and Qt scene concerns through
+multiple inheritance.
+
+### 2. TF policy is expressed through `MessageFilter`, not through timeouts.
+
+If a message has a header with a `frame_id`, its bridge wraps a `MessageFilter`
+keyed on the target frame. By the time the converter runs, the transform is
+already in the buffer; lookups inside the converter use `tf2::TimePointZero`
+and **no timeout**. No callback ever blocks waiting on TF.
+
+`ROSWidget::getGeoCoordinate()` and its `Grid::getGeoCoordinate()` clone are
+deleted **once all consumers are ported**. While ports are in flight (this PR
+ports `Markers` only) the helper remains for unported consumers and is removed
+in the final port PR.
+
+Direct calls to `transform_buffer_->transform(...)` outside a bridge converter
+are a review-blocking smell from this point forward.
+
+### 3. The threading contract: no Qt scene access from the executor thread.
+
+Bridge converters and any code reachable from a ROS callback may only:
+
+- Read message data and TF buffer state (with no timeout).
+- Construct value-typed payloads.
+- Write to thread-safe internal buffers (mutex-protected) on the consumer.
+- Trigger the bridge's queued dispatch.
+
+They may **not** call `findParentBackgroundRaster`, `geoToPixel`,
+`prepareGeometryChange`, `QGraphicsItem::update`, or read/mutate any
+QGraphicsScene state. Those happen in the receiver slot, on the Qt main
+thread, after the queued dispatch.
+
+This is enforced structurally: the bridge holds a `QObject*` receiver only and
+does not hand the converter access to the consuming class's Qt parent.
+A converter that wants to call `geoToPixel` cannot — the data needed for
+`geoToPixel` (the BackgroundRaster) is reachable only from the receiver slot.
+
+### 4. Callback groups split by latency budget.
+
+The camp node exposes two `MutuallyExclusive` callback groups:
+
+- **realtime** — heartbeat, nav, helm, mission status, AIS heartbeat
+  (anything driving a watchdog or status indicator).
+- **scene** — markers, grid, path, AIS contacts (bulk display data, may have
+  expensive payload conversion).
+
+The existing `MultiThreadedExecutor` (`src/camp/ros/node_thread.cpp:16`)
+already supports two-group concurrency. With this split, a slow scene-callback
+cannot starve the watchdog inputs. New bridges select their group at
+construction; the default for TF-gated bridges is **scene**.
+
+### Supporting change: `RosContext`
+
+Replaces the manual `nodeStarted(node, buffer)` propagation through Qt parent
+chains. `RosContext` is a small process-singleton (set once during startup by
+`ROSLink`) that exposes the node, the TF buffer, and the named callback
+groups. Bridges discover their dependencies on construction; the
+`ROSClient::onNodeUpdated()` plumbing can be retired once all consumers have
+moved off it.
+
+## Consequences
+
+### Positive
+
+- New TF-consuming subscribers collapse to ~10 lines per consumer: declare a
+  bridge, declare a receiver slot, connect.
+- The "topic stops → camp stops updating everything" cascade is structurally
+  prevented (point 4) and the per-callback stall is eliminated (point 2).
+- Qt-from-executor-thread footguns become uncompilable rather than reviewable.
+- TF policy lives in one file. Tuning, instrumentation, and caching all have
+  an obvious home.
+- The ROS-side and Qt-side concerns of each consumer are physically
+  separated; the call boundary is value-typed and explicit.
+
+### Negative
+
+- Migration touches every TF-consuming widget: markers, grid, platform path,
+  nav source, AIS, and a handful of smaller consumers. Estimate 4-6 PRs for
+  full coverage.
+- `MessageFilter` drops messages whose TF doesn't resolve within
+  `buffer_timeout`. That is correct behavior, but it is a visible change for
+  any consumer that previously left stale data on screen by accident.
+- Templates in `TopicBridge` will increase build time modestly and produce
+  uglier compile errors. Mitigatable with explicit instantiation in a `.cpp`
+  if it bites in practice.
+- `RosContext` is a singleton, which is a small concession to ergonomics over
+  purity. Alternative (a `QObject` carried as an application-root property) is
+  available if the singleton form proves problematic.
+
+### Migration plan
+
+1. **This PR:** Land `TopicBridge`, `TfDispatcher`, `RosContext`, the ADR,
+   the `Markers` port, and test infrastructure.
+2. **Next PR:** Port `Platform::pathCallback`. This is the bug-fix port:
+   introduces `MessageFilter` for path, eliminates per-pose blocking, removes
+   Qt scene access from the executor thread, and adds the missing try/catch
+   for free.
+3. **Subsequent PRs:** Port `Grid` (delete its local `getGeoCoordinate`
+   override), then `NavSource`, `AisManager`, and remaining smaller consumers.
+4. **Cleanup PR:** Delete `ROSWidget::getGeoCoordinate()`, audit for any
+   remaining direct `transform_buffer_->transform(...)` calls, and retire the
+   `ROSClient::onNodeUpdated` plumbing.
+
+Each step is independently mergeable; reviewers can verify the per-class
+change in isolation.
+
+## Out of scope
+
+- The heavy per-pixel `QImage::setPixelColor` work in
+  `Grid::occupancyGridCallback` — a CPU concern, not a network/TF concern.
+  Worth a follow-up issue but not part of this restructure.
+- The `radar/` subsystem — confirmed not currently used.
+- `camp2`. This decision applies to the legacy `camp/` subsystem only;
+  `camp2` already starts from a cleaner separation.
+- The topic-discovery pattern in `*Manager::scanForSources()` (#44).
+  `TopicBridge` is the natural building block for that work, but the discovery
+  layer itself is independent and is not addressed here.
+
+## Related
+
+- camp #48 — this work
+- camp #44 — topic discovery factor-out (complementary, not subsumed)
+- camp #31 — ROS reconnect robustness (made easier by this contract, not
+  fixed here)
+
+---
+**Authored-By**: `Claude Code Agent`
+**Model**: `Claude Opus 4.7 (1M context)`

--- a/src/camp/markers/markers.cpp
+++ b/src/camp/markers/markers.cpp
@@ -186,7 +186,7 @@ void Markers::setTopic(std::string topic, std::string type)
 
     // Build the dispatcher (target frame "earth", buffer 50 messages, drop
     // after 1 s without TF — preserves prior behavior).
-    marker_dispatcher_ = std::make_unique<
+    marker_dispatcher_ = std::make_shared<
       camp_ros::TfDispatcher<visualization_msgs::msg::Marker, std::shared_ptr<MarkerData>>>(
         node_, transform_buffer_, "earth", 50, std::chrono::seconds(1),
         makeMarkerConverter(node_),
@@ -222,13 +222,21 @@ void Markers::setPixelSize(double s)
 
 void Markers::onMarkerArrayMessage(const visualization_msgs::msg::MarkerArray & data)
 {
-  // Runs on the ROS executor thread; setTopic on the Qt thread can replace
-  // marker_dispatcher_ underneath us, so guard against the race.
-  std::lock_guard<std::mutex> lock(marker_dispatcher_mutex_);
-  if (!marker_dispatcher_) return;
+  // Runs on the ROS executor thread. setTopic on the Qt thread can replace
+  // marker_dispatcher_ underneath us. Snapshot the shared_ptr under the
+  // mutex, then release the lock before iterating: the local copy keeps
+  // the dispatcher alive for the duration of this callback even if
+  // setTopic swaps it concurrently, and setTopic isn't blocked waiting
+  // for a long MarkerArray to drain.
+  std::shared_ptr<DispatcherT> dispatcher;
+  {
+    std::lock_guard<std::mutex> lock(marker_dispatcher_mutex_);
+    dispatcher = marker_dispatcher_;
+  }
+  if (!dispatcher) return;
   for (const auto & marker : data.markers)
   {
-    marker_dispatcher_->add(marker);
+    dispatcher->add(marker);
   }
 }
 

--- a/src/camp/markers/markers.cpp
+++ b/src/camp/markers/markers.cpp
@@ -238,7 +238,11 @@ void Markers::onMarkerPayload(std::shared_ptr<MarkerData> data)
       {
         QTimer::singleShot(
           static_cast<int>((rclcpp::Duration(data->marker.lifetime).seconds() + 1.0) * 1000),
-          this, [this]() { this->purgeExpiredMarkers(); });
+          this, [this]() {
+            prepareGeometryChange();
+            this->purgeExpiredMarkers();
+            GeoGraphicsItem::update();
+          });
       }
       break;
     case visualization_msgs::msg::Marker::DELETE:

--- a/src/camp/markers/markers.cpp
+++ b/src/camp/markers/markers.cpp
@@ -1,21 +1,41 @@
 #include "markers.h"
+
+#include <chrono>
+#include <utility>
+
 #include <QPainter>
-#include <tf2_ros/transform_listener.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tf2/utils.h>
-#include "marine_autonomy/gz4d_geo.h"
-#include <QDebug>
-#include <geometry_msgs/msg/pose_stamped.hpp>
-#include "backgroundraster.h"
-#include <grid_map_ros/grid_map_ros.hpp>
 #include <QTimer>
+
+#include <tf2/utils.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+#include "marine_autonomy/gz4d_geo.h"
+#include "backgroundraster.h"
+#include "markers/markers_converter.h"
+#include "ros/ros_context.h"
+
+namespace
+{
+
+// Wrap convertMarker() to capture the node so the converter can read clock+logger.
+camp_ros::TfDispatcher<visualization_msgs::msg::Marker, std::shared_ptr<Markers::MarkerData>>::Converter
+makeMarkerConverter(rclcpp::Node::SharedPtr node)
+{
+  return [node](const visualization_msgs::msg::Marker & m, tf2_ros::Buffer & buffer)
+    -> std::optional<std::shared_ptr<Markers::MarkerData>>
+  {
+    return camp_markers::convertMarker(m, buffer, node->get_clock()->now(), node->get_logger());
+  };
+}
+
+}  // namespace
 
 Markers::Markers(QWidget* parent, QGraphicsItem *parentItem):
   camp_ros::ROSWidget(parent),
   GeoGraphicsItem(parentItem)
 {
   ui_.setupUi(this);
-  connect(this, &Markers::newMarkersMadeAvailable, this, &Markers::newMarkersAvailable, Qt::QueuedConnection);
   connect(ui_.displayCheckBox, &QCheckBox::stateChanged, this, &Markers::visibilityChanged);
   ui_.displayCheckBox->setChecked(true);
 }
@@ -38,6 +58,8 @@ QRectF Markers::boundingRect() const
 
 void Markers::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
+  (void)option;
+  (void)widget;
   BackgroundRaster* bg = findParentBackgroundRaster();
   if(!current_markers_.empty() && is_visible_)
     for(auto ns: current_markers_)
@@ -49,8 +71,6 @@ void Markers::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, Q
         if(m.second->marker.type == visualization_msgs::msg::Marker::LINE_STRIP)
         {
           p.setWidthF(m.second->marker.scale.x/pixel_size_);
-          // p.setWidth(0);
-          // p.setCosmetic(true);
         }
         if(m.second->marker.type == visualization_msgs::msg::Marker::TEXT_VIEW_FACING)
           p.setCosmetic(true);
@@ -124,19 +144,17 @@ QPainterPath Markers::markerPath(const MarkerData& marker, BackgroundRaster* bg)
       }
       case visualization_msgs::msg::Marker::TEXT_VIEW_FACING:
       {
-        {
-          QFont font;
-          int font_size = std::max(5, int(marker.marker.scale.z*bg->scaledPixelSize()*10));
-          font.setPixelSize(font_size);
-          QFontMetrics metrics(font);
-          auto bounds = metrics.boundingRect(marker.marker.text.c_str());
-          path.addText(QPointF(marker.local_position.x()-bounds.width()*pixel_size_/2.0, marker.local_position.y()+bounds.height()*pixel_size_/2.0), font, marker.marker.text.c_str());
-
-        }
+        QFont font;
+        int font_size = std::max(5, int(marker.marker.scale.z*bg->scaledPixelSize()*10));
+        font.setPixelSize(font_size);
+        QFontMetrics metrics(font);
+        auto bounds = metrics.boundingRect(marker.marker.text.c_str());
+        path.addText(QPointF(marker.local_position.x()-bounds.width()*pixel_size_/2.0, marker.local_position.y()+bounds.height()*pixel_size_/2.0), font, marker.marker.text.c_str());
         break;
       }
       default:
-        RCLCPP_WARN_STREAM(node_->get_logger(), "marker type not handles: " << marker.marker.type);
+        if (node_)
+          RCLCPP_WARN_STREAM(node_->get_logger(), "marker type not handled: " << marker.marker.type);
     }
   }
   return path;
@@ -144,25 +162,47 @@ QPainterPath Markers::markerPath(const MarkerData& marker, BackgroundRaster* bg)
 
 void Markers::setTopic(std::string topic, std::string type)
 {
-  if(node_)
-  {
-    std::chrono::duration<int> buffer_timeout(1);
-    if(type == "visualization_msgs/msg/MarkerArray")
-    {
-      marker_tf2_filter_ = std::make_shared<tf2_ros::MessageFilter<visualization_msgs::msg::Marker>>(*transform_buffer_, "earth", 50, node_, buffer_timeout);
-      marker_tf2_filter_->registerCallback(&Markers::markerCallback, this);
-      marker_array_subscription_ = node_->create_subscription<visualization_msgs::msg::MarkerArray>(topic, 1, std::bind(&Markers::markerArrayCallback, this, std::placeholders::_1));
-    }
-    if(type == "visualization_msgs/msg/Marker")
-    {
-      marker_subscription_.subscribe(node_, topic);
-      marker_tf2_filter_ = std::make_shared<tf2_ros::MessageFilter<visualization_msgs::msg::Marker>>(marker_subscription_, *transform_buffer_, "earth", 50, node_, buffer_timeout);
-      marker_tf2_filter_->registerCallback(&Markers::markerCallback, this);
-    }
+  if (!node_) return;
 
-    ui_.topicLabel->setText(topic.c_str());
+  // Tear down any prior wiring (allows re-binding to a new topic at runtime).
+  marker_array_subscription_.reset();
+  marker_dispatcher_.reset();
+
+  // Pick the scene callback group if RosContext is available so a slow
+  // marker conversion can't starve realtime callbacks. Falls back to the
+  // node's default group when RosContext hasn't been set (e.g. in tests
+  // that don't bring up a full NodeThread).
+  rclcpp::CallbackGroup::SharedPtr cbg;
+  auto * ctx = camp_ros::RosContext::instance();
+  if (ctx) cbg = ctx->group(camp_ros::RosContext::Group::Scene);
+
+  // Build the dispatcher (target frame "earth", buffer 50 messages, drop
+  // after 1 s without TF — preserves prior behavior).
+  marker_dispatcher_ = std::make_unique<
+    camp_ros::TfDispatcher<visualization_msgs::msg::Marker, std::shared_ptr<MarkerData>>>(
+      node_, transform_buffer_, "earth", 50, std::chrono::seconds(1),
+      makeMarkerConverter(node_),
+      this,
+      [this](std::shared_ptr<MarkerData> data) { this->onMarkerPayload(std::move(data)); });
+
+  if (type == "visualization_msgs/msg/MarkerArray")
+  {
+    rclcpp::SubscriptionOptions options;
+    if (cbg) options.callback_group = cbg;
+    marker_array_subscription_ = node_->create_subscription<visualization_msgs::msg::MarkerArray>(
+      topic, 1,
+      [this](const visualization_msgs::msg::MarkerArray & data) { this->onMarkerArrayMessage(data); },
+      options);
+  }
+  else if (type == "visualization_msgs/msg/Marker")
+  {
+    rclcpp::SubscriptionOptions options;
+    if (cbg) options.callback_group = cbg;
+    marker_subscription_.subscribe(node_, topic, rclcpp::QoS(1).get_rmw_qos_profile(), options);
+    marker_dispatcher_->connectInput(marker_subscription_);
   }
 
+  ui_.topicLabel->setText(topic.c_str());
 }
 
 void Markers::setPixelSize(double s)
@@ -170,114 +210,77 @@ void Markers::setPixelSize(double s)
   pixel_size_ = s;
 }
 
-void Markers::markerArrayCallback(const visualization_msgs::msg::MarkerArray &data)
+void Markers::onMarkerArrayMessage(const visualization_msgs::msg::MarkerArray & data)
 {
-  for(const auto &marker: data.markers)
+  if (!marker_dispatcher_) return;
+  for (const auto & marker : data.markers)
   {
-    auto marker_ptr = std::make_shared<visualization_msgs::msg::Marker>(marker);
-    marker_tf2_filter_->add(marker_ptr);
+    marker_dispatcher_->add(marker);
   }
 }
 
-void Markers::markerCallback(const visualization_msgs::msg::Marker &data)
+void Markers::onMarkerPayload(std::shared_ptr<MarkerData> data)
 {
-  std::vector<visualization_msgs::msg::Marker> markers;
-  markers.push_back(data);
-  addMarkers(markers);
-}
-
-void Markers::addMarkers(const std::vector<visualization_msgs::msg::Marker> &markers)
-{
-  for(auto m: markers)
-  {
-    auto marker_data = std::make_shared<MarkerData>();
-    marker_data->marker = m;
-    try
-    {
-      if(m.action == visualization_msgs::msg::Marker::ADD)
-      {
-        auto now = node_->get_clock()->now();
-        if(rclcpp::Duration(m.lifetime).nanoseconds() != 0 && rclcpp::Time(m.header.stamp)+rclcpp::Duration(m.lifetime) < now)
-        {
-          rclcpp::Clock clock;
-          RCLCPP_DEBUG_STREAM_THROTTLE(node_->get_logger(), clock, 5000, "Expired marker: "<< m.ns << " id: " << m.id);
-          continue;
-        }
-        if(m.header.frame_id.empty())
-        {
-          rclcpp::Clock clock;
-          RCLCPP_DEBUG_STREAM_THROTTLE(node_->get_logger(), clock, 1000, "Missing frame_id in marker: "<< m.ns << " id: " << m.id);
-          continue;;
-        }
-        marker_data->position = getGeoCoordinate(m.pose, m.header);
-        marker_data->rotation = tf2::getYaw(m.pose.orientation);
-      }
-      std::lock_guard<std::mutex> lock(new_markers_mutex_);
-      new_markers_.push_back(marker_data);
-    }
-    catch (tf2::TransformException &ex)
-    {
-      rclcpp::Clock clock;
-      RCLCPP_WARN_STREAM_THROTTLE(node_->get_logger(), clock, 1000, "Unable to find transform to earth for marker: " << m.ns << " id: " << m.id << " what: " << ex.what());
-    }
-  }
-  emit newMarkersMadeAvailable();
-}
-
-
-
-void Markers::newMarkersAvailable()
-{
+  if (!data) return;
   prepareGeometryChange();
 
-  std::vector<std::shared_ptr<MarkerData> > new_markers;
+  auto * bg = findParentBackgroundRaster();
+  switch (data->marker.action)
   {
-    std::lock_guard<std::mutex> lock(new_markers_mutex_);
-    new_markers = new_markers_;
-    new_markers_.clear();
+    case visualization_msgs::msg::Marker::ADD:
+      if (bg) data->local_position = geoToPixel(data->position, bg);
+      current_markers_[data->marker.ns][data->marker.id] = data;
+      if (rclcpp::Duration(data->marker.lifetime).seconds() != 0)
+      {
+        QTimer::singleShot(
+          static_cast<int>((rclcpp::Duration(data->marker.lifetime).seconds() + 1.0) * 1000),
+          this, [this]() { this->purgeExpiredMarkers(); });
+      }
+      break;
+    case visualization_msgs::msg::Marker::DELETE:
+      {
+        auto ns_it = current_markers_.find(data->marker.ns);
+        if (ns_it != current_markers_.end())
+          ns_it->second.erase(data->marker.id);
+      }
+      break;
+    case visualization_msgs::msg::Marker::DELETEALL:
+      current_markers_[data->marker.ns].clear();
+      break;
+    default:
+      if (node_)
+        RCLCPP_WARN_STREAM(node_->get_logger(),
+          "Unknown marker action: " << static_cast<int>(data->marker.action));
   }
 
-  auto bg = findParentBackgroundRaster();
-  for(auto marker: new_markers)
-  {
-    switch(marker->marker.action)
-    {
-      case visualization_msgs::msg::Marker::ADD:
-        if(bg)
-          marker->local_position = geoToPixel(marker->position, bg);
-        //ROS_INFO_STREAM(marker->marker.ns << ": " << marker->marker.id << " local pos: " << marker->local_position.x() << ", " << marker->local_position.y());
-        current_markers_[marker->marker.ns][marker->marker.id] = marker;
-        if(rclcpp::Duration(marker->marker.lifetime).seconds() != 0)
-          QTimer::singleShot((rclcpp::Duration(marker->marker.lifetime).seconds()+1.0)*1000, this, &Markers::newMarkersAvailable);
-        break;
-      case visualization_msgs::msg::Marker::DELETE:
-        current_markers_[marker->marker.ns][marker->marker.id].reset();
-        break;
-      case visualization_msgs::msg::Marker::DELETEALL:
-        current_markers_[marker->marker.ns].clear();
-        break;
-      default:
-        RCLCPP_WARN_STREAM(node_->get_logger(), "Unknown marker action: " << marker->marker.action);
-    }
-  }
+  purgeExpiredMarkers();
+  GeoGraphicsItem::update();
+}
 
+void Markers::purgeExpiredMarkers()
+{
+  if (!node_) return;
   auto now = node_->get_clock()->now();
-
-  for(auto& ns: current_markers_)
+  for (auto & ns : current_markers_)
   {
     std::vector<int32_t> expired;
-    for(auto m: ns.second)
-      if(rclcpp::Time(m.second->marker.header.stamp).seconds() != 0.0 && rclcpp::Duration(m.second->marker.lifetime).seconds() != 0 && rclcpp::Time(m.second->marker.header.stamp) + rclcpp::Duration(m.second->marker.lifetime) < now)
-        expired.push_back(m.first);
-    for(auto e: expired)
+    for (auto & m : ns.second)
     {
-      RCLCPP_DEBUG_STREAM(node_->get_logger(), "Purging " << ns.first << ": " << e);
-      ns.second.erase(e);
-
+      if (!m.second) continue;
+      if (rclcpp::Time(m.second->marker.header.stamp).seconds() != 0.0 &&
+          rclcpp::Duration(m.second->marker.lifetime).seconds() != 0 &&
+          rclcpp::Time(m.second->marker.header.stamp) +
+              rclcpp::Duration(m.second->marker.lifetime) < now)
+      {
+        expired.push_back(m.first);
+      }
+    }
+    for (auto id : expired)
+    {
+      RCLCPP_DEBUG_STREAM(node_->get_logger(), "Purging " << ns.first << ": " << id);
+      ns.second.erase(id);
     }
   }
-
-  GeoGraphicsItem::update();
 }
 
 void Markers::visibilityChanged()

--- a/src/camp/markers/markers.cpp
+++ b/src/camp/markers/markers.cpp
@@ -169,7 +169,7 @@ void Markers::setTopic(std::string topic, std::string type)
   // node's default group when RosContext hasn't been set (e.g. in tests
   // that don't bring up a full NodeThread).
   rclcpp::CallbackGroup::SharedPtr cbg;
-  auto * ctx = camp_ros::RosContext::instance();
+  auto ctx = camp_ros::RosContext::instance();
   if (ctx) cbg = ctx->group(camp_ros::RosContext::Group::Scene);
 
   {

--- a/src/camp/markers/markers.cpp
+++ b/src/camp/markers/markers.cpp
@@ -164,14 +164,6 @@ void Markers::setTopic(std::string topic, std::string type)
 {
   if (!node_) return;
 
-  // Tear down any prior wiring (allows re-binding to a new topic at runtime).
-  // Unsubscribe the message_filters subscriber FIRST so it stops feeding the
-  // dispatcher's MessageFilter before we destroy that filter; otherwise an
-  // in-flight ROS callback can call MessageFilter::add() on freed memory.
-  marker_subscription_.unsubscribe();
-  marker_array_subscription_.reset();
-  marker_dispatcher_.reset();
-
   // Pick the scene callback group if RosContext is available so a slow
   // marker conversion can't starve realtime callbacks. Falls back to the
   // node's default group when RosContext hasn't been set (e.g. in tests
@@ -180,14 +172,27 @@ void Markers::setTopic(std::string topic, std::string type)
   auto * ctx = camp_ros::RosContext::instance();
   if (ctx) cbg = ctx->group(camp_ros::RosContext::Group::Scene);
 
-  // Build the dispatcher (target frame "earth", buffer 50 messages, drop
-  // after 1 s without TF — preserves prior behavior).
-  marker_dispatcher_ = std::make_unique<
-    camp_ros::TfDispatcher<visualization_msgs::msg::Marker, std::shared_ptr<MarkerData>>>(
-      node_, transform_buffer_, "earth", 50, std::chrono::seconds(1),
-      makeMarkerConverter(node_),
-      this,
-      [this](std::shared_ptr<MarkerData> data) { this->onMarkerPayload(std::move(data)); });
+  {
+    // Hold the lock across the entire teardown + rebuild: this is the
+    // window where onMarkerArrayMessage (executor thread) could see a
+    // null or half-built marker_dispatcher_. Tear down the subscriber
+    // first so it stops feeding the filter, then reset the dispatcher,
+    // then construct the replacement before releasing the lock.
+    std::lock_guard<std::mutex> lock(marker_dispatcher_mutex_);
+
+    marker_subscription_.unsubscribe();
+    marker_array_subscription_.reset();
+    marker_dispatcher_.reset();
+
+    // Build the dispatcher (target frame "earth", buffer 50 messages, drop
+    // after 1 s without TF — preserves prior behavior).
+    marker_dispatcher_ = std::make_unique<
+      camp_ros::TfDispatcher<visualization_msgs::msg::Marker, std::shared_ptr<MarkerData>>>(
+        node_, transform_buffer_, "earth", 50, std::chrono::seconds(1),
+        makeMarkerConverter(node_),
+        this,
+        [this](std::shared_ptr<MarkerData> data) { this->onMarkerPayload(std::move(data)); });
+  }
 
   if (type == "visualization_msgs/msg/MarkerArray")
   {
@@ -203,6 +208,7 @@ void Markers::setTopic(std::string topic, std::string type)
     rclcpp::SubscriptionOptions options;
     if (cbg) options.callback_group = cbg;
     marker_subscription_.subscribe(node_, topic, rclcpp::QoS(1).get_rmw_qos_profile(), options);
+    std::lock_guard<std::mutex> lock(marker_dispatcher_mutex_);
     marker_dispatcher_->connectInput(marker_subscription_);
   }
 
@@ -216,6 +222,9 @@ void Markers::setPixelSize(double s)
 
 void Markers::onMarkerArrayMessage(const visualization_msgs::msg::MarkerArray & data)
 {
+  // Runs on the ROS executor thread; setTopic on the Qt thread can replace
+  // marker_dispatcher_ underneath us, so guard against the race.
+  std::lock_guard<std::mutex> lock(marker_dispatcher_mutex_);
   if (!marker_dispatcher_) return;
   for (const auto & marker : data.markers)
   {
@@ -253,7 +262,9 @@ void Markers::onMarkerPayload(std::shared_ptr<MarkerData> data)
       }
       break;
     case visualization_msgs::msg::Marker::DELETEALL:
-      current_markers_[data->marker.ns].clear();
+      // visualization_msgs/Marker DELETEALL clears every marker across every
+      // namespace; the message's own ns is ignored.
+      current_markers_.clear();
       break;
     default:
       if (node_)

--- a/src/camp/markers/markers.cpp
+++ b/src/camp/markers/markers.cpp
@@ -165,6 +165,10 @@ void Markers::setTopic(std::string topic, std::string type)
   if (!node_) return;
 
   // Tear down any prior wiring (allows re-binding to a new topic at runtime).
+  // Unsubscribe the message_filters subscriber FIRST so it stops feeding the
+  // dispatcher's MessageFilter before we destroy that filter; otherwise an
+  // in-flight ROS callback can call MessageFilter::add() on freed memory.
+  marker_subscription_.unsubscribe();
   marker_array_subscription_.reset();
   marker_dispatcher_.reset();
 

--- a/src/camp/markers/markers.h
+++ b/src/camp/markers/markers.h
@@ -27,6 +27,8 @@ public:
   void setPixelSize(double s);
 
   using MarkerData = camp_markers::MarkerPayload;
+  using DispatcherT = camp_ros::TfDispatcher<
+    visualization_msgs::msg::Marker, std::shared_ptr<MarkerData>>;
 
 public slots:
   void setTopic(std::string topic, std::string type);
@@ -53,11 +55,13 @@ private:
   // gated on TF to "earth", converted to MarkerData on the executor thread,
   // and dispatched to onMarkerPayload on the Qt main thread.
   //
-  // The dispatcher is mutated by setTopic (Qt thread) and read/dereferenced
-  // by onMarkerArrayMessage (executor thread). Guard both accesses with the
-  // mutex below; the executor's per-callback hold is brief in practice.
+  // shared_ptr (not unique_ptr) so the executor thread can snapshot it
+  // under the mutex, release the lock, and iterate a MarkerArray without
+  // blocking setTopic on the Qt thread for the whole batch. The mutex
+  // protects the *pointer slot* only; once a thread has its own copy of
+  // the shared_ptr, the dispatcher is kept alive by that ref while in use.
   std::mutex marker_dispatcher_mutex_;
-  std::unique_ptr<camp_ros::TfDispatcher<visualization_msgs::msg::Marker, std::shared_ptr<MarkerData>>> marker_dispatcher_;
+  std::shared_ptr<camp_ros::TfDispatcher<visualization_msgs::msg::Marker, std::shared_ptr<MarkerData>>> marker_dispatcher_;
   message_filters::Subscriber<visualization_msgs::msg::Marker> marker_subscription_;
   rclcpp::Subscription<visualization_msgs::msg::MarkerArray>::SharedPtr marker_array_subscription_;
 

--- a/src/camp/markers/markers.h
+++ b/src/camp/markers/markers.h
@@ -2,11 +2,12 @@
 #define MARKERS_H
 
 #include "ros/ros_widget.h"
+#include "ros/tf_dispatcher.h"
+#include "ros/topic_bridge.h"
 #include "geographicsitem.h"
-#include "message_filters/subscriber.hpp"
-#include "message_filters/simple_filter.hpp"
-#include "tf2_ros/message_filter.h"
+#include "markers/markers_converter.h"
 #include "ui_markers.h"
+#include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
 
@@ -22,44 +23,38 @@ public:
 
   void setPixelSize(double s);
 
-signals:
-  void newMarkersMadeAvailable();
+  using MarkerData = camp_markers::MarkerPayload;
 
 public slots:
   void setTopic(std::string topic, std::string type);
   void visibilityChanged();
   void updateBackground(BackgroundRaster * bg);
-  void newMarkersAvailable();
 
 private:
-  void markerArrayCallback(const visualization_msgs::msg::MarkerArray &data);
-  void markerCallback(const visualization_msgs::msg::Marker &data);
-  void addMarkers(const std::vector<visualization_msgs::msg::Marker> &markers);
+  // Receiver slot for the TF dispatcher. Runs on the Qt main thread.
+  void onMarkerPayload(std::shared_ptr<MarkerData> data);
 
+  // Marker-array subscription path: feeds the dispatcher with each marker.
+  // Runs on the ROS executor thread.
+  void onMarkerArrayMessage(const visualization_msgs::msg::MarkerArray & data);
 
-  struct MarkerData
-  {
-    visualization_msgs::msg::Marker marker;
-    QGeoCoordinate position;
-    QPointF local_position;
-    double rotation;
-  };
+  void purgeExpiredMarkers();
 
   QPainterPath markerPath(const MarkerData& marker, BackgroundRaster* bg) const;
 
   Ui::Markers ui_;
 
-  std::map<std::string, std::map<int32_t, std::shared_ptr<MarkerData> > > current_markers_;
-  std::vector<std::shared_ptr<MarkerData> > new_markers_;
-  std::mutex new_markers_mutex_;
+  std::map<std::string, std::map<int32_t, std::shared_ptr<MarkerData>>> current_markers_;
 
+  // TF-gated dispatcher shared by both topic types: each Marker is fed in,
+  // gated on TF to "earth", converted to MarkerData on the executor thread,
+  // and dispatched to onMarkerPayload on the Qt main thread.
+  std::unique_ptr<camp_ros::TfDispatcher<visualization_msgs::msg::Marker, std::shared_ptr<MarkerData>>> marker_dispatcher_;
   message_filters::Subscriber<visualization_msgs::msg::Marker> marker_subscription_;
-  std::shared_ptr<tf2_ros::MessageFilter<visualization_msgs::msg::Marker>> marker_tf2_filter_;
   rclcpp::Subscription<visualization_msgs::msg::MarkerArray>::SharedPtr marker_array_subscription_;
 
   double pixel_size_ = 1.0;
   bool is_visible_ = false;
-
 };
 
 #endif

--- a/src/camp/markers/markers.h
+++ b/src/camp/markers/markers.h
@@ -1,9 +1,12 @@
 #ifndef MARKERS_H
 #define MARKERS_H
 
+#include <mutex>
+
+#include <message_filters/subscriber.hpp>
+
 #include "ros/ros_widget.h"
 #include "ros/tf_dispatcher.h"
-#include "ros/topic_bridge.h"
 #include "geographicsitem.h"
 #include "markers/markers_converter.h"
 #include "ui_markers.h"
@@ -49,6 +52,11 @@ private:
   // TF-gated dispatcher shared by both topic types: each Marker is fed in,
   // gated on TF to "earth", converted to MarkerData on the executor thread,
   // and dispatched to onMarkerPayload on the Qt main thread.
+  //
+  // The dispatcher is mutated by setTopic (Qt thread) and read/dereferenced
+  // by onMarkerArrayMessage (executor thread). Guard both accesses with the
+  // mutex below; the executor's per-callback hold is brief in practice.
+  std::mutex marker_dispatcher_mutex_;
   std::unique_ptr<camp_ros::TfDispatcher<visualization_msgs::msg::Marker, std::shared_ptr<MarkerData>>> marker_dispatcher_;
   message_filters::Subscriber<visualization_msgs::msg::Marker> marker_subscription_;
   rclcpp::Subscription<visualization_msgs::msg::MarkerArray>::SharedPtr marker_array_subscription_;

--- a/src/camp/markers/markers_converter.h
+++ b/src/camp/markers/markers_converter.h
@@ -1,0 +1,107 @@
+#ifndef CAMP_MARKERS_CONVERTER_H
+#define CAMP_MARKERS_CONVERTER_H
+
+// Marker → MarkerPayload converter, factored out for unit testing.
+//
+// The converter runs on the ROS executor thread inside a TfDispatcher. The
+// dispatcher's MessageFilter has already verified that the marker's frame is
+// transformable to "earth", so the buffer lookup uses TimePointZero with no
+// timeout. Errors here are buffer-edge races and we drop the marker.
+
+#include <memory>
+#include <optional>
+
+#include <QGeoCoordinate>
+#include <QPointF>
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_ros/buffer.h>
+#include <visualization_msgs/msg/marker.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+#include "marine_autonomy/gz4d_geo.h"
+
+namespace camp_markers
+{
+
+/// Per-marker payload produced by the converter and consumed by the Qt-side
+/// receiver. `local_position` is filled in by the receiver after geoToPixel,
+/// not by the converter.
+struct MarkerPayload
+{
+  visualization_msgs::msg::Marker marker;
+  QGeoCoordinate position;
+  QPointF local_position;
+  double rotation = 0.0;
+};
+
+/// Convert one Marker message into a MarkerPayload, or std::nullopt to drop.
+///
+/// Drops:
+///   - ADD markers whose lifetime has already expired relative to `now()`.
+///   - ADD markers with empty frame_id.
+///   - ADD markers whose pose can't be transformed from frame_id to "earth".
+///
+/// DELETE / DELETEALL markers are returned with marker copied and no
+/// position/rotation set; the receiver acts on `marker.action`.
+inline std::optional<std::shared_ptr<MarkerPayload>>
+convertMarker(const visualization_msgs::msg::Marker & m,
+              tf2_ros::Buffer & buffer,
+              const rclcpp::Time & now,
+              rclcpp::Logger logger)
+{
+  auto payload = std::make_shared<MarkerPayload>();
+  payload->marker = m;
+
+  if (m.action == visualization_msgs::msg::Marker::ADD)
+  {
+    if (rclcpp::Duration(m.lifetime).nanoseconds() != 0 &&
+        rclcpp::Time(m.header.stamp) + rclcpp::Duration(m.lifetime) < now)
+    {
+      rclcpp::Clock clock;
+      RCLCPP_DEBUG_STREAM_THROTTLE(logger, clock, 5000,
+        "Expired marker: " << m.ns << " id: " << m.id);
+      return std::nullopt;
+    }
+    if (m.header.frame_id.empty())
+    {
+      rclcpp::Clock clock;
+      RCLCPP_DEBUG_STREAM_THROTTLE(logger, clock, 1000,
+        "Missing frame_id in marker: " << m.ns << " id: " << m.id);
+      return std::nullopt;
+    }
+
+    try
+    {
+      geometry_msgs::msg::PoseStamped ps;
+      ps.header = m.header;
+      ps.pose = m.pose;
+      // Timeout 0: don't wait. The dispatcher's MessageFilter has already
+      // verified the transform is reachable at the message stamp.
+      auto ecef = buffer.transform(ps, "earth", tf2::durationFromSec(0.0));
+
+      gz4d::GeoPointECEF ecef_point;
+      ecef_point[0] = ecef.pose.position.x;
+      ecef_point[1] = ecef.pose.position.y;
+      ecef_point[2] = ecef.pose.position.z;
+      gz4d::GeoPointLatLongDegrees ll = ecef_point;
+      payload->position = QGeoCoordinate(ll.latitude(), ll.longitude(), ll.altitude());
+      payload->rotation = tf2::getYaw(m.pose.orientation);
+    }
+    catch (const tf2::TransformException & ex)
+    {
+      rclcpp::Clock clock;
+      RCLCPP_WARN_STREAM_THROTTLE(logger, clock, 1000,
+        "Unable to transform marker " << m.ns << ":" << m.id
+        << " (" << m.header.frame_id << " -> earth): " << ex.what());
+      return std::nullopt;
+    }
+  }
+  return payload;
+}
+
+} // namespace camp_markers
+
+#endif

--- a/src/camp/markers/markers_converter.h
+++ b/src/camp/markers/markers_converter.h
@@ -5,8 +5,9 @@
 //
 // The converter runs on the ROS executor thread inside a TfDispatcher. The
 // dispatcher's MessageFilter has already verified that the marker's frame is
-// transformable to "earth", so the buffer lookup uses TimePointZero with no
-// timeout. Errors here are buffer-edge races and we drop the marker.
+// transformable to "earth" at the message stamp, so the buffer lookup uses
+// the message stamp with no timeout. Errors here are buffer-edge races and
+// we drop the marker.
 
 #include <memory>
 #include <optional>

--- a/src/camp/markers/markers_converter.h
+++ b/src/camp/markers/markers_converter.h
@@ -53,11 +53,11 @@ convertMarker(const visualization_msgs::msg::Marker & m,
               const rclcpp::Time & now,
               rclcpp::Logger logger)
 {
-  auto payload = std::make_shared<MarkerPayload>();
-  payload->marker = m;
-
   if (m.action == visualization_msgs::msg::Marker::ADD)
   {
+    // Run all drop checks BEFORE allocating MarkerPayload — the converter
+    // runs on the executor thread and unnecessary heap traffic per dropped
+    // marker adds up under high-rate sources.
     if (rclcpp::Duration(m.lifetime).nanoseconds() != 0 &&
         rclcpp::Time(m.header.stamp) + rclcpp::Duration(m.lifetime) < now)
     {
@@ -74,6 +74,7 @@ convertMarker(const visualization_msgs::msg::Marker & m,
       return std::nullopt;
     }
 
+    geometry_msgs::msg::PoseStamped ecef;
     try
     {
       geometry_msgs::msg::PoseStamped ps;
@@ -81,15 +82,7 @@ convertMarker(const visualization_msgs::msg::Marker & m,
       ps.pose = m.pose;
       // Timeout 0: don't wait. The dispatcher's MessageFilter has already
       // verified the transform is reachable at the message stamp.
-      auto ecef = buffer.transform(ps, "earth", tf2::durationFromSec(0.0));
-
-      gz4d::GeoPointECEF ecef_point;
-      ecef_point[0] = ecef.pose.position.x;
-      ecef_point[1] = ecef.pose.position.y;
-      ecef_point[2] = ecef.pose.position.z;
-      gz4d::GeoPointLatLongDegrees ll = ecef_point;
-      payload->position = QGeoCoordinate(ll.latitude(), ll.longitude(), ll.altitude());
-      payload->rotation = tf2::getYaw(m.pose.orientation);
+      ecef = buffer.transform(ps, "earth", tf2::durationFromSec(0.0));
     }
     catch (const tf2::TransformException & ex)
     {
@@ -99,7 +92,25 @@ convertMarker(const visualization_msgs::msg::Marker & m,
         << " (" << m.header.frame_id << " -> earth): " << ex.what());
       return std::nullopt;
     }
+
+    // Marker is being kept — allocate and populate.
+    auto payload = std::make_shared<MarkerPayload>();
+    payload->marker = m;
+
+    gz4d::GeoPointECEF ecef_point;
+    ecef_point[0] = ecef.pose.position.x;
+    ecef_point[1] = ecef.pose.position.y;
+    ecef_point[2] = ecef.pose.position.z;
+    gz4d::GeoPointLatLongDegrees ll = ecef_point;
+    payload->position = QGeoCoordinate(ll.latitude(), ll.longitude(), ll.altitude());
+    payload->rotation = tf2::getYaw(m.pose.orientation);
+    return payload;
   }
+
+  // DELETE / DELETEALL: no drop conditions, no TF lookup; allocate a
+  // payload carrying the action so the receiver can act on it.
+  auto payload = std::make_shared<MarkerPayload>();
+  payload->marker = m;
   return payload;
 }
 

--- a/src/camp/ros/node_thread.cpp
+++ b/src/camp/ros/node_thread.cpp
@@ -33,8 +33,8 @@ void NodeThread::start()
   // Construct RosContext (creates the realtime/scene callback groups on the
   // node) before adding the node to the executor, so the executor sees the
   // groups during add_node.
-  context_ = std::make_unique<RosContext>(node_, buffer_);
-  RosContext::setInstance(context_.get());
+  context_ = std::make_shared<RosContext>(node_, buffer_);
+  RosContext::setInstance(context_);
 
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(node_);

--- a/src/camp/ros/node_thread.cpp
+++ b/src/camp/ros/node_thread.cpp
@@ -1,4 +1,5 @@
 #include "node_thread.h"
+#include "ros_context.h"
 #include "tf2_ros/create_timer_ros.h"
 //#include "node_manager.h"
 
@@ -10,14 +11,14 @@ NodeThread::NodeThread()
 
 }
 
+NodeThread::~NodeThread() = default;
+
 void NodeThread::start()
 {
   node_ = std::make_shared<rclcpp::Node>("camp");
-  rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(node_);
 
   buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
-  
+
   // From: https://docs.ros.org/en/kilted/Tutorials/Intermediate/Tf2/Using-Stamped-Datatypes-With-Tf2-Ros-MessageFilter.html
   // Create the timer interface before call to waitForTransform,
   // to avoid a tf2_ros::CreateTimerInterfaceException exception
@@ -26,12 +27,24 @@ void NodeThread::start()
     node_->get_node_timers_interface()
   );
   buffer_->setCreateTimerInterface(timer_interface);
-  
+
   transform_listener_ = std::make_unique<tf2_ros::TransformListener>(*buffer_, node_);
-  
+
+  // Construct RosContext (creates the realtime/scene callback groups on the
+  // node) before adding the node to the executor, so the executor sees the
+  // groups during add_node.
+  context_ = std::make_unique<RosContext>(node_, buffer_);
+  RosContext::setInstance(context_.get());
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(node_);
+
   emit started(node_, buffer_);
 
   executor.spin();
+
+  RosContext::clearInstance();
+  context_.reset();
 
   emit shuttingDown();
 }

--- a/src/camp/ros/node_thread.h
+++ b/src/camp/ros/node_thread.h
@@ -9,12 +9,14 @@ namespace camp_ros
 {
 
 class NodeManager;
+class RosContext;
 
 class NodeThread: public QObject
 {
   Q_OBJECT
 public:
   NodeThread();
+  ~NodeThread() override;
 
 public slots:
   // Starts the ROS node.
@@ -28,6 +30,7 @@ private:
   rclcpp::Node::SharedPtr node_;
   std::unique_ptr<tf2_ros::TransformListener> transform_listener_;
   std::shared_ptr<tf2_ros::Buffer> buffer_;
+  std::unique_ptr<RosContext> context_;
 };
 
 } // namespace camp_ros

--- a/src/camp/ros/node_thread.h
+++ b/src/camp/ros/node_thread.h
@@ -30,7 +30,7 @@ private:
   rclcpp::Node::SharedPtr node_;
   std::unique_ptr<tf2_ros::TransformListener> transform_listener_;
   std::shared_ptr<tf2_ros::Buffer> buffer_;
-  std::unique_ptr<RosContext> context_;
+  std::shared_ptr<RosContext> context_;
 };
 
 } // namespace camp_ros

--- a/src/camp/ros/ros_context.cpp
+++ b/src/camp/ros/ros_context.cpp
@@ -1,0 +1,53 @@
+#include "ros_context.h"
+
+#include <mutex>
+
+namespace camp_ros
+{
+namespace
+{
+std::mutex g_instance_mutex;
+RosContext* g_instance = nullptr;
+} // namespace
+
+RosContext::RosContext(rclcpp::Node::SharedPtr node, tf2_ros::Buffer::SharedPtr buffer)
+: node_(std::move(node)),
+  buffer_(std::move(buffer)),
+  realtime_group_(node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive)),
+  scene_group_(node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive))
+{
+}
+
+RosContext::~RosContext() = default;
+
+rclcpp::CallbackGroup::SharedPtr RosContext::group(Group g) const
+{
+  switch (g)
+  {
+    case Group::Realtime:
+      return realtime_group_;
+    case Group::Scene:
+      return scene_group_;
+  }
+  return nullptr;
+}
+
+RosContext* RosContext::instance()
+{
+  std::lock_guard<std::mutex> lock(g_instance_mutex);
+  return g_instance;
+}
+
+void RosContext::setInstance(RosContext* ctx)
+{
+  std::lock_guard<std::mutex> lock(g_instance_mutex);
+  g_instance = ctx;
+}
+
+void RosContext::clearInstance()
+{
+  std::lock_guard<std::mutex> lock(g_instance_mutex);
+  g_instance = nullptr;
+}
+
+} // namespace camp_ros

--- a/src/camp/ros/ros_context.cpp
+++ b/src/camp/ros/ros_context.cpp
@@ -7,7 +7,7 @@ namespace camp_ros
 namespace
 {
 std::mutex g_instance_mutex;
-RosContext* g_instance = nullptr;
+std::shared_ptr<RosContext> g_instance;
 } // namespace
 
 RosContext::RosContext(rclcpp::Node::SharedPtr node, tf2_ros::Buffer::SharedPtr buffer)
@@ -32,22 +32,22 @@ rclcpp::CallbackGroup::SharedPtr RosContext::group(Group g) const
   return nullptr;
 }
 
-RosContext* RosContext::instance()
+std::shared_ptr<RosContext> RosContext::instance()
 {
   std::lock_guard<std::mutex> lock(g_instance_mutex);
   return g_instance;
 }
 
-void RosContext::setInstance(RosContext* ctx)
+void RosContext::setInstance(std::shared_ptr<RosContext> ctx)
 {
   std::lock_guard<std::mutex> lock(g_instance_mutex);
-  g_instance = ctx;
+  g_instance = std::move(ctx);
 }
 
 void RosContext::clearInstance()
 {
   std::lock_guard<std::mutex> lock(g_instance_mutex);
-  g_instance = nullptr;
+  g_instance.reset();
 }
 
 } // namespace camp_ros

--- a/src/camp/ros/ros_context.h
+++ b/src/camp/ros/ros_context.h
@@ -12,8 +12,10 @@ namespace camp_ros
 /// groups. Created once by `NodeThread` during startup and torn down on
 /// shutdown. Replaces manual fan-out of node/buffer through Qt parent chains.
 ///
-/// Thread-safe to read after `setInstance(...)` has been called and before
-/// `clearInstance()`.
+/// `instance()` returns a raw pointer guarded by an internal mutex; the
+/// access itself is thread-safe between `setInstance(...)` and
+/// `clearInstance()`. The pointer must NOT be cached across that window —
+/// use it within a single short scope and re-fetch on the next call.
 class RosContext
 {
 public:

--- a/src/camp/ros/ros_context.h
+++ b/src/camp/ros/ros_context.h
@@ -12,10 +12,11 @@ namespace camp_ros
 /// groups. Created once by `NodeThread` during startup and torn down on
 /// shutdown. Replaces manual fan-out of node/buffer through Qt parent chains.
 ///
-/// `instance()` returns a raw pointer guarded by an internal mutex; the
-/// access itself is thread-safe between `setInstance(...)` and
-/// `clearInstance()`. The pointer must NOT be cached across that window —
-/// use it within a single short scope and re-fetch on the next call.
+/// `instance()` returns a `shared_ptr` guarded by an internal mutex. Holding
+/// the returned `shared_ptr` keeps the underlying `RosContext` alive even
+/// across a concurrent `clearInstance()`, so dereferences are safe for the
+/// scope of the local. The shared_ptr is empty until `setInstance(...)` has
+/// been called and after `clearInstance()` has run with no other holders.
 class RosContext
 {
 public:
@@ -40,9 +41,11 @@ public:
   tf2_ros::Buffer::SharedPtr buffer() const { return buffer_; }
   rclcpp::CallbackGroup::SharedPtr group(Group g) const;
 
-  /// Returns nullptr until `setInstance(...)` has been called.
-  static RosContext* instance();
-  static void setInstance(RosContext* ctx);
+  /// Returns an empty `shared_ptr` until `setInstance(...)` has been called.
+  /// The returned `shared_ptr` keeps the instance alive for its own scope,
+  /// even if `clearInstance()` runs concurrently on another thread.
+  static std::shared_ptr<RosContext> instance();
+  static void setInstance(std::shared_ptr<RosContext> ctx);
   static void clearInstance();
 
 private:

--- a/src/camp/ros/ros_context.h
+++ b/src/camp/ros/ros_context.h
@@ -1,0 +1,55 @@
+#ifndef CAMP_ROS_CONTEXT_H
+#define CAMP_ROS_CONTEXT_H
+
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer.h>
+
+namespace camp_ros
+{
+
+/// Process-wide registry of the camp ROS node, TF buffer, and named callback
+/// groups. Created once by `NodeThread` during startup and torn down on
+/// shutdown. Replaces manual fan-out of node/buffer through Qt parent chains.
+///
+/// Thread-safe to read after `setInstance(...)` has been called and before
+/// `clearInstance()`.
+class RosContext
+{
+public:
+  /// Latency-budget grouping for subscription callbacks.
+  /// `Realtime` is reserved for watchdog inputs (heartbeat, nav, helm,
+  /// mission status). `Scene` is for bulk display data (markers, grid, path,
+  /// AIS contacts) whose callbacks may do heavier work and must not be
+  /// allowed to starve realtime callbacks.
+  enum class Group
+  {
+    Realtime,
+    Scene
+  };
+
+  RosContext(rclcpp::Node::SharedPtr node, tf2_ros::Buffer::SharedPtr buffer);
+  ~RosContext();
+
+  RosContext(const RosContext&) = delete;
+  RosContext& operator=(const RosContext&) = delete;
+
+  rclcpp::Node::SharedPtr node() const { return node_; }
+  tf2_ros::Buffer::SharedPtr buffer() const { return buffer_; }
+  rclcpp::CallbackGroup::SharedPtr group(Group g) const;
+
+  /// Returns nullptr until `setInstance(...)` has been called.
+  static RosContext* instance();
+  static void setInstance(RosContext* ctx);
+  static void clearInstance();
+
+private:
+  rclcpp::Node::SharedPtr node_;
+  tf2_ros::Buffer::SharedPtr buffer_;
+  rclcpp::CallbackGroup::SharedPtr realtime_group_;
+  rclcpp::CallbackGroup::SharedPtr scene_group_;
+};
+
+} // namespace camp_ros
+
+#endif

--- a/src/camp/ros/tf_dispatcher.h
+++ b/src/camp/ros/tf_dispatcher.h
@@ -101,9 +101,6 @@ public:
   template<typename FilterT>
   void connectInput(FilterT & upstream) { filter_->connectInput(upstream); }
 
-  /// Underlying tf2_ros::MessageFilter. Exposed for advanced use.
-  std::shared_ptr<tf2_ros::MessageFilter<MsgT>> filter() const { return filter_; }
-
 private:
   rclcpp::Node::SharedPtr node_;
   tf2_ros::Buffer::SharedPtr buffer_;

--- a/src/camp/ros/tf_dispatcher.h
+++ b/src/camp/ros/tf_dispatcher.h
@@ -34,7 +34,11 @@ namespace camp_ros
 /// add(). For the common "subscribe + gate" case, see TopicBridge.
 ///
 /// Lifetime contract: the receiver QObject must outlive this dispatcher.
-/// In practice, hold the dispatcher as a member of the receiver.
+/// In practice, hold the dispatcher as a member of the receiver. The
+/// `QPointer` test inside the dispatch lambda is a defensive courtesy only —
+/// `QPointer` is not thread-safe, so the actual safety guarantee comes from
+/// the ownership rule plus `Qt::QueuedConnection` (events queued to a
+/// destroyed receiver are dropped by Qt's event system).
 template<typename MsgT, typename PayloadT>
 class TfDispatcher
 {

--- a/src/camp/ros/tf_dispatcher.h
+++ b/src/camp/ros/tf_dispatcher.h
@@ -1,0 +1,115 @@
+#ifndef CAMP_ROS_TF_DISPATCHER_H
+#define CAMP_ROS_TF_DISPATCHER_H
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <QObject>
+#include <QPointer>
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/message_filter.h>
+
+namespace camp_ros
+{
+
+/// TF-gated dispatcher for stamped messages of type MsgT.
+///
+/// Wraps tf2_ros::MessageFilter to delay messages until the requested target
+/// frame is reachable. When the filter dispatches a message (on the ROS
+/// executor thread), TfDispatcher invokes the converter to produce a
+/// value-typed PayloadT, then posts the payload to a Qt receiver via
+/// Qt::QueuedConnection.
+///
+/// The converter runs on the executor thread and may use the TF buffer with
+/// tf2::TimePointZero (no timeout) — by contract, the transform is already
+/// in the buffer when the converter is called.
+///
+/// TfDispatcher does not own a subscription. Callers feed it messages via
+/// add(). For the common "subscribe + gate" case, see TopicBridge.
+///
+/// Lifetime contract: the receiver QObject must outlive this dispatcher.
+/// In practice, hold the dispatcher as a member of the receiver.
+template<typename MsgT, typename PayloadT>
+class TfDispatcher
+{
+public:
+  using MsgConstSharedPtr = std::shared_ptr<const MsgT>;
+  using Converter = std::function<std::optional<PayloadT>(const MsgT&, tf2_ros::Buffer&)>;
+  using ReceiverFn = std::function<void(PayloadT)>;
+
+  TfDispatcher(rclcpp::Node::SharedPtr node,
+               tf2_ros::Buffer::SharedPtr buffer,
+               const std::string & target_frame,
+               uint32_t queue_size,
+               std::chrono::nanoseconds buffer_timeout,
+               Converter converter,
+               QObject * receiver,
+               ReceiverFn receiver_fn)
+  : node_(std::move(node)),
+    buffer_(std::move(buffer))
+  {
+    filter_ = std::make_shared<tf2_ros::MessageFilter<MsgT>>(
+      *buffer_,
+      target_frame,
+      queue_size,
+      node_->get_node_logging_interface(),
+      node_->get_node_clock_interface(),
+      buffer_timeout);
+
+    // The lambda captures everything by value so it is safe for
+    // tf2_ros::MessageFilter to hold even if the dispatcher is destroyed
+    // (the filter and its callbacks tear down together).
+    filter_->registerCallback(
+      [buffer = buffer_, converter = std::move(converter),
+       receiver_ptr = QPointer<QObject>(receiver),
+       receiver_fn = std::move(receiver_fn)]
+      (const MsgConstSharedPtr & msg)
+      {
+        if (!receiver_ptr) return;
+        auto payload = converter(*msg, *buffer);
+        if (!payload) return;
+        QObject * raw_receiver = receiver_ptr.data();
+        if (!raw_receiver) return;
+        QMetaObject::invokeMethod(
+          raw_receiver,
+          [receiver_ptr, receiver_fn, value = std::move(*payload)]() mutable
+          {
+            if (receiver_ptr) receiver_fn(std::move(value));
+          },
+          Qt::QueuedConnection);
+      });
+  }
+
+  ~TfDispatcher() = default;
+
+  TfDispatcher(const TfDispatcher &) = delete;
+  TfDispatcher & operator=(const TfDispatcher &) = delete;
+
+  /// Feed a message into the filter. Will dispatch (eventually) when the
+  /// target transform is available, or be dropped after buffer_timeout.
+  void add(const MsgConstSharedPtr & msg) { filter_->add(msg); }
+  void add(const MsgT & msg) { filter_->add(std::make_shared<MsgT>(msg)); }
+
+  /// Connect a message_filters::SimpleFilter (e.g. message_filters::Subscriber)
+  /// to feed this dispatcher.
+  template<typename FilterT>
+  void connectInput(FilterT & upstream) { filter_->connectInput(upstream); }
+
+  /// Underlying tf2_ros::MessageFilter. Exposed for advanced use.
+  std::shared_ptr<tf2_ros::MessageFilter<MsgT>> filter() const { return filter_; }
+
+private:
+  rclcpp::Node::SharedPtr node_;
+  tf2_ros::Buffer::SharedPtr buffer_;
+  std::shared_ptr<tf2_ros::MessageFilter<MsgT>> filter_;
+};
+
+} // namespace camp_ros
+
+#endif

--- a/src/camp/ros/topic_bridge.h
+++ b/src/camp/ros/topic_bridge.h
@@ -132,8 +132,13 @@ public:
 private:
   rclcpp::Node::SharedPtr node_;
   std::string topic_;
-  message_filters::Subscriber<MsgT> subscriber_;
+  // dispatcher_ owns the MessageFilter that subscriber_ feeds via
+  // connectInput(). Declare dispatcher_ before subscriber_ so that on
+  // destruction subscriber_ is torn down (and stops feeding the filter)
+  // before the filter itself is destroyed. Otherwise an in-flight ROS
+  // callback can call MessageFilter::add() on freed memory.
   std::unique_ptr<TfDispatcher<MsgT, PayloadT>> dispatcher_;
+  message_filters::Subscriber<MsgT> subscriber_;
 };
 
 } // namespace camp_ros

--- a/src/camp/ros/topic_bridge.h
+++ b/src/camp/ros/topic_bridge.h
@@ -1,0 +1,141 @@
+#ifndef CAMP_ROS_TOPIC_BRIDGE_H
+#define CAMP_ROS_TOPIC_BRIDGE_H
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <QObject>
+#include <QPointer>
+
+#include <message_filters/subscriber.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer.h>
+
+#include "tf_dispatcher.h"
+
+namespace camp_ros
+{
+
+/// Plain (non-TF-gated) topic bridge.
+///
+/// Owns an rclcpp::Subscription. Each received message is passed through the
+/// converter on the ROS executor thread; if the converter returns a payload,
+/// it is dispatched to the receiver via Qt::QueuedConnection.
+///
+/// Lifetime contract: the receiver QObject must outlive this bridge. In
+/// practice, hold the bridge as a member of the receiver.
+template<typename MsgT, typename PayloadT>
+class PlainTopicBridge
+{
+public:
+  using Converter = std::function<std::optional<PayloadT>(const MsgT &)>;
+  using ReceiverFn = std::function<void(PayloadT)>;
+
+  PlainTopicBridge(rclcpp::Node::SharedPtr node,
+                   const std::string & topic,
+                   const rclcpp::QoS & qos,
+                   rclcpp::CallbackGroup::SharedPtr callback_group,
+                   Converter converter,
+                   QObject * receiver,
+                   ReceiverFn receiver_fn)
+  : node_(std::move(node)),
+    topic_(topic)
+  {
+    rclcpp::SubscriptionOptions options;
+    options.callback_group = std::move(callback_group);
+
+    subscription_ = node_->create_subscription<MsgT>(
+      topic, qos,
+      [converter = std::move(converter),
+       receiver_ptr = QPointer<QObject>(receiver),
+       receiver_fn = std::move(receiver_fn)]
+      (const std::shared_ptr<const MsgT> msg)
+      {
+        if (!receiver_ptr) return;
+        auto payload = converter(*msg);
+        if (!payload) return;
+        QObject * raw_receiver = receiver_ptr.data();
+        if (!raw_receiver) return;
+        QMetaObject::invokeMethod(
+          raw_receiver,
+          [receiver_ptr, receiver_fn, value = std::move(*payload)]() mutable
+          {
+            if (receiver_ptr) receiver_fn(std::move(value));
+          },
+          Qt::QueuedConnection);
+      },
+      options);
+  }
+
+  ~PlainTopicBridge() = default;
+
+  PlainTopicBridge(const PlainTopicBridge &) = delete;
+  PlainTopicBridge & operator=(const PlainTopicBridge &) = delete;
+
+  std::string topic() const { return topic_; }
+
+private:
+  rclcpp::Node::SharedPtr node_;
+  std::string topic_;
+  typename rclcpp::Subscription<MsgT>::SharedPtr subscription_;
+};
+
+/// TF-gated topic bridge.
+///
+/// Owns a message_filters::Subscriber connected to a TfDispatcher. Messages
+/// are released only when the target frame is reachable; the converter runs
+/// on the executor thread with a TF buffer guaranteed-available, and the
+/// payload is dispatched to the receiver via Qt::QueuedConnection.
+template<typename MsgT, typename PayloadT>
+class TfTopicBridge
+{
+public:
+  using Converter = typename TfDispatcher<MsgT, PayloadT>::Converter;
+  using ReceiverFn = typename TfDispatcher<MsgT, PayloadT>::ReceiverFn;
+
+  TfTopicBridge(rclcpp::Node::SharedPtr node,
+                tf2_ros::Buffer::SharedPtr buffer,
+                const std::string & topic,
+                const rclcpp::QoS & qos,
+                const std::string & target_frame,
+                uint32_t filter_queue_size,
+                std::chrono::nanoseconds buffer_timeout,
+                rclcpp::CallbackGroup::SharedPtr callback_group,
+                Converter converter,
+                QObject * receiver,
+                ReceiverFn receiver_fn)
+  : node_(std::move(node)),
+    topic_(topic)
+  {
+    rclcpp::SubscriptionOptions options;
+    options.callback_group = std::move(callback_group);
+    subscriber_.subscribe(node_, topic, qos.get_rmw_qos_profile(), options);
+
+    dispatcher_ = std::make_unique<TfDispatcher<MsgT, PayloadT>>(
+      node_, std::move(buffer), target_frame,
+      filter_queue_size, buffer_timeout,
+      std::move(converter), receiver, std::move(receiver_fn));
+    dispatcher_->connectInput(subscriber_);
+  }
+
+  ~TfTopicBridge() = default;
+
+  TfTopicBridge(const TfTopicBridge &) = delete;
+  TfTopicBridge & operator=(const TfTopicBridge &) = delete;
+
+  std::string topic() const { return topic_; }
+
+private:
+  rclcpp::Node::SharedPtr node_;
+  std::string topic_;
+  message_filters::Subscriber<MsgT> subscriber_;
+  std::unique_ptr<TfDispatcher<MsgT, PayloadT>> dispatcher_;
+};
+
+} // namespace camp_ros
+
+#endif

--- a/src/camp/ros/topic_bridge.h
+++ b/src/camp/ros/topic_bridge.h
@@ -27,7 +27,11 @@ namespace camp_ros
 /// it is dispatched to the receiver via Qt::QueuedConnection.
 ///
 /// Lifetime contract: the receiver QObject must outlive this bridge. In
-/// practice, hold the bridge as a member of the receiver.
+/// practice, hold the bridge as a member of the receiver. The `QPointer`
+/// test inside the dispatch lambda is a defensive courtesy only — `QPointer`
+/// is not thread-safe, so the actual safety guarantee comes from the
+/// ownership rule plus `Qt::QueuedConnection` (events queued to a destroyed
+/// receiver are dropped by Qt's event system).
 template<typename MsgT, typename PayloadT>
 class PlainTopicBridge
 {
@@ -90,6 +94,11 @@ private:
 /// are released only when the target frame is reachable; the converter runs
 /// on the executor thread with a TF buffer guaranteed-available, and the
 /// payload is dispatched to the receiver via Qt::QueuedConnection.
+///
+/// Lifetime contract: see PlainTopicBridge above (and the underlying
+/// TfDispatcher) — the receiver QObject must outlive this bridge, and the
+/// `QPointer` test in the dispatch path is courtesy, not the actual safety
+/// guarantee.
 template<typename MsgT, typename PayloadT>
 class TfTopicBridge
 {

--- a/test/test_markers_converter.cpp
+++ b/test/test_markers_converter.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <string>

--- a/test/test_markers_converter.cpp
+++ b/test/test_markers_converter.cpp
@@ -85,7 +85,9 @@ TEST_F(MarkersConverterTest, addMarkerWithValidTfProducesPayload)
   ASSERT_TRUE(out.has_value());
   EXPECT_EQ((*out)->marker.ns, "ns_a");
   EXPECT_EQ((*out)->marker.id, 1);
-  // earth-frame identity at the origin is roughly the geo origin (lat=0, lon=0).
+  // surfaceTransform places base_link at the WGS-84 surface (≈ lat=0, lon=0);
+  // we use it instead of an identity translation to dodge the singular ECEF
+  // (0, 0, 0) point that converts to NaN lat/lon.
   EXPECT_TRUE((*out)->position.isValid());
 }
 

--- a/test/test_markers_converter.cpp
+++ b/test/test_markers_converter.cpp
@@ -1,0 +1,193 @@
+// Tests for camp_markers::convertMarker — the per-marker logic that runs
+// inside the TF dispatcher's converter on the executor thread.
+//
+// These tests exercise marker-action handling, lifetime expiry, missing
+// frame_id handling, and TF-driven geo conversion. The threading and TF
+// gating around the converter are tested separately in test_topic_bridge.cpp.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer.h>
+
+#include <visualization_msgs/msg/marker.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include "markers/markers_converter.h"
+
+using std::chrono_literals::operator""s;
+
+namespace
+{
+
+geometry_msgs::msg::TransformStamped identityTransform(
+  const std::string & parent, const std::string & child, const rclcpp::Time & stamp)
+{
+  geometry_msgs::msg::TransformStamped t;
+  t.header.stamp = stamp;
+  t.header.frame_id = parent;
+  t.child_frame_id = child;
+  t.transform.rotation.w = 1.0;
+  return t;
+}
+
+// Earth-fixed → child transform that places `child` at the surface near the
+// equator/prime meridian (ECEF ~ (a, 0, 0), where a is the WGS-84 semi-major
+// axis). Avoids the singular (0, 0, 0) ECEF point that converts to NaN
+// lat/lon.
+geometry_msgs::msg::TransformStamped surfaceTransform(
+  const std::string & parent, const std::string & child, const rclcpp::Time & stamp)
+{
+  auto t = identityTransform(parent, child, stamp);
+  t.transform.translation.x = 6378137.0;  // WGS-84 semi-major axis (meters)
+  return t;
+}
+
+}  // namespace
+
+class MarkersConverterTest : public ::testing::Test
+{
+protected:
+  rclcpp::Node::SharedPtr node;
+  std::shared_ptr<tf2_ros::Buffer> buffer;
+
+  void SetUp() override
+  {
+    static std::atomic<unsigned> counter{0};
+    auto n = std::to_string(counter.fetch_add(1));
+    node = rclcpp::Node::make_shared("markers_converter_test_" + n);
+    buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  }
+
+  rclcpp::Time now() const { return node->get_clock()->now(); }
+  rclcpp::Logger logger() const { return node->get_logger(); }
+};
+
+TEST_F(MarkersConverterTest, addMarkerWithValidTfProducesPayload)
+{
+  buffer->setTransform(surfaceTransform("earth", "base_link", now()),
+                       "test", /*is_static=*/true);
+
+  visualization_msgs::msg::Marker m;
+  m.action = visualization_msgs::msg::Marker::ADD;
+  m.ns = "ns_a";
+  m.id = 1;
+  m.header.frame_id = "base_link";
+  m.header.stamp = now();
+  m.pose.orientation.w = 1.0;
+
+  auto out = camp_markers::convertMarker(m, *buffer, now(), logger());
+  ASSERT_TRUE(out.has_value());
+  EXPECT_EQ((*out)->marker.ns, "ns_a");
+  EXPECT_EQ((*out)->marker.id, 1);
+  // earth-frame identity at the origin is roughly the geo origin (lat=0, lon=0).
+  EXPECT_TRUE((*out)->position.isValid());
+}
+
+TEST_F(MarkersConverterTest, addMarkerWithEmptyFrameIdIsDropped)
+{
+  visualization_msgs::msg::Marker m;
+  m.action = visualization_msgs::msg::Marker::ADD;
+  m.header.frame_id = "";  // empty
+  m.header.stamp = now();
+
+  auto out = camp_markers::convertMarker(m, *buffer, now(), logger());
+  EXPECT_FALSE(out.has_value())
+    << "ADD with empty frame_id must be dropped, not propagated";
+}
+
+TEST_F(MarkersConverterTest, addMarkerWithUnreachableFrameIsDropped)
+{
+  // No TF set up — frame is not reachable.
+  visualization_msgs::msg::Marker m;
+  m.action = visualization_msgs::msg::Marker::ADD;
+  m.header.frame_id = "no_such_frame";
+  m.header.stamp = now();
+  m.pose.orientation.w = 1.0;
+
+  auto out = camp_markers::convertMarker(m, *buffer, now(), logger());
+  EXPECT_FALSE(out.has_value());
+}
+
+TEST_F(MarkersConverterTest, addMarkerWithExpiredLifetimeIsDropped)
+{
+  buffer->setTransform(surfaceTransform("earth", "base_link", now()),
+                       "test", /*is_static=*/true);
+
+  // Marker stamped 10 s in the past with a 1 s lifetime → already expired.
+  auto stamp = rclcpp::Time(now()) - rclcpp::Duration(10s);
+  visualization_msgs::msg::Marker m;
+  m.action = visualization_msgs::msg::Marker::ADD;
+  m.header.frame_id = "base_link";
+  m.header.stamp = stamp;
+  m.lifetime = rclcpp::Duration(1s);
+  m.pose.orientation.w = 1.0;
+
+  auto out = camp_markers::convertMarker(m, *buffer, now(), logger());
+  EXPECT_FALSE(out.has_value())
+    << "ADD with expired lifetime must be dropped";
+}
+
+TEST_F(MarkersConverterTest, addMarkerWithZeroLifetimeIsAcceptedRegardlessOfStamp)
+{
+  buffer->setTransform(surfaceTransform("earth", "base_link", now()),
+                       "test", /*is_static=*/true);
+
+  // 1 hour ago, lifetime=0 means "infinite" — must not be dropped.
+  auto stamp = rclcpp::Time(now()) - rclcpp::Duration(3600s);
+  visualization_msgs::msg::Marker m;
+  m.action = visualization_msgs::msg::Marker::ADD;
+  m.header.frame_id = "base_link";
+  m.header.stamp = stamp;
+  m.lifetime = rclcpp::Duration(0s);
+  m.pose.orientation.w = 1.0;
+
+  auto out = camp_markers::convertMarker(m, *buffer, now(), logger());
+  EXPECT_TRUE(out.has_value())
+    << "ADD with lifetime=0 means 'permanent' and must not be dropped";
+}
+
+TEST_F(MarkersConverterTest, deleteActionPassesThroughWithoutTf)
+{
+  // No TF set — DELETE actions don't need a position lookup, but in the
+  // current shape the converter still produces a payload (with no position)
+  // so the receiver can act on the action.
+  visualization_msgs::msg::Marker m;
+  m.action = visualization_msgs::msg::Marker::DELETE;
+  m.ns = "ns_b";
+  m.id = 7;
+  m.header.frame_id = "anything";
+  m.header.stamp = now();
+
+  auto out = camp_markers::convertMarker(m, *buffer, now(), logger());
+  ASSERT_TRUE(out.has_value());
+  EXPECT_EQ((*out)->marker.action, visualization_msgs::msg::Marker::DELETE);
+  EXPECT_EQ((*out)->marker.ns, "ns_b");
+  EXPECT_EQ((*out)->marker.id, 7);
+}
+
+TEST_F(MarkersConverterTest, deleteAllActionPassesThrough)
+{
+  visualization_msgs::msg::Marker m;
+  m.action = visualization_msgs::msg::Marker::DELETEALL;
+  m.ns = "ns_c";
+  m.header.stamp = now();
+
+  auto out = camp_markers::convertMarker(m, *buffer, now(), logger());
+  ASSERT_TRUE(out.has_value());
+  EXPECT_EQ((*out)->marker.action, visualization_msgs::msg::Marker::DELETEALL);
+  EXPECT_EQ((*out)->marker.ns, "ns_c");
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  int rc = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return rc;
+}

--- a/test/test_topic_bridge.cpp
+++ b/test/test_topic_bridge.cpp
@@ -574,12 +574,12 @@ TEST(RosContextTest, singletonRoundTrip)
 
   EXPECT_EQ(camp_ros::RosContext::instance(), nullptr);
 
-  camp_ros::RosContext ctx(node, buffer);
-  camp_ros::RosContext::setInstance(&ctx);
-  EXPECT_EQ(camp_ros::RosContext::instance(), &ctx);
+  auto ctx = std::make_shared<camp_ros::RosContext>(node, buffer);
+  camp_ros::RosContext::setInstance(ctx);
+  EXPECT_EQ(camp_ros::RosContext::instance().get(), ctx.get());
 
-  auto realtime = ctx.group(camp_ros::RosContext::Group::Realtime);
-  auto scene = ctx.group(camp_ros::RosContext::Group::Scene);
+  auto realtime = ctx->group(camp_ros::RosContext::Group::Realtime);
+  auto scene = ctx->group(camp_ros::RosContext::Group::Scene);
   ASSERT_NE(realtime, nullptr);
   ASSERT_NE(scene, nullptr);
   EXPECT_NE(realtime.get(), scene.get())
@@ -587,6 +587,35 @@ TEST(RosContextTest, singletonRoundTrip)
 
   camp_ros::RosContext::clearInstance();
   EXPECT_EQ(camp_ros::RosContext::instance(), nullptr);
+}
+
+TEST(RosContextTest, sharedPtrSurvivesConcurrentClearInstance)
+{
+  // The whole point of returning shared_ptr (vs. raw pointer) is that a
+  // caller's local copy keeps the RosContext alive across a concurrent
+  // clearInstance. Pin that contract down explicitly: clearInstance must
+  // not destroy the object while a caller still holds the shared_ptr.
+  auto node = rclcpp::Node::make_shared("camp_ros_context_concurrent_test");
+  auto buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+
+  auto ctx = std::make_shared<camp_ros::RosContext>(node, buffer);
+  camp_ros::RosContext::setInstance(ctx);
+
+  auto consumer_view = camp_ros::RosContext::instance();
+  ASSERT_NE(consumer_view, nullptr);
+
+  // Drop the original ref AND clear the global slot. With raw-pointer
+  // semantics this would have destroyed the object; with shared_ptr the
+  // consumer's view keeps it alive.
+  ctx.reset();
+  camp_ros::RosContext::clearInstance();
+  EXPECT_EQ(camp_ros::RosContext::instance(), nullptr);
+
+  // consumer_view is still safe to dereference.
+  auto realtime = consumer_view->group(camp_ros::RosContext::Group::Realtime);
+  ASSERT_NE(realtime, nullptr);
+
+  consumer_view.reset();  // last ref; destruction happens here.
 }
 
 // ---------------------------------------------------------------------------

--- a/test/test_topic_bridge.cpp
+++ b/test/test_topic_bridge.cpp
@@ -171,7 +171,8 @@ TEST_F(TopicBridgeTest, plainBridgeReceivesPublishedMessage)
   // Publisher uses the same node + executor as the bridge. Wait briefly for
   // the subscription to come up before publishing.
   auto pub = node->create_publisher<std_msgs::msg::Int32>("/test_int", 10);
-  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+  ASSERT_TRUE(waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; }))
+    << "publisher never matched the bridge's subscriber";
 
   std_msgs::msg::Int32 msg;
   msg.data = 42;
@@ -193,7 +194,8 @@ TEST_F(TopicBridgeTest, plainBridgeDispatchesOnQtThreadNotExecutorThread)
     [&receiver](int v) { receiver.onInt(v); });
 
   auto pub = node->create_publisher<std_msgs::msg::Int32>("/test_int_thread", 10);
-  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+  ASSERT_TRUE(waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; }))
+    << "publisher never matched the bridge's subscriber";
 
   std_msgs::msg::Int32 msg;
   msg.data = 1;
@@ -219,7 +221,8 @@ TEST_F(TopicBridgeTest, plainBridgeConverterReturningNulloptDropsMessage)
     [&receiver](int v) { receiver.onInt(v); });
 
   auto pub = node->create_publisher<std_msgs::msg::Int32>("/test_int_drop", 10);
-  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+  ASSERT_TRUE(waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; }))
+    << "publisher never matched the bridge's subscriber";
 
   std_msgs::msg::Int32 dropped;
   dropped.data = -7;
@@ -280,7 +283,8 @@ TEST_F(TopicBridgeTest, tfBridgeWithdrawsDispatchUntilTfArrives)
 
   auto pub = node->create_publisher<geometry_msgs::msg::PointStamped>(
     "/test_pt_late", 10);
-  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+  ASSERT_TRUE(waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; }))
+    << "publisher never matched the bridge's subscriber";
 
   // Publish before TF is available.
   geometry_msgs::msg::PointStamped m;
@@ -322,7 +326,8 @@ TEST_F(TopicBridgeTest, tfBridgeDispatchesImmediatelyWhenTfPresent)
 
   auto pub = node->create_publisher<geometry_msgs::msg::PointStamped>(
     "/test_pt_early", 10);
-  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+  ASSERT_TRUE(waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; }))
+    << "publisher never matched the bridge's subscriber";
 
   geometry_msgs::msg::PointStamped m;
   m.header.frame_id = "base_link";
@@ -350,7 +355,8 @@ TEST_F(TopicBridgeTest, tfBridgeDropsMessageWhenTfNeverArrives)
 
   auto pub = node->create_publisher<geometry_msgs::msg::PointStamped>(
     "/test_pt_drop", 10);
-  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+  ASSERT_TRUE(waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; }))
+    << "publisher never matched the bridge's subscriber";
 
   geometry_msgs::msg::PointStamped m;
   m.header.frame_id = "no_such_frame";
@@ -381,7 +387,8 @@ TEST_F(TopicBridgeTest, tfBridgeRecoversAfterTopicStopsAndResumes)
   {
     auto pub = node->create_publisher<geometry_msgs::msg::PointStamped>(
       "/test_pt_resume", 10);
-    waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+    ASSERT_TRUE(waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; }))
+    << "publisher never matched the bridge's subscriber";
 
     geometry_msgs::msg::PointStamped m;
     m.header.frame_id = "base_link";
@@ -403,7 +410,8 @@ TEST_F(TopicBridgeTest, tfBridgeRecoversAfterTopicStopsAndResumes)
   // Resume: a fresh publisher.
   auto pub2 = node->create_publisher<geometry_msgs::msg::PointStamped>(
     "/test_pt_resume", 10);
-  waitForUntil(500, [&]() { return pub2->get_subscription_count() >= 1; });
+  ASSERT_TRUE(waitForUntil(500, [&]() { return pub2->get_subscription_count() >= 1; }))
+    << "fresh publisher never matched the bridge's subscriber after resume";
 
   geometry_msgs::msg::PointStamped m2;
   m2.header.frame_id = "base_link";
@@ -436,9 +444,9 @@ TEST_F(TopicBridgeTest, multipleBridgesOnSameNodeDoNotInterfere)
 
   auto pa = node->create_publisher<std_msgs::msg::Int32>("/multi_a", 10);
   auto pb = node->create_publisher<std_msgs::msg::Int32>("/multi_b", 10);
-  waitForUntil(500, [&]() {
+  ASSERT_TRUE(waitForUntil(500, [&]() {
     return pa->get_subscription_count() >= 1 && pb->get_subscription_count() >= 1;
-  });
+  })) << "publishers /multi_a and /multi_b never matched their subscribers";
 
   std_msgs::msg::Int32 ma; ma.data = 1; pa->publish(ma);
   std_msgs::msg::Int32 mb; mb.data = 2; pb->publish(mb);
@@ -499,10 +507,10 @@ TEST_F(TopicBridgeTest, sceneCallbackDoesNotStarveRealtimeCallback)
 
   auto scene_pub = node->create_publisher<std_msgs::msg::Int32>("/iso_scene", 10);
   auto rt_pub = node->create_publisher<std_msgs::msg::Int32>("/iso_rt", 10);
-  waitForUntil(500, [&]() {
+  ASSERT_TRUE(waitForUntil(500, [&]() {
     return scene_pub->get_subscription_count() >= 1 &&
            rt_pub->get_subscription_count() >= 1;
-  });
+  })) << "publishers /iso_scene and /iso_rt never matched their subscribers";
 
   // Block the scene group's worker.
   std_msgs::msg::Int32 sm; sm.data = 1; scene_pub->publish(sm);

--- a/test/test_topic_bridge.cpp
+++ b/test/test_topic_bridge.cpp
@@ -1,0 +1,525 @@
+// Tests for camp_ros::PlainTopicBridge, TfTopicBridge, TfDispatcher, and
+// RosContext. See docs/decisions/0001-topicbridge-and-executor-contract.md.
+//
+// These tests pin down the threading and TF contracts:
+//   - Receiver slots fire on the Qt main thread, never on the ROS executor.
+//   - TF-gated bridges withhold dispatch until the target frame is reachable.
+//   - TF-gated bridges drop messages whose TF never resolves (within timeout).
+//   - Bridge destruction is safe and does not deadlock.
+//
+// The fixture spins a real rclcpp::Node + MultiThreadedExecutor on a worker
+// thread and treats the test thread as the "Qt main thread."
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QObject>
+#include <QSignalSpy>
+#include <QThread>
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/create_timer_ros.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <geometry_msgs/msg/point_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <std_msgs/msg/int32.hpp>
+
+#include "ros/ros_context.h"
+#include "ros/tf_dispatcher.h"
+#include "ros/topic_bridge.h"
+
+using namespace std::chrono_literals;
+
+namespace
+{
+
+// QObject receiver used to capture dispatched payloads. Records each payload
+// and the thread it was delivered on, then emits gotOne() so QSignalSpy can
+// pump events until dispatch completes.
+class TestReceiver : public QObject
+{
+  Q_OBJECT
+public:
+  std::vector<int> int_payloads;
+  std::vector<geometry_msgs::msg::PointStamped> point_payloads;
+  Qt::HANDLE delivery_thread_handle = nullptr;
+
+  void onInt(int v)
+  {
+    int_payloads.push_back(v);
+    delivery_thread_handle = QThread::currentThreadId();
+    Q_EMIT gotOne();
+  }
+
+  void onPoint(geometry_msgs::msg::PointStamped p)
+  {
+    point_payloads.push_back(std::move(p));
+    delivery_thread_handle = QThread::currentThreadId();
+    Q_EMIT gotOne();
+  }
+
+Q_SIGNALS:
+  void gotOne();
+};
+
+// Pump Qt events for up to `ms` milliseconds, returning early if `predicate`
+// becomes true. Used when QSignalSpy::wait() is too coarse (we want to assert
+// that *no* dispatch happened within a timeout).
+template<typename Pred>
+bool waitForUntil(int ms, Pred predicate)
+{
+  QElapsedTimer timer;
+  timer.start();
+  while (timer.elapsed() < ms)
+  {
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    if (predicate()) return true;
+    std::this_thread::sleep_for(5ms);
+  }
+  return predicate();
+}
+
+void pumpEventsFor(int ms)
+{
+  QElapsedTimer timer;
+  timer.start();
+  while (timer.elapsed() < ms)
+  {
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    std::this_thread::sleep_for(5ms);
+  }
+}
+
+geometry_msgs::msg::TransformStamped identityTransform(
+  const std::string & parent, const std::string & child, const rclcpp::Time & stamp)
+{
+  geometry_msgs::msg::TransformStamped t;
+  t.header.stamp = stamp;
+  t.header.frame_id = parent;
+  t.child_frame_id = child;
+  t.transform.rotation.w = 1.0;
+  return t;
+}
+
+}  // namespace
+
+class TopicBridgeTest : public ::testing::Test
+{
+protected:
+  rclcpp::Node::SharedPtr node;
+  std::shared_ptr<tf2_ros::Buffer> buffer;
+  std::unique_ptr<tf2_ros::TransformListener> tf_listener;
+  std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor;
+  std::thread executor_thread;
+  rclcpp::CallbackGroup::SharedPtr default_cbg;
+  Qt::HANDLE qt_thread_handle = nullptr;
+  std::atomic<unsigned> node_counter{0};
+
+  void SetUp() override
+  {
+    qt_thread_handle = QThread::currentThreadId();
+    static std::atomic<unsigned> global_counter{0};
+    auto suffix = std::to_string(global_counter.fetch_add(1));
+    node = rclcpp::Node::make_shared("camp_topic_bridge_test_" + suffix);
+    buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+    auto timer_iface = std::make_shared<tf2_ros::CreateTimerROS>(
+      node->get_node_base_interface(), node->get_node_timers_interface());
+    buffer->setCreateTimerInterface(timer_iface);
+    tf_listener = std::make_unique<tf2_ros::TransformListener>(*buffer, node);
+    default_cbg = node->create_callback_group(
+      rclcpp::CallbackGroupType::MutuallyExclusive);
+
+    executor = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+    executor->add_node(node);
+    executor_thread = std::thread([this]() { executor->spin(); });
+  }
+
+  void TearDown() override
+  {
+    if (executor) executor->cancel();
+    if (executor_thread.joinable()) executor_thread.join();
+    executor.reset();
+    tf_listener.reset();
+    buffer.reset();
+    node.reset();
+  }
+};
+
+// ---------------------------------------------------------------------------
+// PlainTopicBridge
+// ---------------------------------------------------------------------------
+
+TEST_F(TopicBridgeTest, plainBridgeReceivesPublishedMessage)
+{
+  TestReceiver receiver;
+  camp_ros::PlainTopicBridge<std_msgs::msg::Int32, int> bridge(
+    node, "/test_int", rclcpp::QoS(10), default_cbg,
+    [](const std_msgs::msg::Int32 & m) -> std::optional<int> { return m.data; },
+    &receiver,
+    [&receiver](int v) { receiver.onInt(v); });
+
+  // Publisher uses the same node + executor as the bridge. Wait briefly for
+  // the subscription to come up before publishing.
+  auto pub = node->create_publisher<std_msgs::msg::Int32>("/test_int", 10);
+  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+
+  std_msgs::msg::Int32 msg;
+  msg.data = 42;
+  pub->publish(msg);
+
+  QSignalSpy spy(&receiver, &TestReceiver::gotOne);
+  ASSERT_TRUE(spy.wait(2000)) << "payload was never dispatched";
+  ASSERT_EQ(receiver.int_payloads.size(), 1u);
+  EXPECT_EQ(receiver.int_payloads.front(), 42);
+}
+
+TEST_F(TopicBridgeTest, plainBridgeDispatchesOnQtThreadNotExecutorThread)
+{
+  TestReceiver receiver;
+  camp_ros::PlainTopicBridge<std_msgs::msg::Int32, int> bridge(
+    node, "/test_int_thread", rclcpp::QoS(10), default_cbg,
+    [](const std_msgs::msg::Int32 & m) -> std::optional<int> { return m.data; },
+    &receiver,
+    [&receiver](int v) { receiver.onInt(v); });
+
+  auto pub = node->create_publisher<std_msgs::msg::Int32>("/test_int_thread", 10);
+  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+
+  std_msgs::msg::Int32 msg;
+  msg.data = 1;
+  pub->publish(msg);
+
+  QSignalSpy spy(&receiver, &TestReceiver::gotOne);
+  ASSERT_TRUE(spy.wait(2000));
+  EXPECT_EQ(receiver.delivery_thread_handle, qt_thread_handle)
+    << "receiver slot must run on the Qt main thread, not the executor thread";
+}
+
+TEST_F(TopicBridgeTest, plainBridgeConverterReturningNulloptDropsMessage)
+{
+  TestReceiver receiver;
+  camp_ros::PlainTopicBridge<std_msgs::msg::Int32, int> bridge(
+    node, "/test_int_drop", rclcpp::QoS(10), default_cbg,
+    [](const std_msgs::msg::Int32 & m) -> std::optional<int>
+    {
+      if (m.data < 0) return std::nullopt;
+      return m.data;
+    },
+    &receiver,
+    [&receiver](int v) { receiver.onInt(v); });
+
+  auto pub = node->create_publisher<std_msgs::msg::Int32>("/test_int_drop", 10);
+  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+
+  std_msgs::msg::Int32 dropped;
+  dropped.data = -7;
+  pub->publish(dropped);
+
+  std_msgs::msg::Int32 kept;
+  kept.data = 13;
+  pub->publish(kept);
+
+  QSignalSpy spy(&receiver, &TestReceiver::gotOne);
+  ASSERT_TRUE(spy.wait(2000));
+  // Pump for a little longer to make sure no straggler arrives for the dropped one.
+  pumpEventsFor(200);
+  ASSERT_EQ(receiver.int_payloads.size(), 1u);
+  EXPECT_EQ(receiver.int_payloads.front(), 13);
+}
+
+TEST_F(TopicBridgeTest, plainBridgeDestructIsCleanWhenIdle)
+{
+  TestReceiver receiver;
+  {
+    camp_ros::PlainTopicBridge<std_msgs::msg::Int32, int> bridge(
+      node, "/test_int_destr", rclcpp::QoS(10), default_cbg,
+      [](const std_msgs::msg::Int32 & m) -> std::optional<int> { return m.data; },
+      &receiver,
+      [&receiver](int v) { receiver.onInt(v); });
+    // Bridge goes out of scope here.
+  }
+  // No deadlock, no crash. Pump a bit to confirm no late dispatches.
+  pumpEventsFor(100);
+  EXPECT_EQ(receiver.int_payloads.size(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// TfTopicBridge
+// ---------------------------------------------------------------------------
+
+TEST_F(TopicBridgeTest, tfBridgeWithdrawsDispatchUntilTfArrives)
+{
+  TestReceiver receiver;
+  camp_ros::TfTopicBridge<geometry_msgs::msg::PointStamped, geometry_msgs::msg::PointStamped> bridge(
+    node, buffer, "/test_pt_late", rclcpp::QoS(10),
+    /*target_frame=*/"earth",
+    /*filter_queue_size=*/10,
+    /*buffer_timeout=*/2s,
+    default_cbg,
+    [](const geometry_msgs::msg::PointStamped & m, tf2_ros::Buffer & buf)
+      -> std::optional<geometry_msgs::msg::PointStamped>
+    {
+      // By contract, the transform is in the buffer when the converter runs.
+      // We do a TimePointZero lookup with no timeout to confirm.
+      auto t = buf.lookupTransform("earth", m.header.frame_id, tf2::TimePointZero);
+      (void)t;
+      return m;
+    },
+    &receiver,
+    [&receiver](geometry_msgs::msg::PointStamped p) { receiver.onPoint(std::move(p)); });
+
+  auto pub = node->create_publisher<geometry_msgs::msg::PointStamped>(
+    "/test_pt_late", 10);
+  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+
+  // Publish before TF is available.
+  geometry_msgs::msg::PointStamped m;
+  m.header.frame_id = "base_link";
+  m.header.stamp = node->now();
+  m.point.x = 1.0;
+  pub->publish(m);
+
+  // No TF yet → no dispatch within a window.
+  pumpEventsFor(300);
+  EXPECT_EQ(receiver.point_payloads.size(), 0u)
+    << "TF-gated bridge dispatched without target transform";
+
+  // Provide TF: earth → base_link identity.
+  auto tf = identityTransform("earth", "base_link", node->now());
+  buffer->setTransform(tf, "test_authority", /*is_static=*/true);
+
+  // Now the queued message should release.
+  QSignalSpy spy(&receiver, &TestReceiver::gotOne);
+  ASSERT_TRUE(spy.wait(2000)) << "queued message did not dispatch after TF arrived";
+  ASSERT_EQ(receiver.point_payloads.size(), 1u);
+  EXPECT_EQ(receiver.point_payloads.front().header.frame_id, "base_link");
+}
+
+TEST_F(TopicBridgeTest, tfBridgeDispatchesImmediatelyWhenTfPresent)
+{
+  // TF available BEFORE the bridge subscribes.
+  auto tf = identityTransform("earth", "base_link", node->now());
+  buffer->setTransform(tf, "test_authority", /*is_static=*/true);
+
+  TestReceiver receiver;
+  camp_ros::TfTopicBridge<geometry_msgs::msg::PointStamped, geometry_msgs::msg::PointStamped> bridge(
+    node, buffer, "/test_pt_early", rclcpp::QoS(10),
+    "earth", 10, 2s, default_cbg,
+    [](const geometry_msgs::msg::PointStamped & m, tf2_ros::Buffer &)
+      -> std::optional<geometry_msgs::msg::PointStamped> { return m; },
+    &receiver,
+    [&receiver](geometry_msgs::msg::PointStamped p) { receiver.onPoint(std::move(p)); });
+
+  auto pub = node->create_publisher<geometry_msgs::msg::PointStamped>(
+    "/test_pt_early", 10);
+  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+
+  geometry_msgs::msg::PointStamped m;
+  m.header.frame_id = "base_link";
+  m.header.stamp = node->now();
+  m.point.y = 5.0;
+  pub->publish(m);
+
+  QSignalSpy spy(&receiver, &TestReceiver::gotOne);
+  ASSERT_TRUE(spy.wait(2000));
+  ASSERT_EQ(receiver.point_payloads.size(), 1u);
+  EXPECT_DOUBLE_EQ(receiver.point_payloads.front().point.y, 5.0);
+}
+
+TEST_F(TopicBridgeTest, tfBridgeDropsMessageWhenTfNeverArrives)
+{
+  TestReceiver receiver;
+  // Short buffer_timeout so the test runs fast.
+  camp_ros::TfTopicBridge<geometry_msgs::msg::PointStamped, geometry_msgs::msg::PointStamped> bridge(
+    node, buffer, "/test_pt_drop", rclcpp::QoS(10),
+    "earth", 10, /*buffer_timeout=*/200ms, default_cbg,
+    [](const geometry_msgs::msg::PointStamped & m, tf2_ros::Buffer &)
+      -> std::optional<geometry_msgs::msg::PointStamped> { return m; },
+    &receiver,
+    [&receiver](geometry_msgs::msg::PointStamped p) { receiver.onPoint(std::move(p)); });
+
+  auto pub = node->create_publisher<geometry_msgs::msg::PointStamped>(
+    "/test_pt_drop", 10);
+  waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+
+  geometry_msgs::msg::PointStamped m;
+  m.header.frame_id = "no_such_frame";
+  m.header.stamp = node->now();
+  pub->publish(m);
+
+  // Wait well past buffer_timeout.
+  pumpEventsFor(800);
+  EXPECT_EQ(receiver.point_payloads.size(), 0u)
+    << "TF-gated bridge dispatched a message whose target was never reachable";
+}
+
+TEST_F(TopicBridgeTest, tfBridgeRecoversAfterTopicStopsAndResumes)
+{
+  auto tf = identityTransform("earth", "base_link", node->now());
+  buffer->setTransform(tf, "test_authority", /*is_static=*/true);
+
+  TestReceiver receiver;
+  camp_ros::TfTopicBridge<geometry_msgs::msg::PointStamped, geometry_msgs::msg::PointStamped> bridge(
+    node, buffer, "/test_pt_resume", rclcpp::QoS(10),
+    "earth", 10, 2s, default_cbg,
+    [](const geometry_msgs::msg::PointStamped & m, tf2_ros::Buffer &)
+      -> std::optional<geometry_msgs::msg::PointStamped> { return m; },
+    &receiver,
+    [&receiver](geometry_msgs::msg::PointStamped p) { receiver.onPoint(std::move(p)); });
+
+  // First publish round.
+  {
+    auto pub = node->create_publisher<geometry_msgs::msg::PointStamped>(
+      "/test_pt_resume", 10);
+    waitForUntil(500, [&]() { return pub->get_subscription_count() >= 1; });
+
+    geometry_msgs::msg::PointStamped m;
+    m.header.frame_id = "base_link";
+    m.header.stamp = node->now();
+    m.point.x = 1.0;
+    pub->publish(m);
+
+    QSignalSpy spy(&receiver, &TestReceiver::gotOne);
+    ASSERT_TRUE(spy.wait(2000));
+    // pub goes out of scope → "topic stops"
+  }
+
+  // Quiet period: no spurious dispatches.
+  size_t after_first = receiver.point_payloads.size();
+  pumpEventsFor(200);
+  EXPECT_EQ(receiver.point_payloads.size(), after_first)
+    << "bridge dispatched after publisher disappeared";
+
+  // Resume: a fresh publisher.
+  auto pub2 = node->create_publisher<geometry_msgs::msg::PointStamped>(
+    "/test_pt_resume", 10);
+  waitForUntil(500, [&]() { return pub2->get_subscription_count() >= 1; });
+
+  geometry_msgs::msg::PointStamped m2;
+  m2.header.frame_id = "base_link";
+  m2.header.stamp = node->now();
+  m2.point.x = 2.0;
+  pub2->publish(m2);
+
+  QSignalSpy spy2(&receiver, &TestReceiver::gotOne);
+  ASSERT_TRUE(spy2.wait(2000)) << "bridge did not recover after topic resumed";
+  ASSERT_EQ(receiver.point_payloads.size(), after_first + 1);
+  EXPECT_DOUBLE_EQ(receiver.point_payloads.back().point.x, 2.0);
+}
+
+// ---------------------------------------------------------------------------
+// Multiple bridges, no interference
+// ---------------------------------------------------------------------------
+
+TEST_F(TopicBridgeTest, multipleBridgesOnSameNodeDoNotInterfere)
+{
+  TestReceiver r1;
+  TestReceiver r2;
+  camp_ros::PlainTopicBridge<std_msgs::msg::Int32, int> b1(
+    node, "/multi_a", rclcpp::QoS(10), default_cbg,
+    [](const std_msgs::msg::Int32 & m) -> std::optional<int> { return m.data; },
+    &r1, [&r1](int v) { r1.onInt(v); });
+  camp_ros::PlainTopicBridge<std_msgs::msg::Int32, int> b2(
+    node, "/multi_b", rclcpp::QoS(10), default_cbg,
+    [](const std_msgs::msg::Int32 & m) -> std::optional<int> { return m.data * 10; },
+    &r2, [&r2](int v) { r2.onInt(v); });
+
+  auto pa = node->create_publisher<std_msgs::msg::Int32>("/multi_a", 10);
+  auto pb = node->create_publisher<std_msgs::msg::Int32>("/multi_b", 10);
+  waitForUntil(500, [&]() {
+    return pa->get_subscription_count() >= 1 && pb->get_subscription_count() >= 1;
+  });
+
+  std_msgs::msg::Int32 ma; ma.data = 1; pa->publish(ma);
+  std_msgs::msg::Int32 mb; mb.data = 2; pb->publish(mb);
+
+  ASSERT_TRUE(waitForUntil(2000, [&]() {
+    return !r1.int_payloads.empty() && !r2.int_payloads.empty();
+  }));
+  EXPECT_EQ(r1.int_payloads.front(), 1);
+  EXPECT_EQ(r2.int_payloads.front(), 20);
+}
+
+// ---------------------------------------------------------------------------
+// TfDispatcher used standalone (sub-stream feeding pattern)
+// ---------------------------------------------------------------------------
+
+TEST_F(TopicBridgeTest, tfDispatcherStandaloneDispatchesGatedOnTf)
+{
+  auto tf = identityTransform("earth", "base_link", node->now());
+  buffer->setTransform(tf, "test_authority", /*is_static=*/true);
+
+  TestReceiver receiver;
+  camp_ros::TfDispatcher<geometry_msgs::msg::PointStamped, geometry_msgs::msg::PointStamped>
+    dispatcher(
+      node, buffer, "earth", 10, 2s,
+      [](const geometry_msgs::msg::PointStamped & m, tf2_ros::Buffer &)
+        -> std::optional<geometry_msgs::msg::PointStamped> { return m; },
+      &receiver,
+      [&receiver](geometry_msgs::msg::PointStamped p) { receiver.onPoint(std::move(p)); });
+
+  geometry_msgs::msg::PointStamped m;
+  m.header.frame_id = "base_link";
+  m.header.stamp = node->now();
+  m.point.z = 9.0;
+  dispatcher.add(m);
+
+  QSignalSpy spy(&receiver, &TestReceiver::gotOne);
+  ASSERT_TRUE(spy.wait(2000));
+  ASSERT_EQ(receiver.point_payloads.size(), 1u);
+  EXPECT_DOUBLE_EQ(receiver.point_payloads.front().point.z, 9.0);
+}
+
+// ---------------------------------------------------------------------------
+// RosContext (no fixture — avoid the executor-thread machinery; we are only
+// exercising the singleton accessor and callback-group construction)
+// ---------------------------------------------------------------------------
+
+TEST(RosContextTest, singletonRoundTrip)
+{
+  auto node = rclcpp::Node::make_shared("camp_ros_context_test");
+  auto buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+
+  EXPECT_EQ(camp_ros::RosContext::instance(), nullptr);
+
+  camp_ros::RosContext ctx(node, buffer);
+  camp_ros::RosContext::setInstance(&ctx);
+  EXPECT_EQ(camp_ros::RosContext::instance(), &ctx);
+
+  auto realtime = ctx.group(camp_ros::RosContext::Group::Realtime);
+  auto scene = ctx.group(camp_ros::RosContext::Group::Scene);
+  ASSERT_NE(realtime, nullptr);
+  ASSERT_NE(scene, nullptr);
+  EXPECT_NE(realtime.get(), scene.get())
+    << "Realtime and Scene must be distinct callback groups";
+
+  camp_ros::RosContext::clearInstance();
+  EXPECT_EQ(camp_ros::RosContext::instance(), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// main: rclcpp + Qt event loop
+// ---------------------------------------------------------------------------
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  QCoreApplication app(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  int rc = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return rc;
+}
+
+#include "test_topic_bridge.moc"

--- a/test/test_topic_bridge.cpp
+++ b/test/test_topic_bridge.cpp
@@ -124,7 +124,6 @@ protected:
   std::thread executor_thread;
   rclcpp::CallbackGroup::SharedPtr default_cbg;
   Qt::HANDLE qt_thread_handle = nullptr;
-  std::atomic<unsigned> node_counter{0};
 
   void SetUp() override
   {
@@ -449,6 +448,80 @@ TEST_F(TopicBridgeTest, multipleBridgesOnSameNodeDoNotInterfere)
   }));
   EXPECT_EQ(r1.int_payloads.front(), 1);
   EXPECT_EQ(r2.int_payloads.front(), 20);
+}
+
+// ---------------------------------------------------------------------------
+// Callback-group isolation
+// ---------------------------------------------------------------------------
+
+TEST_F(TopicBridgeTest, sceneCallbackDoesNotStarveRealtimeCallback)
+{
+  // Two MutuallyExclusive callback groups can run in parallel only if the
+  // executor has at least two worker threads. On a degenerate single-core
+  // machine this test would deadlock; skip there.
+  if (executor->get_number_of_threads() < 2)
+  {
+    GTEST_SKIP() << "MultiThreadedExecutor has fewer than 2 threads; "
+                 << "callback-group isolation cannot be observed.";
+  }
+
+  auto realtime_cbg = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+  auto scene_cbg = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  TestReceiver realtime_receiver;
+  TestReceiver scene_receiver;
+
+  std::atomic<bool> scene_in_callback{false};
+  std::atomic<bool> release_scene{false};
+
+  // Scene bridge: converter blocks until released, simulating a slow payload
+  // conversion that would otherwise starve the realtime group on a shared
+  // executor.
+  camp_ros::PlainTopicBridge<std_msgs::msg::Int32, int> scene_bridge(
+    node, "/iso_scene", rclcpp::QoS(10), scene_cbg,
+    [&](const std_msgs::msg::Int32 & m) -> std::optional<int>
+    {
+      scene_in_callback.store(true);
+      while (!release_scene.load()) std::this_thread::sleep_for(5ms);
+      return m.data;
+    },
+    &scene_receiver,
+    [&scene_receiver](int v) { scene_receiver.onInt(v); });
+
+  // Realtime bridge: fast converter.
+  camp_ros::PlainTopicBridge<std_msgs::msg::Int32, int> realtime_bridge(
+    node, "/iso_rt", rclcpp::QoS(10), realtime_cbg,
+    [](const std_msgs::msg::Int32 & m) -> std::optional<int> { return m.data; },
+    &realtime_receiver,
+    [&realtime_receiver](int v) { realtime_receiver.onInt(v); });
+
+  auto scene_pub = node->create_publisher<std_msgs::msg::Int32>("/iso_scene", 10);
+  auto rt_pub = node->create_publisher<std_msgs::msg::Int32>("/iso_rt", 10);
+  waitForUntil(500, [&]() {
+    return scene_pub->get_subscription_count() >= 1 &&
+           rt_pub->get_subscription_count() >= 1;
+  });
+
+  // Block the scene group's worker.
+  std_msgs::msg::Int32 sm; sm.data = 1; scene_pub->publish(sm);
+  ASSERT_TRUE(waitForUntil(2000, [&]() { return scene_in_callback.load(); }))
+    << "scene callback never started — cannot test isolation";
+
+  // While scene is blocked, the realtime callback must still fire.
+  std_msgs::msg::Int32 rm; rm.data = 99; rt_pub->publish(rm);
+  QSignalSpy spy(&realtime_receiver, &TestReceiver::gotOne);
+  ASSERT_TRUE(spy.wait(2000))
+    << "realtime callback was starved by a blocked scene callback";
+  EXPECT_EQ(realtime_receiver.int_payloads.front(), 99);
+  EXPECT_EQ(scene_receiver.int_payloads.size(), 0u)
+    << "scene receiver fired despite its converter still blocking";
+
+  // Cleanup: release the scene callback so the bridge's subscription can
+  // shut down cleanly when it goes out of scope.
+  release_scene.store(true);
+  pumpEventsFor(200);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #48.

## Summary
- Adopt `TopicBridge` + executor-contract design (see ADR in this PR)
- Introduce `TopicBridge<MsgT, PayloadT>` and `RosContext`
- Port `Markers` to use the new abstractions as the reference exemplar
- Bring up test infrastructure (BUILD_TESTING, gtest + Qt Test) and add tests
  covering the threading contract, MessageFilter integration, lifecycle, and
  the markers port behaviors

## Out of scope (follow-up issues)
- Port `Platform::pathCallback` (the highest-impact freeze fix)
- Port `Grid`, `NavSource`, `AisManager`
- Heavy `QImage` work in `Grid::occupancyGridCallback`

## Test plan
- [ ] `make build` succeeds for the ui layer
- [ ] `colcon test --packages-select camp` passes
- [ ] Launch camp, load a project with markers, confirm rendering unchanged
- [ ] Kill TF for marker frames; helm watchdog stays green (callback group split)

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
