### PR TITLE
Field import: camp (2026-05-01)

### DIFF
--- a/.agent/work-plans/issue-50/progress.md
+++ b/.agent/work-plans/issue-50/progress.md
@@ -1,0 +1,35 @@
+---
+issue: 50
+---
+
+# Issue #50 — Field import: camp (2026-05-01)
+
+## External Review
+**Status**: complete
+**When**: 2026-05-18 19:10
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #51 — 0 formal reviews, 1 conversation comment (self-review, multi-specialist).
+2 valid suggestions + 1 deferred + 0 false positives.
+**CI**: no checks configured on camp.
+
+### Actions
+- [x] **Code:** Switch all 7 NavSource subscriptions from
+  `.reliability_best_available()` to `.reliable()` to sidestep the
+  same rmw_zenoh 0.2.9 keyexpr bug `udp_bridge#16` worked around on
+  the publisher side (commit `3c18b09`). UX choice ratified by user
+  ("Switch all 7 sites to `.reliable()` now").
+- [x] **PR body:** Replace the inverted-QoS-rule "Why" paragraph
+  with the commit-message framing (defensive: subscriber matches
+  workspace publisher's RELIABLE default; both ends avoid the
+  BEST_AVAILABLE keyexpr bug). Updated via `gh api PATCH` —
+  `gh pr edit --body-file` was the silent classic-Projects no-op
+  (see `reference_gh_pr_edit_workaround.md`).
+- [ ] **Deferred** (file as follow-up issue if it turns out load-bearing):
+  basic NavSource subscription-binding test. Author already
+  acknowledged tests aren't load-bearing for this mechanical
+  defensive change.
+- [ ] **Field check** (post-merge, on boat / operator bench):
+  `ros2 topic info <bridged_nav_topic> --verbose` should now show
+  CAMP as a subscriber. If not, the keyexpr-bug hypothesis was wrong
+  and the QoS choice needs to be re-evaluated.

--- a/.agent/work-plans/issue-50/progress.md
+++ b/.agent/work-plans/issue-50/progress.md
@@ -24,7 +24,7 @@ issue: 50
   workspace publisher's RELIABLE default; both ends avoid the
   BEST_AVAILABLE keyexpr bug). Updated via `gh api PATCH` —
   `gh pr edit --body-file` was the silent classic-Projects no-op
-  (see `reference_gh_pr_edit_workaround.md`).
+  on this repo.
 - [ ] **Deferred** (file as follow-up issue if it turns out load-bearing):
   basic NavSource subscription-binding test. Author already
   acknowledged tests aren't load-bearing for this mechanical
@@ -33,3 +33,16 @@ issue: 50
   `ros2 topic info <bridged_nav_topic> --verbose` should now show
   CAMP as a subscriber. If not, the keyexpr-bug hypothesis was wrong
   and the QoS choice needs to be re-evaluated.
+
+## External Review
+**Status**: complete
+**When**: 2026-05-18 19:55
+**By**: Claude Code Agent (Claude Opus 4.7 (1M context))
+
+**PR**: #51 — Copilot review against HEAD `1cb5413`, 1 valid + 0 false positives.
+**CI**: all 4 checks pass (Cleanup artifacts / Upload results / Agent / Prepare).
+
+### Actions
+- [x] **Fix:** Remove dead-link reference to private agent-memory file
+  (`reference_gh_pr_edit_workaround.md`) from progress.md. Inline the
+  workaround context instead.

--- a/src/camp/nav_source.cpp
+++ b/src/camp/nav_source.cpp
@@ -37,17 +37,17 @@ void NavSource::trySubscribe()
           RCLCPP_INFO_STREAM(node_->get_logger(), "   type: " << topic_type);
           if(topic_type == "sensor_msgs/msg/NavSatFix")
           {
-            position_subscription_ = node_->create_subscription<sensor_msgs::msg::NavSatFix>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::positionCallback, this, std::placeholders::_1));
+            position_subscription_ = node_->create_subscription<sensor_msgs::msg::NavSatFix>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::positionCallback, this, std::placeholders::_1));
             pending_position_topic_.clear();
           }
           else if(topic_type == "geographic_msgs/msg/GeoPointStamped")
           {
-            geo_point_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPointStamped>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::geoPointCallback, this, std::placeholders::_1));
+            geo_point_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPointStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::geoPointCallback, this, std::placeholders::_1));
             pending_position_topic_.clear();
           }
           else if(topic_type == "geographic_msgs/msg/GeoPoseStamped")
           {
-            geo_pose_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPoseStamped>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::geoPoseCallback, this, std::placeholders::_1));
+            geo_pose_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPoseStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::geoPoseCallback, this, std::placeholders::_1));
             pending_position_topic_.clear();
           }
         }
@@ -59,12 +59,12 @@ void NavSource::trySubscribe()
         {
           if(topic_type == "sensor_msgs/msg/Imu")
           {
-            orientation_subscription_ = node_->create_subscription<sensor_msgs::msg::Imu>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::orientationCallback, this, std::placeholders::_1));
+            orientation_subscription_ = node_->create_subscription<sensor_msgs::msg::Imu>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::orientationCallback, this, std::placeholders::_1));
             pending_orientation_topic_.clear();
           }
           if(topic_type == "geometry_msgs/msg/QuaternionStamped")
           {
-            quaternion_subscription_ = node_->create_subscription<geometry_msgs::msg::QuaternionStamped>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::quaternionCallback, this, std::placeholders::_1));
+            quaternion_subscription_ = node_->create_subscription<geometry_msgs::msg::QuaternionStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::quaternionCallback, this, std::placeholders::_1));
             pending_orientation_topic_.clear();
           }
         }
@@ -76,12 +76,12 @@ void NavSource::trySubscribe()
         {
           if(topic_type == "geometry_msgs/msg/TwistWithCovarianceStamped")
           {
-            velocity_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::velocityCallback, this, std::placeholders::_1));
+            velocity_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::velocityCallback, this, std::placeholders::_1));
             pending_velocity_topic_.clear();
           }
           if(topic_type == "geometry_msgs/msg/TwistStamped")
           {
-            velocity_twist_stamped_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistStamped>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::velocityTwistStampedCallback, this, std::placeholders::_1));
+            velocity_twist_stamped_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::velocityTwistStampedCallback, this, std::placeholders::_1));
             pending_velocity_topic_.clear();
           }
         }

--- a/src/camp/nav_source.cpp
+++ b/src/camp/nav_source.cpp
@@ -37,17 +37,17 @@ void NavSource::trySubscribe()
           RCLCPP_INFO_STREAM(node_->get_logger(), "   type: " << topic_type);
           if(topic_type == "sensor_msgs/msg/NavSatFix")
           {
-            position_subscription_ = node_->create_subscription<sensor_msgs::msg::NavSatFix>(name, rclcpp::SensorDataQoS(), std::bind(&NavSource::positionCallback, this, std::placeholders::_1));
+            position_subscription_ = node_->create_subscription<sensor_msgs::msg::NavSatFix>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::positionCallback, this, std::placeholders::_1));
             pending_position_topic_.clear();
           }
           else if(topic_type == "geographic_msgs/msg/GeoPointStamped")
           {
-            geo_point_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPointStamped>(name, rclcpp::SensorDataQoS(), std::bind(&NavSource::geoPointCallback, this, std::placeholders::_1));
+            geo_point_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPointStamped>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::geoPointCallback, this, std::placeholders::_1));
             pending_position_topic_.clear();
           }
           else if(topic_type == "geographic_msgs/msg/GeoPoseStamped")
           {
-            geo_pose_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPoseStamped>(name, rclcpp::SensorDataQoS(), std::bind(&NavSource::geoPoseCallback, this, std::placeholders::_1));
+            geo_pose_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPoseStamped>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::geoPoseCallback, this, std::placeholders::_1));
             pending_position_topic_.clear();
           }
         }
@@ -59,12 +59,12 @@ void NavSource::trySubscribe()
         {
           if(topic_type == "sensor_msgs/msg/Imu")
           {
-            orientation_subscription_ = node_->create_subscription<sensor_msgs::msg::Imu>(name, rclcpp::SensorDataQoS(), std::bind(&NavSource::orientationCallback, this, std::placeholders::_1));
+            orientation_subscription_ = node_->create_subscription<sensor_msgs::msg::Imu>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::orientationCallback, this, std::placeholders::_1));
             pending_orientation_topic_.clear();
           }
           if(topic_type == "geometry_msgs/msg/QuaternionStamped")
           {
-            quaternion_subscription_ = node_->create_subscription<geometry_msgs::msg::QuaternionStamped>(name, rclcpp::SensorDataQoS(), std::bind(&NavSource::quaternionCallback, this, std::placeholders::_1));
+            quaternion_subscription_ = node_->create_subscription<geometry_msgs::msg::QuaternionStamped>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::quaternionCallback, this, std::placeholders::_1));
             pending_orientation_topic_.clear();
           }
         }
@@ -76,12 +76,12 @@ void NavSource::trySubscribe()
         {
           if(topic_type == "geometry_msgs/msg/TwistWithCovarianceStamped")
           {
-            velocity_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(name, rclcpp::SensorDataQoS(), std::bind(&NavSource::velocityCallback, this, std::placeholders::_1));
+            velocity_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::velocityCallback, this, std::placeholders::_1));
             pending_velocity_topic_.clear();
           }
           if(topic_type == "geometry_msgs/msg/TwistStamped")
           {
-            velocity_twist_stamped_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistStamped>(name, rclcpp::SensorDataQoS(), std::bind(&NavSource::velocityTwistStampedCallback, this, std::placeholders::_1));
+            velocity_twist_stamped_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistStamped>(name, rclcpp::SensorDataQoS().reliability_best_available(), std::bind(&NavSource::velocityTwistStampedCallback, this, std::placeholders::_1));
             pending_velocity_topic_.clear();
           }
         }


### PR DESCRIPTION
## Field import — `camp` (2026-05-01)

Imports the field-side fix to NavSource subscriber QoS made on
gitcloud during the 2026-05-01 BizzyBoat deployment
(rolker/unh_echoboats_project11#121), and follows up with a pre-merge
QoS tightening (see [conversation comment](https://github.com/rolker/camp/pull/51#issuecomment) — same rmw_zenoh keyexpr bug
applies to subscriber liveliness).

Closes #50.

## Commits

- `ea2e83e` — `nav_source: relax SensorDataQoS reliability to BEST_AVAILABLE`
  (the original field-side import)
- `3c18b09` — `fix(nav_source): use .reliable() instead of .reliability_best_available()`
  (pre-merge: align subscriber side with [udp_bridge#16](https://github.com/rolker/udp_bridge/pull/16)'s
  publisher-side workaround for the rmw_zenoh 0.2.9 keyexpr-encoding
  bug that affects BEST_AVAILABLE liveliness on both ends)

## Why

`NavSource` was using `rclcpp::SensorDataQoS()` (BEST_EFFORT for
reliability, depth 5) for all per-platform nav subscriptions. After
the field-side bridge work (see [udp_bridge#16](https://github.com/rolker/udp_bridge/pull/16)),
workspace dest publishers default to RELIABLE specifically to sidestep
a bug in `rmw_zenoh_cpp` 0.2.9 that fails to encode BEST_AVAILABLE
into its liveliness keyexpr — leaving graph discovery incomplete.

NavSource's subscriber side has the same bug surface: leaving
BEST_AVAILABLE here would re-introduce the discovery failure on the
subscriber's liveliness keyexpr (data still routes by topic name, but
`ros2 topic info <topic> --verbose` would not show CAMP as a
subscriber, and the rmw graph stays incomplete).

The fix pins all 7 NavSource subscriptions to RELIABLE explicitly,
matching the publisher-side workaround. This is compatibility-
preserving today: workspace publishers for these nav topics are
already RELIABLE-by-default. If a future BEST_EFFORT publisher is
introduced for these topics the binding will need to be revisited.

## Test plan

- [x] Build clean against the workspace (1m 33s, no warnings beyond
      pre-existing).
- [x] `colcon test --packages-select camp` — 22 tests pass.
- [ ] On bench: subscribe a NavSource consumer to a bridged nav
      topic, verify it connects and receives data with the bridge
      dest publisher in RELIABLE mode.
- [ ] On boat: confirm CAMP shows position / orientation / velocity
      from the platforms message after relaunch, and that
      `ros2 topic info <bridged_nav_topic> --verbose` lists CAMP as
      a subscriber.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
