### PR TITLE
Auto-display Collision Monitor danger zones on the CAMP map (#53)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(marine_ais_msgs REQUIRED)
 find_package(marine_sensor_msgs REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(nav2_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(marine_autonomy REQUIRED)
 find_package(marine_interfaces REQUIRED)
@@ -73,6 +74,8 @@ set(SOURCES
     src/camp/mainwindow.cpp
     src/camp/markers/markers.cpp
     src/camp/markers/markers_manager.cpp
+    src/camp/collision_monitor/collision_monitor.cpp
+    src/camp/collision_monitor/collision_monitor_manager.cpp
     src/camp/missionitem.cpp
     src/camp/mission_manager/mission_manager.cpp
     src/camp/orbit.cpp
@@ -130,6 +133,8 @@ set (UIS
     src/camp/mainwindow.ui
     src/camp/markers/markers.ui
     src/camp/markers/markers_manager.ui
+    src/camp/collision_monitor/collision_monitor.ui
+    src/camp/collision_monitor/collision_monitor_manager.ui
     src/camp/waypointdetails.ui
     src/camp/grids/grid.ui
     src/camp/grids/grid_manager.ui
@@ -156,6 +161,7 @@ ament_target_dependencies(CCOMAutonomousMissionPlanner
     message_filters
     marine_ais_msgs
     nav_msgs
+    nav2_msgs
     marine_autonomy
     marine_interfaces
 
@@ -369,6 +375,26 @@ if(BUILD_TESTING)
     marine_autonomy
   )
   target_link_libraries(test_markers_converter
+    Qt5::Core
+    Qt5::Positioning
+  )
+
+  # Collision-monitor polygon converter unit tests
+  ament_add_gtest(test_collision_monitor_converter
+    test/test_collision_monitor_converter.cpp
+  )
+  target_include_directories(test_collision_monitor_converter PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp
+  )
+  ament_target_dependencies(test_collision_monitor_converter
+    rclcpp
+    tf2
+    tf2_ros
+    tf2_geometry_msgs
+    geometry_msgs
+    marine_autonomy
+  )
+  target_link_libraries(test_collision_monitor_converter
     Qt5::Core
     Qt5::Positioning
   )

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
 
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>
+  <depend>nav2_msgs</depend>
   <depend>pluginlib</depend>
   <depend>marine_autonomy</depend>
   <depend>marine_interfaces</depend>

--- a/src/camp/collision_monitor/collision_monitor.cpp
+++ b/src/camp/collision_monitor/collision_monitor.cpp
@@ -61,7 +61,10 @@ void CollisionMonitor::paint(QPainter* painter, const QStyleOptionGraphicsItem* 
 QPainterPath CollisionMonitor::polygonPath(BackgroundRaster* bg) const
 {
   QPainterPath path;
-  if(bg && points_.size() >= 2)
+  // A closed, fillable polygon needs at least 3 vertices; fewer would
+  // closeSubpath() into a degenerate line. Collision-monitor zones are always
+  // >=3 (4 in practice), so this is a defensive guard.
+  if(bg && points_.size() >= 3)
   {
     bool first = true;
     for(const auto& gc: points_)

--- a/src/camp/collision_monitor/collision_monitor.cpp
+++ b/src/camp/collision_monitor/collision_monitor.cpp
@@ -1,0 +1,148 @@
+#include "collision_monitor.h"
+
+#include <chrono>
+#include <utility>
+
+#include <QBrush>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPen>
+
+#include "backgroundraster.h"
+#include "ros/ros_context.h"
+
+CollisionMonitor::CollisionMonitor(QWidget* parent, QGraphicsItem* parentItem):
+  camp_ros::ROSWidget(parent),
+  GeoGraphicsItem(parentItem)
+{
+  ui_.setupUi(this);
+  connect(ui_.displayCheckBox, &QCheckBox::stateChanged, this, &CollisionMonitor::visibilityChanged);
+  ui_.displayCheckBox->setChecked(true);
+}
+
+QRectF CollisionMonitor::boundingRect() const
+{
+  if(!is_visible_)
+    return QRectF();
+  return polygonPath(findParentBackgroundRaster()).boundingRect();
+}
+
+void CollisionMonitor::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
+{
+  (void)option;
+  (void)widget;
+  if(!is_visible_)
+    return;
+
+  auto path = polygonPath(findParentBackgroundRaster());
+  if(path.isEmpty())
+    return;
+
+  painter->save();
+  // Cosmetic pen: constant on-screen line width regardless of map zoom.
+  QPen pen(color_);
+  pen.setCosmetic(true);
+  pen.setWidthF(active_ ? 2.0 : 1.0);
+  painter->setPen(pen);
+  if(active_)
+  {
+    QColor fill = color_;
+    fill.setAlpha(90);
+    painter->setBrush(QBrush(fill));
+  }
+  else
+  {
+    painter->setBrush(Qt::NoBrush);
+  }
+  painter->drawPath(path);
+  painter->restore();
+}
+
+QPainterPath CollisionMonitor::polygonPath(BackgroundRaster* bg) const
+{
+  QPainterPath path;
+  if(bg && points_.size() >= 2)
+  {
+    bool first = true;
+    for(const auto& gc: points_)
+    {
+      QPointF px = geoToPixel(gc, bg);
+      if(first)
+      {
+        path.moveTo(px);
+        first = false;
+      }
+      else
+      {
+        path.lineTo(px);
+      }
+    }
+    path.closeSubpath();
+  }
+  return path;
+}
+
+void CollisionMonitor::setColor(QColor color)
+{
+  color_ = color;
+  GeoGraphicsItem::update();
+}
+
+void CollisionMonitor::setTopic(std::string topic)
+{
+  if(!node_)
+    return;
+
+  // Use the Scene callback group when available so polygon conversion can't
+  // starve realtime callbacks; falls back to the node default otherwise.
+  rclcpp::CallbackGroup::SharedPtr cbg;
+  auto ctx = camp_ros::RosContext::instance();
+  if(ctx)
+    cbg = ctx->group(camp_ros::RosContext::Group::Scene);
+
+  auto node = node_;
+  // QoS(1), reliable/volatile — matches the markers/grid overlays. If a future
+  // bridge republishes these polygons best-effort, switch to best_effort here.
+  bridge_ = std::make_unique<camp_ros::TfTopicBridge<geometry_msgs::msg::PolygonStamped, PayloadT>>(
+    node_, transform_buffer_, topic, rclcpp::QoS(1), "earth", 50, std::chrono::seconds(1), cbg,
+    [node](const geometry_msgs::msg::PolygonStamped& msg, tf2_ros::Buffer& buffer)
+      -> std::optional<PayloadT>
+    {
+      return camp_collision_monitor::convertPolygon(msg, buffer, node->get_logger());
+    },
+    this,
+    [this](PayloadT data) { this->onPolygonPayload(std::move(data)); });
+
+  ui_.topicLabel->setText(topic.c_str());
+}
+
+void CollisionMonitor::setActive(bool active)
+{
+  if(active_ == active)
+    return;
+  active_ = active;
+  GeoGraphicsItem::update();
+}
+
+void CollisionMonitor::onPolygonPayload(PayloadT data)
+{
+  if(!data)
+    return;
+  prepareGeometryChange();
+  points_ = std::move(data->points);
+  GeoGraphicsItem::update();
+}
+
+void CollisionMonitor::visibilityChanged()
+{
+  prepareGeometryChange();
+  is_visible_ = ui_.displayCheckBox->isChecked();
+  GeoGraphicsItem::update();
+}
+
+void CollisionMonitor::updateBackground(BackgroundRaster* bg)
+{
+  prepareGeometryChange();
+  setParentItem(bg);
+  GeoGraphicsItem::update();
+}

--- a/src/camp/collision_monitor/collision_monitor.h
+++ b/src/camp/collision_monitor/collision_monitor.h
@@ -1,0 +1,76 @@
+#ifndef COLLISION_MONITOR_H
+#define COLLISION_MONITOR_H
+
+#include <memory>
+#include <vector>
+
+#include <QColor>
+#include <QGeoCoordinate>
+
+#include "ros/ros_widget.h"
+#include "ros/topic_bridge.h"
+#include "geographicsitem.h"
+#include "collision_monitor/collision_monitor_converter.h"
+#include "ui_collision_monitor.h"
+#include "geometry_msgs/msg/polygon_stamped.hpp"
+
+class BackgroundRaster;
+
+/// One Nav2 Collision Monitor danger zone (slowdown or stop), rendered as a
+/// georeferenced polygon on the map. Drawn as a thin outline when idle and
+/// filled when the zone is actively gating motion. The active state is driven
+/// externally (by CollisionMonitorManager, from nav2_msgs/CollisionMonitorState)
+/// via setActive().
+class CollisionMonitor: public camp_ros::ROSWidget, public GeoGraphicsItem
+{
+  Q_OBJECT
+  Q_INTERFACES(QGraphicsItem)
+public:
+  /// Which Collision Monitor action this zone corresponds to, so gating state
+  /// can be routed to the right zone(s).
+  enum class Kind { Slowdown, Stop };
+
+  CollisionMonitor(QWidget* parent = nullptr, QGraphicsItem* parentItem = nullptr);
+
+  QRectF boundingRect() const override;
+  void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
+  int type() const override { return CollisionMonitorType; }
+
+  /// Base color for this zone's outline (and fill when active).
+  void setColor(QColor color);
+
+  void setKind(Kind kind) { kind_ = kind; }
+  Kind kind() const { return kind_; }
+
+  using PayloadT = std::shared_ptr<camp_collision_monitor::CollisionPolygonPayload>;
+
+public slots:
+  /// Subscribe to a geometry_msgs/PolygonStamped topic for this zone.
+  void setTopic(std::string topic);
+  /// Toggle filled (active) vs outline-only (idle) rendering.
+  void setActive(bool active);
+  void visibilityChanged();
+  void updateBackground(BackgroundRaster* bg);
+
+private:
+  // Receiver slot for the TF bridge. Runs on the Qt main thread.
+  void onPolygonPayload(PayloadT data);
+
+  QPainterPath polygonPath(BackgroundRaster* bg) const;
+
+  Ui::CollisionMonitor ui_;
+
+  // TF-gated bridge: PolygonStamped (base-frame) gated on TF to "earth",
+  // converted to geographic vertices on the executor thread, dispatched to
+  // onPolygonPayload on the Qt main thread. Held as a member so the receiver
+  // (this) outlives it, per the TopicBridge lifetime contract.
+  std::unique_ptr<camp_ros::TfTopicBridge<geometry_msgs::msg::PolygonStamped, PayloadT>> bridge_;
+
+  std::vector<QGeoCoordinate> points_;
+  QColor color_ = QColor(240, 180, 0);
+  Kind kind_ = Kind::Slowdown;
+  bool active_ = false;
+  bool is_visible_ = false;
+};
+
+#endif

--- a/src/camp/collision_monitor/collision_monitor.ui
+++ b/src/camp/collision_monitor/collision_monitor.ui
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CollisionMonitor</class>
+ <widget class="QWidget" name="CollisionMonitor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>478</width>
+    <height>49</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Collision Monitor</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QCheckBox" name="displayCheckBox">
+     <property name="text">
+      <string>show</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="topicLabel">
+     <property name="text">
+      <string>(topic)</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/camp/collision_monitor/collision_monitor_converter.h
+++ b/src/camp/collision_monitor/collision_monitor_converter.h
@@ -1,0 +1,97 @@
+#ifndef CAMP_COLLISION_MONITOR_CONVERTER_H
+#define CAMP_COLLISION_MONITOR_CONVERTER_H
+
+// PolygonStamped -> CollisionPolygonPayload converter, factored out for reuse
+// and testing.
+//
+// The converter runs on the ROS executor thread inside a TfDispatcher. The
+// dispatcher's MessageFilter has already verified that the polygon's frame is
+// transformable to "earth" at the message stamp, so per-vertex lookups use the
+// message stamp with no timeout. Errors here are buffer-edge races and we drop
+// the polygon.
+//
+// Each vertex is transformed individually to "earth" -> geographic, which
+// handles the base-frame heading (the polygons are published in a rotating
+// base frame, e.g. base_link) without any manual yaw math. Collision-monitor
+// zones have only a handful of vertices, so the per-vertex cost is negligible.
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <QGeoCoordinate>
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_ros/buffer.h>
+#include <geometry_msgs/msg/point_stamped.hpp>
+#include <geometry_msgs/msg/polygon_stamped.hpp>
+
+#include "marine_autonomy/gz4d_geo.h"
+
+namespace camp_collision_monitor
+{
+
+/// Polygon vertices in geographic coordinates, produced by the converter and
+/// consumed by the Qt-side receiver (which maps them to scene pixels).
+struct CollisionPolygonPayload
+{
+  std::vector<QGeoCoordinate> points;
+};
+
+/// Convert one PolygonStamped into a CollisionPolygonPayload, or std::nullopt
+/// to drop (empty frame_id, or a vertex that fails to transform to "earth").
+inline std::optional<std::shared_ptr<CollisionPolygonPayload>>
+convertPolygon(const geometry_msgs::msg::PolygonStamped & msg,
+               tf2_ros::Buffer & buffer,
+               rclcpp::Logger logger)
+{
+  if (msg.header.frame_id.empty())
+  {
+    rclcpp::Clock clock;
+    RCLCPP_DEBUG_STREAM_THROTTLE(logger, clock, 1000,
+      "Collision-monitor polygon has empty frame_id; dropping");
+    return std::nullopt;
+  }
+
+  auto payload = std::make_shared<CollisionPolygonPayload>();
+  payload->points.reserve(msg.polygon.points.size());
+
+  for (const auto & pt : msg.polygon.points)
+  {
+    geometry_msgs::msg::PointStamped ps;
+    ps.header = msg.header;
+    ps.point.x = pt.x;
+    ps.point.y = pt.y;
+    ps.point.z = pt.z;
+
+    geometry_msgs::msg::PointStamped ecef;
+    try
+    {
+      // Timeout 0: the dispatcher's MessageFilter has already verified the
+      // transform is reachable at the message stamp.
+      ecef = buffer.transform(ps, "earth", tf2::durationFromSec(0.0));
+    }
+    catch (const tf2::TransformException & ex)
+    {
+      rclcpp::Clock clock;
+      RCLCPP_WARN_STREAM_THROTTLE(logger, clock, 1000,
+        "Unable to transform collision-monitor polygon vertex ("
+        << msg.header.frame_id << " -> earth): " << ex.what());
+      return std::nullopt;
+    }
+
+    gz4d::GeoPointECEF ecef_point;
+    ecef_point[0] = ecef.point.x;
+    ecef_point[1] = ecef.point.y;
+    ecef_point[2] = ecef.point.z;
+    gz4d::GeoPointLatLongDegrees ll = ecef_point;
+    payload->points.emplace_back(ll.latitude(), ll.longitude(), ll.altitude());
+  }
+
+  return payload;
+}
+
+} // namespace camp_collision_monitor
+
+#endif

--- a/src/camp/collision_monitor/collision_monitor_manager.cpp
+++ b/src/camp/collision_monitor/collision_monitor_manager.cpp
@@ -1,0 +1,128 @@
+#include "collision_monitor_manager.h"
+
+#include <optional>
+
+#include <QColor>
+#include <QTimer>
+
+#include "backgroundraster.h"
+#include "collision_monitor/collision_monitor.h"
+#include "ros/ros_context.h"
+
+namespace
+{
+// Match the bridged/boat-side topic basenames robustly to whatever namespace
+// prefix the udp_bridge applies (e.g. /bizzy/collision_slowdown_polygon or
+// .../collision_monitor/slowdown_polygon).
+bool isCollisionPolygon(const std::string& name, const char* kind)
+{
+  return name.find("collision") != std::string::npos &&
+         name.find(kind) != std::string::npos &&
+         name.find("polygon") != std::string::npos;
+}
+}  // namespace
+
+CollisionMonitorManager::CollisionMonitorManager(QWidget* parent):
+  camp_ros::ROSWidget(parent)
+{
+  ui_.setupUi(this);
+
+  scan_timer_ = new QTimer(this);
+  connect(scan_timer_, &QTimer::timeout, this, &CollisionMonitorManager::scanForSources);
+  scan_timer_->start(1000);
+
+  state_timeout_ = new QTimer(this);
+  state_timeout_->setSingleShot(true);
+  connect(state_timeout_, &QTimer::timeout, this, &CollisionMonitorManager::clearActiveStates);
+}
+
+CollisionMonitorManager::~CollisionMonitorManager()
+{
+}
+
+void CollisionMonitorManager::scanForSources()
+{
+  if(!node_)
+    return;
+
+  auto topics = node_->get_topic_names_and_types();
+  for(const auto& topic: topics)
+  {
+    const auto& name = topic.first;
+    for(const auto& type: topic.second)
+    {
+      if(type == "geometry_msgs/msg/PolygonStamped")
+      {
+        const bool is_slow = isCollisionPolygon(name, "slowdown");
+        const bool is_stop = isCollisionPolygon(name, "stop");
+        if((is_slow || is_stop) && monitors_.find(name) == monitors_.end())
+        {
+          auto* monitor = new CollisionMonitor(this, background_);
+          monitor->nodeStarted(node_, transform_buffer_);
+          // stop zone = red, slowdown zone = amber.
+          monitor->setKind(is_stop ? CollisionMonitor::Kind::Stop : CollisionMonitor::Kind::Slowdown);
+          monitor->setColor(is_stop ? QColor(220, 30, 30) : QColor(240, 180, 0));
+          monitor->setTopic(name);
+          monitor->setObjectName(name.c_str());
+          ui_.monitorsLayout->addWidget(monitor);
+          monitors_[name] = monitor;
+        }
+      }
+      else if(type == "nav2_msgs/msg/CollisionMonitorState" && !state_bridge_)
+      {
+        rclcpp::CallbackGroup::SharedPtr cbg;
+        auto ctx = camp_ros::RosContext::instance();
+        if(ctx)
+          cbg = ctx->group(camp_ros::RosContext::Group::Scene);
+
+        state_bridge_ = std::make_unique<
+          camp_ros::PlainTopicBridge<nav2_msgs::msg::CollisionMonitorState, uint8_t>>(
+          node_, name, rclcpp::QoS(1), cbg,
+          [](const nav2_msgs::msg::CollisionMonitorState& msg) -> std::optional<uint8_t>
+          {
+            return msg.action_type;
+          },
+          this,
+          [this](uint8_t action_type) { this->onState(action_type); });
+      }
+    }
+  }
+}
+
+void CollisionMonitorManager::onState(uint8_t action_type)
+{
+  using State = nav2_msgs::msg::CollisionMonitorState;
+  // Light each zone exactly when the monitor reports its own action. The
+  // monitor reports a single highest-priority action per cycle, so as an
+  // obstacle closes the operator sees the slowdown zone fill (amber), then the
+  // stop zone (red). CollisionMonitorState also carries polygon_name, but it's
+  // the Nav2 polygon instance name and shares no string with the published
+  // topic, so it can't be mapped to a zone client-side; action_type is the
+  // reliable discriminator. All zones of the matching kind are lit (correct
+  // for the single-zone-per-kind deployment, and honest for multi-zone setups
+  // where we can't tell which same-kind zone fired).
+  for(const auto& entry: monitors_)
+  {
+    const bool active = (entry.second->kind() == CollisionMonitor::Kind::Stop)
+                          ? (action_type == State::STOP)
+                          : (action_type == State::SLOWDOWN);
+    entry.second->setActive(active);
+  }
+
+  // Restart the staleness watchdog: a fresh state message means the link is
+  // live. 2 s comfortably covers the VPN-throttled 1 Hz state rate.
+  state_timeout_->start(2000);
+}
+
+void CollisionMonitorManager::clearActiveStates()
+{
+  for(const auto& entry: monitors_)
+    entry.second->setActive(false);
+}
+
+void CollisionMonitorManager::updateBackground(BackgroundRaster* bg)
+{
+  background_ = bg;
+  for(auto& entry: monitors_)
+    entry.second->updateBackground(bg);
+}

--- a/src/camp/collision_monitor/collision_monitor_manager.h
+++ b/src/camp/collision_monitor/collision_monitor_manager.h
@@ -1,0 +1,56 @@
+#ifndef COLLISION_MONITOR_MANAGER_H
+#define COLLISION_MONITOR_MANAGER_H
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+
+#include "ros/ros_widget.h"
+#include "ros/topic_bridge.h"
+#include "ui_collision_monitor_manager.h"
+#include "nav2_msgs/msg/collision_monitor_state.hpp"
+
+class QTimer;
+class BackgroundRaster;
+class CollisionMonitor;
+
+/// Discovers and displays the Nav2 Collision Monitor danger zones. Scans for
+/// the slowdown/stop PolygonStamped topics and auto-creates a CollisionMonitor
+/// overlay for each (no manual UI step, mirroring GridManager/MarkersManager),
+/// and subscribes to the CollisionMonitorState topic to drive each zone's
+/// active (filled) rendering by gating state.
+class CollisionMonitorManager: public camp_ros::ROSWidget
+{
+  Q_OBJECT
+public:
+  explicit CollisionMonitorManager(QWidget* parent = nullptr);
+  ~CollisionMonitorManager();
+
+public slots:
+  void updateBackground(BackgroundRaster* bg);
+
+private slots:
+  void scanForSources();
+
+private:
+  // Receiver for the state bridge. Runs on the Qt main thread.
+  void onState(uint8_t action_type);
+  // Sets every zone idle (used when the state topic goes stale).
+  void clearActiveStates();
+
+  Ui::CollisionMonitorManager ui_;
+
+  std::map<std::string, CollisionMonitor*> monitors_;
+
+  std::unique_ptr<camp_ros::PlainTopicBridge<nav2_msgs::msg::CollisionMonitorState, uint8_t>> state_bridge_;
+
+  QTimer* scan_timer_ = nullptr;
+  // Single-shot watchdog: if no CollisionMonitorState arrives within its
+  // interval (e.g. the link drops over the horizon), clear all zones so a
+  // stale STOP/SLOWDOWN fill can't linger and mislead the operator.
+  QTimer* state_timeout_ = nullptr;
+  BackgroundRaster* background_ = nullptr;
+};
+
+#endif

--- a/src/camp/collision_monitor/collision_monitor_manager.ui
+++ b/src/camp/collision_monitor/collision_monitor_manager.ui
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CollisionMonitorManager</class>
+ <widget class="QWidget" name="CollisionMonitorManager">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>231</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Collision Monitor Manager</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="monitorsLayout"/>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/camp/geographicsitem.h
+++ b/src/camp/geographicsitem.h
@@ -32,6 +32,7 @@ public:
         SearchPatternType,
         GridType,
         AvoidAreaType,
+        CollisionMonitorType,
     };
     
     GeoGraphicsItem(QGraphicsItem *parentItem = Q_NULLPTR);

--- a/src/camp/mainwindow.cpp
+++ b/src/camp/mainwindow.cpp
@@ -96,6 +96,7 @@ MainWindow::~MainWindow()
     delete m_ais_manager;
     //delete m_radar_manager;
     delete m_grid_manager;
+    delete m_markers_manager;
     delete m_collision_monitor_manager;
 }
 

--- a/src/camp/mainwindow.cpp
+++ b/src/camp/mainwindow.cpp
@@ -24,6 +24,7 @@
 #include "platform_manager/platform.h"
 #include "grids/grid_manager.h"
 #include "markers/markers_manager.h"
+#include "collision_monitor/collision_monitor_manager.h"
 
 #include <QDebug>
 
@@ -73,6 +74,11 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(project, &AutonomousVehicleProject::backgroundUpdated, m_markers_manager, &MarkersManager::updateBackground);
     connect(this, &MainWindow::closing, m_markers_manager, &QWidget::close);
 
+    m_collision_monitor_manager = new CollisionMonitorManager();
+    connect(m_ui->rosLink, &ROSLink::rosConnected, m_collision_monitor_manager, &CollisionMonitorManager::nodeStarted);
+    connect(project, &AutonomousVehicleProject::backgroundUpdated, m_collision_monitor_manager, &CollisionMonitorManager::updateBackground);
+    connect(this, &MainWindow::closing, m_collision_monitor_manager, &QWidget::close);
+
     // m_sound_play = new SoundPlay();
     // connect(m_ui->rosLink, &ROSLink::rosConnected, m_sound_play, &SoundPlay::nodeStarted);
 
@@ -90,6 +96,7 @@ MainWindow::~MainWindow()
     delete m_ais_manager;
     //delete m_radar_manager;
     delete m_grid_manager;
+    delete m_collision_monitor_manager;
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)
@@ -594,6 +601,11 @@ void MainWindow::on_actionGridManager_triggered()
 void MainWindow::on_actionMarkersManager_triggered()
 {
     m_markers_manager->show();
+}
+
+void MainWindow::on_actionCollisionMonitorManager_triggered()
+{
+    m_collision_monitor_manager->show();
 }
 
 // void MainWindow::on_actionSay_something_triggered()

--- a/src/camp/mainwindow.h
+++ b/src/camp/mainwindow.h
@@ -15,6 +15,7 @@ class RadarManager;
 // class SpeechAlerts;
 class GridManager;
 class MarkersManager;
+class CollisionMonitorManager;
 
 class AutonomousVehicleProject;
 
@@ -78,6 +79,7 @@ private slots:
     void on_actionAISManager_triggered();
     void on_actionGridManager_triggered();
     void on_actionMarkersManager_triggered();
+    void on_actionCollisionMonitorManager_triggered();
     void on_actionRadarManager_triggered();
     //void on_actionSay_something_triggered();
     void on_actionFollow_triggered();
@@ -95,6 +97,7 @@ private:
     //RadarManager* m_radar_manager = nullptr;
     GridManager* m_grid_manager = nullptr;
     MarkersManager* m_markers_manager = nullptr;
+    CollisionMonitorManager* m_collision_monitor_manager = nullptr;
     // SoundPlay* m_sound_play;
     // SpeechAlerts* m_speech_alerts;
 

--- a/src/camp/mainwindow.ui
+++ b/src/camp/mainwindow.ui
@@ -227,6 +227,7 @@
     <addaction name="actionShowTail"/>
     <addaction name="actionGridManager"/>
     <addaction name="actionMarkersManager"/>
+    <addaction name="actionCollisionMonitorManager"/>
     <addaction name="actionAISManager"/>
     <addaction name="actionSay_something"/>
     <addaction name="actionFollow"/>
@@ -417,6 +418,11 @@
   <action name="actionMarkersManager">
    <property name="text">
     <string>Markers Manager</string>
+   </property>
+  </action>
+  <action name="actionCollisionMonitorManager">
+   <property name="text">
+    <string>Collision Monitor Manager</string>
    </property>
   </action>
   <action name="actionAvoid">

--- a/test/test_collision_monitor_converter.cpp
+++ b/test/test_collision_monitor_converter.cpp
@@ -1,0 +1,134 @@
+// Tests for camp_collision_monitor::convertPolygon — the per-polygon logic
+// that runs inside the TF dispatcher's converter on the executor thread.
+//
+// Exercises empty-frame handling, unreachable-frame handling, and TF-driven
+// per-vertex geo conversion. The threading and TF gating around the converter
+// are tested separately in test_topic_bridge.cpp.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/buffer.h>
+
+#include <geometry_msgs/msg/point32.hpp>
+#include <geometry_msgs/msg/polygon_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include "collision_monitor/collision_monitor_converter.h"
+
+namespace
+{
+
+// Earth-fixed -> child transform placing `child` at the WGS-84 surface near
+// (lat=0, lon=0), avoiding the singular (0,0,0) ECEF point that converts to
+// NaN lat/lon. Mirrors test_markers_converter.cpp.
+geometry_msgs::msg::TransformStamped surfaceTransform(
+  const std::string & parent, const std::string & child, const rclcpp::Time & stamp)
+{
+  geometry_msgs::msg::TransformStamped t;
+  t.header.stamp = stamp;
+  t.header.frame_id = parent;
+  t.child_frame_id = child;
+  t.transform.rotation.w = 1.0;
+  t.transform.translation.x = 6378137.0;  // WGS-84 semi-major axis (meters)
+  return t;
+}
+
+geometry_msgs::msg::Point32 point32(float x, float y)
+{
+  geometry_msgs::msg::Point32 p;
+  p.x = x;
+  p.y = y;
+  p.z = 0.0f;
+  return p;
+}
+
+}  // namespace
+
+class CollisionMonitorConverterTest : public ::testing::Test
+{
+protected:
+  rclcpp::Node::SharedPtr node;
+  std::shared_ptr<tf2_ros::Buffer> buffer;
+
+  void SetUp() override
+  {
+    static std::atomic<unsigned> counter{0};
+    auto n = std::to_string(counter.fetch_add(1));
+    node = rclcpp::Node::make_shared("collision_monitor_converter_test_" + n);
+    buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock());
+  }
+
+  rclcpp::Time now() const { return node->get_clock()->now(); }
+  rclcpp::Logger logger() const { return node->get_logger(); }
+};
+
+TEST_F(CollisionMonitorConverterTest, validPolygonProducesAllVertices)
+{
+  buffer->setTransform(surfaceTransform("earth", "base_link", now()),
+                       "test", /*is_static=*/true);
+
+  geometry_msgs::msg::PolygonStamped poly;
+  poly.header.frame_id = "base_link";
+  poly.header.stamp = now();
+  poly.polygon.points = {point32(1, 1), point32(1, -1), point32(-1, -1), point32(-1, 1)};
+
+  auto out = camp_collision_monitor::convertPolygon(poly, *buffer, logger());
+  ASSERT_TRUE(out.has_value());
+  ASSERT_EQ((*out)->points.size(), 4u);
+  for(const auto& gc : (*out)->points)
+    EXPECT_TRUE(gc.isValid());
+}
+
+TEST_F(CollisionMonitorConverterTest, emptyFrameIdIsDropped)
+{
+  geometry_msgs::msg::PolygonStamped poly;
+  poly.header.frame_id = "";  // empty
+  poly.header.stamp = now();
+  poly.polygon.points = {point32(1, 1), point32(-1, -1)};
+
+  auto out = camp_collision_monitor::convertPolygon(poly, *buffer, logger());
+  EXPECT_FALSE(out.has_value())
+    << "polygon with empty frame_id must be dropped, not propagated";
+}
+
+TEST_F(CollisionMonitorConverterTest, unreachableFrameIsDropped)
+{
+  // No TF set up — frame is not reachable to "earth".
+  geometry_msgs::msg::PolygonStamped poly;
+  poly.header.frame_id = "no_such_frame";
+  poly.header.stamp = now();
+  poly.polygon.points = {point32(1, 1), point32(-1, -1)};
+
+  auto out = camp_collision_monitor::convertPolygon(poly, *buffer, logger());
+  EXPECT_FALSE(out.has_value());
+}
+
+TEST_F(CollisionMonitorConverterTest, emptyPolygonProducesEmptyPayload)
+{
+  // A degenerate (no-vertex) polygon with a valid frame is not an error; it
+  // yields an empty point list (the overlay simply draws nothing).
+  buffer->setTransform(surfaceTransform("earth", "base_link", now()),
+                       "test", /*is_static=*/true);
+
+  geometry_msgs::msg::PolygonStamped poly;
+  poly.header.frame_id = "base_link";
+  poly.header.stamp = now();
+
+  auto out = camp_collision_monitor::convertPolygon(poly, *buffer, logger());
+  ASSERT_TRUE(out.has_value());
+  EXPECT_TRUE((*out)->points.empty());
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  int rc = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return rc;
+}


### PR DESCRIPTION
## Summary

Auto-displays the Nav2 Collision Monitor **slowdown/stop danger zones** on the CAMP map, georeferenced and colored by gating state — so the operator can see *when* collision avoidance is acting and *on what*.

Closes #53. Part of rolker/unh_echoboats_project11#183 (operator awareness of active collision avoidance — this is the polygon-overlay slice; the annunciator row and the optional reflex-pointcloud overlay remain under #183).

## Motivation

On deployment rolker/unh_echoboats_project11#186 (2026-05-28), reflex CA fired ~331 times in a dense-buoy region (stop/slowdown alternating every 0.2–1.5 s) and the operator had **no in-CAMP indication** of what CA saw or when it was gating — root-causing it meant reading boat-side `collision_monitor*.log` after the fact.

The data was already there: `collision_*_polygon` and `collision_monitor_state` are in the udp_bridge `topics_list`, and CAMP already georeferences ROS-frame data. It just wasn't being drawn (CAMP's generic polygon layer only instantiates on a manual right-click).

## What changed

New `CollisionMonitor` (`GeoGraphicsItem`) + `CollisionMonitorManager`, following the existing **Markers** overlay pattern:

- **TF-gated `TopicBridge`** converts each polygon vertex to geographic coords on the executor thread; per-vertex transform handles the rotating base frame (`base_link`) with no manual yaw math.
- **1 s topic scan** auto-creates the zones by basename match (`collision`+`slowdown`/`stop`+`polygon`) — no manual UI step, robust to the udp_bridge namespace prefix.
- **`CollisionMonitorState` `PlainTopicBridge`** drives per-kind active coloring (amber = slowdown zone gating, red = stop zone gating), applied across *all* zones of the matching kind.
- **Staleness watchdog**: if the state topic stops (e.g. over-the-horizon link loss) the zones clear after 2 s, so a stale fill can't linger and mislead.
- Reachable from **Settings → Collision Monitor Manager** (per-zone visibility toggle), mirroring the Grid/Markers managers.

## Review findings addressed (pre-push adversarial review)

- **State routing no longer assumes one zone per kind** — routes by `action_type` across all discovered zones rather than two overwrite-prone pointers (`CollisionMonitorState.polygon_name` is the Nav2 instance name and shares no string with the published topic, so it can't be mapped to a zone client-side; `action_type` is the reliable discriminator).
- **Stale-state watchdog** added (above) — addresses the stuck-fill-on-link-loss case.
- **Converter unit test** added.

## Verification

- ✅ `colcon build` clean (no warnings in new files).
- ✅ `colcon test` — 27/27 pass, including 4 new `test_collision_monitor_converter` cases (empty-frame, unreachable-frame, valid multi-vertex, empty-polygon).
- ⏳ **Runtime verification pending**: not yet exercised live. The polygons + state are in the bag recording list, so replaying a #186 bag (or sim) into CAMP is the next validation — confirm both zones appear, track the boat heading, and recolor on SLOWDOWN/STOP. QoS is reliable/volatile `depth 1` (matches Markers/Grid); if a future bridge republishes best-effort, the polygon QoS will need to switch to best_effort.

## Test plan

- [x] Build + unit tests green
- [ ] Replay a #186 bag with CAMP: zones render, georeferenced, heading-correct
- [ ] Confirm amber→red transition as an obstacle closes, and clear-on-stale

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
