### PR TITLE
Fix CAMP path-line: subscribe to received_global_plan, not received_global_path

### DIFF
--- a/src/camp/platform_manager/platform.cpp
+++ b/src/camp/platform_manager/platform.cpp
@@ -100,7 +100,7 @@ void Platform::update(const marine_interfaces::msg::Platform& platform)
   m_ui->helmManager->updateRobotNamespace(platformNamespace.c_str());
   m_ui->missionManager->updateRobotNamespace(platformNamespace.c_str());
 
-  path_topic_ = "/" + platformNamespace + "/received_global_path";
+  path_topic_ = "/" + platformNamespace + "/received_global_plan";
   subscribeToPathTopic();
 
   m_width = platform.width;


### PR DESCRIPTION
## Summary

One-line fix: `Platform` subscribed to `<ns>/received_global_path`, a topic
nothing publishes, so the platform's path-line overlay never rendered. The boat's
controller (`marine_nav_crabbing_path_follower::CrabbingPathFollower`) publishes
the followed path on **`received_global_plan`** (`plan`, not `path`). Verified by
grep that nothing in the workspace publishes `received_global_path` and that this
was the only occurrence in camp.

```diff
- path_topic_ = "/" + platformNamespace + "/received_global_path";
+ path_topic_ = "/" + platformNamespace + "/received_global_plan";
```

## Over-the-horizon note

For the overlay to render OTH, `received_global_plan` must also cross the
udp_bridge — added in rolker/unh_echoboats_project11#200. On the local network this
fix alone restores the overlay. (The path is also visible OTH via the already-bridged
`path_follower_visualization` markers; this restores the dedicated path-line.)

## Related

- rolker/unh_marine_navigation#30 / PR #51 — survey-line obstacle avoidance (the operator-feedback context this surfaced from).
- rolker/unh_echoboats_project11#200 — bridges `received_global_plan` for OTH.

## Test plan

- [ ] Build via CI (change is a single compile-safe string-literal value; a from-scratch local Qt build was not run for a one-character topic-name fix)
- [ ] Runtime: with the boat publishing `received_global_plan` and the topic bridged, confirm the platform path-line overlay renders in CAMP

Closes #55

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
