### PR TITLE
Field import: camp (2026-06-01)

### DIFF
--- a/src/camp/ros/ros_widget.cpp
+++ b/src/camp/ros/ros_widget.cpp
@@ -13,10 +13,41 @@ ROSWidget::ROSWidget(QWidget *parent)
 
 QGeoCoordinate ROSWidget::getGeoCoordinate(const geometry_msgs::msg::Pose &pose, const std_msgs::msg::Header &header)
 {
+    if(header.frame_id.empty())
+      return {};
+
     geometry_msgs::msg::PoseStamped ps;
     ps.header = header;
     ps.pose = pose;
-    auto ecef = transform_buffer_->transform(ps, "earth", tf2::durationFromSec(1.5));
+
+    geometry_msgs::msg::PoseStamped ecef;
+    try
+    {
+      ecef = transform_buffer_->transform(ps, "earth", tf2::durationFromSec(1.5));
+    }
+    catch (const tf2::TransformException &)
+    {
+      // A stale-stamped pose - e.g. a nav_msgs/Path overlay whose poses
+      // carry old planning stamps arriving over the bridge - throws
+      // (typically ExtrapolationException) and, left uncaught, aborts the
+      // whole application. The map->earth transform is quasi-static, so
+      // retry against the latest available transform (stamp 0 == latest)
+      // rather than the pose's own stale stamp.
+      try
+      {
+        ps.header.stamp.sec = 0;
+        ps.header.stamp.nanosec = 0;
+        ecef = transform_buffer_->transform(ps, "earth", tf2::durationFromSec(1.5));
+      }
+      catch (const tf2::TransformException &ex)
+      {
+        rclcpp::Clock clock;
+        RCLCPP_WARN_STREAM_THROTTLE(node_->get_logger(), clock, 2000,
+          "ROSWidget: unable to transform pose to earth: " << ex.what()
+          << " source frame: " << header.frame_id);
+        return {};
+      }
+    }
 
     gz4d::GeoPointECEF ecef_point;
     ecef_point[0] = ecef.pose.position.x;


### PR DESCRIPTION
Imports 1 field commit from the 2026-06-01 BizzyBoat deployment
(`gitcloud/jazzy`), preserving the original field SHA (branched from the field
ref — not cherry-picked).

- `b5c40d3` Guard `ROSWidget::getGeoCoordinate` against stale-stamped TF lookups

Fixes a CAMP SIGABRT crash loop: stale-stamped `nav_msgs/Path` overlay poses
(followed-path / survey-avoidance viz arriving ~56 s in the past over the bridge)
threw `tf2::BackwardExtrapolationException`. Now caught + retried at the latest
`map`→`earth` transform; point dropped with a throttled warning only if that
also fails. Mirrors the already-guarded `Grid::getGeoCoordinate`.

Pre-review notes in the issue (local `rclcpp::Clock` for the throttle vs node
clock; no regression test). Draft pending review.

Closes #57.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
