### PR TITLE
Field import: camp (2026-06-03) — callback-group concurrency fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ install (TARGETS CCOMAutonomousMissionPlanner
 set(rqt_helm_manager_SRCS
   src/camp/helm_manager/rqt_helm_manager.cpp
   src/camp/helm_manager/helm_manager.cpp
+  src/camp/ros/ros_context.cpp
 )
 
 add_library(rqt_helm_manager SHARED
@@ -208,6 +209,7 @@ ament_target_dependencies(rqt_helm_manager
   marine_interfaces
   rqt_gui_cpp
   rclcpp
+  tf2_ros
 )
 
 target_link_libraries(rqt_helm_manager

--- a/src/camp/ais/ais_manager.cpp
+++ b/src/camp/ais/ais_manager.cpp
@@ -2,6 +2,7 @@
 #include "ui_ais_manager.h"
 #include <QTimer>
 #include "backgroundraster.h"
+#include "ros/ros_context.h"
 
 AISManager::AISManager(QWidget* parent):
   camp_ros::ROSWidget(parent),
@@ -39,7 +40,10 @@ void AISManager::scanForSources()
           if (topic_type == "marine_ais_msgs/msg/AISContact")
           {
             RCLCPP_INFO_STREAM(node_->get_logger(), "Subscribing to ais topic: " << name);
-            m_sources[name] = node_->create_subscription<marine_ais_msgs::msg::AISContact>(name, 10, std::bind(&AISManager::aisContactCallback, this, std::placeholders::_1));
+            rclcpp::SubscriptionOptions sub_options;
+            if (auto ctx = camp_ros::RosContext::instance())
+              sub_options.callback_group = ctx->nextDedicatedGroup();
+            m_sources[name] = node_->create_subscription<marine_ais_msgs::msg::AISContact>(name, 10, std::bind(&AISManager::aisContactCallback, this, std::placeholders::_1), sub_options);
             m_ui->sourcesListWidget->addItem(name.c_str());
             break;
           }

--- a/src/camp/grids/grid.cpp
+++ b/src/camp/grids/grid.cpp
@@ -8,6 +8,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include "backgroundraster.h"
 #include <grid_map_ros/grid_map_ros.hpp>
+#include "ros/ros_context.h"
 
 Grid::Grid(QWidget* parent, QGraphicsItem *parentItem)
   :camp_ros::ROSWidget(parent),
@@ -162,6 +163,10 @@ QGeoCoordinate Grid::getGeoCoordinate(const geometry_msgs::msg::Pose &pose, cons
     geometry_msgs::msg::PoseStamped grid_corner;
     grid_corner.header = header;
     grid_corner.pose = pose;
+    // Wait briefly for the transform so momentary TF lag doesn't blank the
+    // grid. Safe to block here: the grid runs on its own dedicated callback
+    // group (see visibilityChanged), so this wait delays only the grid's
+    // thread, never the overlays or realtime telemetry.
     auto ecef = transform_buffer_->transform(grid_corner, "earth", tf2::durationFromSec(0.5));
 
     gz4d::GeoPointECEF ecef_point;
@@ -206,10 +211,16 @@ void Grid::visibilityChanged()
   is_visible_ = ui_.displayCheckBox->isChecked();
   if(is_visible_ && node_)
   {
+    // Dedicated callback group: the grid callback builds a full QImage and
+    // (in getGeoCoordinate) does a TF transform, so it must not share a thread
+    // with the light overlays or it starves them.
+    rclcpp::SubscriptionOptions sub_options;
+    if (auto ctx = camp_ros::RosContext::instance())
+      sub_options.callback_group = ctx->nextDedicatedGroup();
     if(type_ == "nav_msgs/msg/OccupancyGrid")
-      occupancy_grid_subscription_ = node_->create_subscription<nav_msgs::msg::OccupancyGrid>(topic_, 1, std::bind(&Grid::occupancyGridCallback, this, std::placeholders::_1));
+      occupancy_grid_subscription_ = node_->create_subscription<nav_msgs::msg::OccupancyGrid>(topic_, 1, std::bind(&Grid::occupancyGridCallback, this, std::placeholders::_1), sub_options);
     if(type_ == "grid_map_msgs/msg/GridMap")
-      grid_map_subscription_ = node_->create_subscription<grid_map_msgs::msg::GridMap>(topic_, 1, std::bind(&Grid::gridMapCallback, this, std::placeholders::_1));
+      grid_map_subscription_ = node_->create_subscription<grid_map_msgs::msg::GridMap>(topic_, 1, std::bind(&Grid::gridMapCallback, this, std::placeholders::_1), sub_options);
   }
   else
   {

--- a/src/camp/helm_manager/helm_manager.cpp
+++ b/src/camp/helm_manager/helm_manager.cpp
@@ -5,6 +5,7 @@
 #include <QPalette>
 #include <QTimer>
 #include "std_msgs/msg/string.hpp"
+#include "ros/ros_context.h"
 
 HelmManager::HelmManager(QWidget* parent):
   QWidget(parent),
@@ -70,7 +71,10 @@ void HelmManager::updateRobotNamespace(QString robot_namespace)
   
 
 
-  heartbeat_subscription_ = node_->create_subscription<marine_interfaces::msg::Heartbeat>(ns+"marine/heartbeat", 1, std::bind(&HelmManager::heartbeatCallback, this, std::placeholders::_1));
+  rclcpp::SubscriptionOptions realtime_options;
+  if (auto ctx = camp_ros::RosContext::instance())
+    realtime_options.callback_group = ctx->group(camp_ros::RosContext::Group::Realtime);
+  heartbeat_subscription_ = node_->create_subscription<marine_interfaces::msg::Heartbeat>(ns+"marine/heartbeat", 1, std::bind(&HelmManager::heartbeatCallback, this, std::placeholders::_1), realtime_options);
   send_command_publisher_ = node_->create_publisher<std_msgs::msg::String>(ns+"marine/send_command",1);
 }
 

--- a/src/camp/mission_manager/mission_manager.cpp
+++ b/src/camp/mission_manager/mission_manager.cpp
@@ -2,6 +2,7 @@
 #include "ui_mission_manager.h"
 #include <QMenu>
 #include <QGeoCoordinate>
+#include "ros/ros_context.h"
 
 MissionManager::MissionManager(QWidget *parent)
   :camp_ros::ROSWidget(parent), m_ui(new Ui::MissionManager)
@@ -18,7 +19,10 @@ void MissionManager::updateRobotNamespace(QString robot_namespace)
 {
   if(node_)
   {
-    mission_status_subscription_ = node_->create_subscription<marine_interfaces::msg::Heartbeat>("/"+robot_namespace.toStdString()+"/marine/status/mission_manager" , 1, std::bind(&MissionManager::missionStatusCallback, this, std::placeholders::_1));
+    rclcpp::SubscriptionOptions realtime_options;
+    if (auto ctx = camp_ros::RosContext::instance())
+      realtime_options.callback_group = ctx->group(camp_ros::RosContext::Group::Realtime);
+    mission_status_subscription_ = node_->create_subscription<marine_interfaces::msg::Heartbeat>("/"+robot_namespace.toStdString()+"/marine/status/mission_manager" , 1, std::bind(&MissionManager::missionStatusCallback, this, std::placeholders::_1), realtime_options);
     send_command_publisher_ = node_->create_publisher<std_msgs::msg::String>("/"+robot_namespace.toStdString()+"/marine/send_command",1);
 
     rclcpp::QoS qos(1);

--- a/src/camp/nav_source.cpp
+++ b/src/camp/nav_source.cpp
@@ -4,6 +4,7 @@
 #include <QPainter>
 #include <QTimer>
 #include <QDebug>
+#include "ros/ros_context.h"
 
 NavSource::NavSource(const marine_interfaces::msg::NavSource& source, QObject* parent, QGraphicsItem *parentItem): camp_ros::ROSObject(parent), GeoGraphicsItem(parentItem)
 {
@@ -20,6 +21,9 @@ void NavSource::trySubscribe()
 {
   if(node_)
   {
+    rclcpp::SubscriptionOptions realtime_options;
+    if (auto ctx = camp_ros::RosContext::instance())
+      realtime_options.callback_group = ctx->group(camp_ros::RosContext::Group::Realtime);
     RCLCPP_INFO_STREAM(node_->get_logger(), "NavSource::trySubscribe");
     RCLCPP_INFO_STREAM(node_->get_logger(), "pending_position_topic_: " << pending_position_topic_);
     RCLCPP_INFO_STREAM(node_->get_logger(), "pending_orientation_topic_: " << pending_orientation_topic_);
@@ -37,17 +41,17 @@ void NavSource::trySubscribe()
           RCLCPP_INFO_STREAM(node_->get_logger(), "   type: " << topic_type);
           if(topic_type == "sensor_msgs/msg/NavSatFix")
           {
-            position_subscription_ = node_->create_subscription<sensor_msgs::msg::NavSatFix>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::positionCallback, this, std::placeholders::_1));
+            position_subscription_ = node_->create_subscription<sensor_msgs::msg::NavSatFix>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::positionCallback, this, std::placeholders::_1), realtime_options);
             pending_position_topic_.clear();
           }
           else if(topic_type == "geographic_msgs/msg/GeoPointStamped")
           {
-            geo_point_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPointStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::geoPointCallback, this, std::placeholders::_1));
+            geo_point_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPointStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::geoPointCallback, this, std::placeholders::_1), realtime_options);
             pending_position_topic_.clear();
           }
           else if(topic_type == "geographic_msgs/msg/GeoPoseStamped")
           {
-            geo_pose_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPoseStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::geoPoseCallback, this, std::placeholders::_1));
+            geo_pose_subscription_ = node_->create_subscription<geographic_msgs::msg::GeoPoseStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::geoPoseCallback, this, std::placeholders::_1), realtime_options);
             pending_position_topic_.clear();
           }
         }
@@ -59,12 +63,12 @@ void NavSource::trySubscribe()
         {
           if(topic_type == "sensor_msgs/msg/Imu")
           {
-            orientation_subscription_ = node_->create_subscription<sensor_msgs::msg::Imu>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::orientationCallback, this, std::placeholders::_1));
+            orientation_subscription_ = node_->create_subscription<sensor_msgs::msg::Imu>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::orientationCallback, this, std::placeholders::_1), realtime_options);
             pending_orientation_topic_.clear();
           }
           if(topic_type == "geometry_msgs/msg/QuaternionStamped")
           {
-            quaternion_subscription_ = node_->create_subscription<geometry_msgs::msg::QuaternionStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::quaternionCallback, this, std::placeholders::_1));
+            quaternion_subscription_ = node_->create_subscription<geometry_msgs::msg::QuaternionStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::quaternionCallback, this, std::placeholders::_1), realtime_options);
             pending_orientation_topic_.clear();
           }
         }
@@ -76,12 +80,12 @@ void NavSource::trySubscribe()
         {
           if(topic_type == "geometry_msgs/msg/TwistWithCovarianceStamped")
           {
-            velocity_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::velocityCallback, this, std::placeholders::_1));
+            velocity_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::velocityCallback, this, std::placeholders::_1), realtime_options);
             pending_velocity_topic_.clear();
           }
           if(topic_type == "geometry_msgs/msg/TwistStamped")
           {
-            velocity_twist_stamped_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::velocityTwistStampedCallback, this, std::placeholders::_1));
+            velocity_twist_stamped_subscription_ = node_->create_subscription<geometry_msgs::msg::TwistStamped>(name, rclcpp::SensorDataQoS().reliable(), std::bind(&NavSource::velocityTwistStampedCallback, this, std::placeholders::_1), realtime_options);
             pending_velocity_topic_.clear();
           }
         }

--- a/src/camp/platform_manager/platform.cpp
+++ b/src/camp/platform_manager/platform.cpp
@@ -3,6 +3,7 @@
 #include <QPainter>
 #include "nav_source.h"
 #include "backgroundraster.h"
+#include "ros/ros_context.h"
 
 #include <QDebug>
 
@@ -234,7 +235,12 @@ void Platform::subscribeToPathTopic()
 {
   if(!path_topic_.empty() && node_ && !path_subscription_)
   {
-    path_subscription_ = node_->create_subscription<nav_msgs::msg::Path>(path_topic_, 10, std::bind(&Platform::pathCallback, this, std::placeholders::_1));
+    // Dedicated callback group: the planned path churns under the avoider, so
+    // keep it off the shared overlay thread.
+    rclcpp::SubscriptionOptions sub_options;
+    if (auto ctx = camp_ros::RosContext::instance())
+      sub_options.callback_group = ctx->nextDedicatedGroup();
+    path_subscription_ = node_->create_subscription<nav_msgs::msg::Path>(path_topic_, 10, std::bind(&Platform::pathCallback, this, std::placeholders::_1), sub_options);
   }
 }
 

--- a/src/camp/platform_manager/platform_manager.cpp
+++ b/src/camp/platform_manager/platform_manager.cpp
@@ -2,6 +2,7 @@
 #include "ui_platform_manager.h"
 #include "platform.h"
 #include "backgroundraster.h"
+#include "ros/ros_context.h"
 
 PlatformManager::PlatformManager(QWidget* parent):
   camp_ros::ROSWidget(parent),
@@ -19,7 +20,10 @@ PlatformManager::~PlatformManager()
 
 void PlatformManager::onNodeUpdated()
 {
-  platform_list_subscription_ = node_->create_subscription<marine_interfaces::msg::PlatformList>("/marine/platforms", 5, std::bind(&PlatformManager::platformListCallback, this, std::placeholders::_1));
+  rclcpp::SubscriptionOptions sub_options;
+  if (auto ctx = camp_ros::RosContext::instance())
+    sub_options.callback_group = ctx->nextDedicatedGroup();
+  platform_list_subscription_ = node_->create_subscription<marine_interfaces::msg::PlatformList>("/marine/platforms", 5, std::bind(&PlatformManager::platformListCallback, this, std::placeholders::_1), sub_options);
 }
 
 void PlatformManager::platformListCallback(const marine_interfaces::msg::PlatformList &message)

--- a/src/camp/ros/ros_context.cpp
+++ b/src/camp/ros/ros_context.cpp
@@ -16,6 +16,15 @@ RosContext::RosContext(rclcpp::Node::SharedPtr node, tf2_ros::Buffer::SharedPtr 
   realtime_group_(node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive)),
   scene_group_(node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive))
 {
+  // Pool of dedicated MutuallyExclusive groups for heavy/blocking display
+  // streams (handed out by nextDedicatedGroup()). Created here — before the
+  // node joins the executor — so the MultiThreadedExecutor picks them up.
+  // Sized generously; on a 16-thread box this leaves ample headroom.
+  constexpr std::size_t kDedicatedGroupCount = 8;
+  dedicated_pool_.reserve(kDedicatedGroupCount);
+  for (std::size_t i = 0; i < kDedicatedGroupCount; ++i)
+    dedicated_pool_.push_back(
+      node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive));
 }
 
 RosContext::~RosContext() = default;
@@ -30,6 +39,15 @@ rclcpp::CallbackGroup::SharedPtr RosContext::group(Group g) const
       return scene_group_;
   }
   return nullptr;
+}
+
+rclcpp::CallbackGroup::SharedPtr RosContext::nextDedicatedGroup()
+{
+  if (dedicated_pool_.empty())
+    return nullptr;
+  const std::size_t idx =
+    dedicated_index_.fetch_add(1) % dedicated_pool_.size();
+  return dedicated_pool_[idx];
 }
 
 std::shared_ptr<RosContext> RosContext::instance()

--- a/src/camp/ros/ros_context.h
+++ b/src/camp/ros/ros_context.h
@@ -48,10 +48,16 @@ public:
 
   /// Returns one of a fixed pool of dedicated MutuallyExclusive callback
   /// groups, handed out round-robin. Use for heavy or potentially-blocking
-  /// display streams (e.g. costmap/grid, path) so each runs on its own thread
-  /// and can't starve the shared Scene/Realtime groups or each other. The pool
-  /// is created at construction (before the node joins the executor), so the
-  /// groups are guaranteed visible to the MultiThreadedExecutor.
+  /// display streams (e.g. costmap/grid, path) so a slow callback runs in its
+  /// own group and can run concurrently with the shared Scene/Realtime groups,
+  /// rather than serializing behind them.
+  ///
+  /// Caveat: this isolates *groups*, not threads. The MultiThreadedExecutor has
+  /// a fixed thread pool, so concurrency is bounded by the thread count, and the
+  /// round-robin reuse means that once more streams take groups than the pool
+  /// size, two streams share a group and serialize again. Size the pool for the
+  /// number of heavy streams. The pool is created at construction (before the
+  /// node joins the executor), so the groups are visible to the executor.
   rclcpp::CallbackGroup::SharedPtr nextDedicatedGroup();
 
   /// Returns an empty `shared_ptr` until `setInstance(...)` has been called.

--- a/src/camp/ros/ros_context.h
+++ b/src/camp/ros/ros_context.h
@@ -1,7 +1,10 @@
 #ifndef CAMP_ROS_CONTEXT_H
 #define CAMP_ROS_CONTEXT_H
 
+#include <atomic>
+#include <cstddef>
 #include <memory>
+#include <vector>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/buffer.h>
 
@@ -22,9 +25,11 @@ class RosContext
 public:
   /// Latency-budget grouping for subscription callbacks.
   /// `Realtime` is reserved for watchdog inputs (heartbeat, nav, helm,
-  /// mission status). `Scene` is for bulk display data (markers, grid, path,
-  /// AIS contacts) whose callbacks may do heavier work and must not be
-  /// allowed to starve realtime callbacks.
+  /// mission status) — light, non-blocking callbacks that share one thread.
+  /// `Scene` is for light overlay display (markers, collision zones). Heavy
+  /// or potentially-blocking display streams (costmap/grid, path) must NOT
+  /// share a group with these — they take a dedicated group from
+  /// `nextDedicatedGroup()` so a slow/blocking callback can't starve the rest.
   enum class Group
   {
     Realtime,
@@ -41,6 +46,14 @@ public:
   tf2_ros::Buffer::SharedPtr buffer() const { return buffer_; }
   rclcpp::CallbackGroup::SharedPtr group(Group g) const;
 
+  /// Returns one of a fixed pool of dedicated MutuallyExclusive callback
+  /// groups, handed out round-robin. Use for heavy or potentially-blocking
+  /// display streams (e.g. costmap/grid, path) so each runs on its own thread
+  /// and can't starve the shared Scene/Realtime groups or each other. The pool
+  /// is created at construction (before the node joins the executor), so the
+  /// groups are guaranteed visible to the MultiThreadedExecutor.
+  rclcpp::CallbackGroup::SharedPtr nextDedicatedGroup();
+
   /// Returns an empty `shared_ptr` until `setInstance(...)` has been called.
   /// The returned `shared_ptr` keeps the instance alive for its own scope,
   /// even if `clearInstance()` runs concurrently on another thread.
@@ -53,6 +66,8 @@ private:
   tf2_ros::Buffer::SharedPtr buffer_;
   rclcpp::CallbackGroup::SharedPtr realtime_group_;
   rclcpp::CallbackGroup::SharedPtr scene_group_;
+  std::vector<rclcpp::CallbackGroup::SharedPtr> dedicated_pool_;
+  std::atomic<std::size_t> dedicated_index_{0};
 };
 
 } // namespace camp_ros


### PR DESCRIPTION
Imports field commit `c5391c0` (CAMP callback-group concurrency fix) from the 2026-06-03 (#211)
deployment. See #66 for the pre-review (no tests — executor wiring; null-guarded; needs relaunch)
and the relationship to the trackline-removal crash rolker/camp#65.

Closes #66.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
