### PR TITLE
Add boat-footprint display as a Layers-tab overlay (closes #64)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ set(SOURCES
     src/camp/mainwindow.cpp
     src/camp/collision_monitor/collision_monitor.cpp
     src/camp/collision_monitor/collision_monitor_manager.cpp
+    src/camp/footprint/footprint.cpp
+    src/camp/footprint/footprint_manager.cpp
     src/camp/missionitem.cpp
     src/camp/mission_manager/mission_manager.cpp
     src/camp/orbit.cpp

--- a/src/camp/footprint/footprint.cpp
+++ b/src/camp/footprint/footprint.cpp
@@ -1,0 +1,117 @@
+#include "footprint.h"
+
+#include <chrono>
+#include <utility>
+
+#include <QPainter>
+#include <QPainterPath>
+#include <QPen>
+
+#include "ros/ros_context.h"
+
+Footprint::Footprint(QObject* parent, QGraphicsItem* parentItem):
+  camp_ros::ROSObject(parent),
+  GeoGraphicsItem(parentItem)
+{
+}
+
+QRectF Footprint::boundingRect() const
+{
+  return polygonPath().boundingRect();
+}
+
+void Footprint::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
+{
+  (void)option;
+  (void)widget;
+  auto path = polygonPath();
+  if(path.isEmpty())
+    return;
+
+  painter->save();
+  // Cosmetic pen: constant on-screen width regardless of map zoom.
+  QPen pen(color_);
+  pen.setCosmetic(true);
+  pen.setWidthF(2.0);
+  painter->setPen(pen);
+  painter->setBrush(Qt::NoBrush);
+  painter->drawPath(path);
+  painter->restore();
+}
+
+QPainterPath Footprint::polygonPath() const
+{
+  QPainterPath path;
+  // The footprint is anchored to the persistent scene root and projected via the
+  // bg-free geoToPixel (Web-Mercator scene), so it renders with or without a
+  // chart loaded. A closed outline needs at least 3 vertices.
+  if(points_.size() >= 3)
+  {
+    bool first = true;
+    for(const auto& gc: points_)
+    {
+      QPointF px = geoToPixel(gc);
+      if(first)
+      {
+        path.moveTo(px);
+        first = false;
+      }
+      else
+      {
+        path.lineTo(px);
+      }
+    }
+    path.closeSubpath();
+  }
+  return path;
+}
+
+void Footprint::onNodeUpdated()
+{
+  // (Re)subscribe when the node (re)appears and a topic has been assigned.
+  if(node_ && !topic_.empty())
+    setTopic(topic_);
+}
+
+void Footprint::setTopic(std::string topic)
+{
+  topic_ = std::move(topic);
+  if(!node_)
+    return;
+
+  // Use the Scene callback group so polygon conversion can't starve realtime
+  // callbacks; fall back to the node default otherwise.
+  rclcpp::CallbackGroup::SharedPtr cbg;
+  auto ctx = camp_ros::RosContext::instance();
+  if(ctx)
+    cbg = ctx->group(camp_ros::RosContext::Group::Scene);
+
+  auto node = node_;
+  // QoS(1), reliable/volatile — matches the collision/marker overlays. The
+  // converter transforms each vertex to "earth"->geographic, handling the
+  // (rotating) publish frame without manual yaw math.
+  bridge_ = std::make_unique<camp_ros::TfTopicBridge<geometry_msgs::msg::PolygonStamped, PayloadT>>(
+    node_, transform_buffer_, topic_, rclcpp::QoS(1), "earth", 50, std::chrono::seconds(1), cbg,
+    [node](const geometry_msgs::msg::PolygonStamped& msg, tf2_ros::Buffer& buffer)
+      -> std::optional<PayloadT>
+    {
+      return camp_collision_monitor::convertPolygon(msg, buffer, node->get_logger());
+    },
+    this,
+    [this](PayloadT data) { this->onPolygonPayload(std::move(data)); });
+}
+
+void Footprint::onPolygonPayload(PayloadT data)
+{
+  if(!data)
+    return;
+  prepareGeometryChange();
+  points_ = std::move(data->points);
+  GeoGraphicsItem::update();
+}
+
+void Footprint::updateBackground()
+{
+  prepareGeometryChange();
+  GeoGraphicsItem::update();
+}

--- a/src/camp/footprint/footprint.h
+++ b/src/camp/footprint/footprint.h
@@ -1,0 +1,58 @@
+#ifndef CAMP_FOOTPRINT_H
+#define CAMP_FOOTPRINT_H
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <QColor>
+#include <QGeoCoordinate>
+
+#include "ros/ros_object.h"
+#include "ros/topic_bridge.h"
+#include "geographicsitem.h"
+#include "collision_monitor/collision_monitor_converter.h"
+#include "geometry_msgs/msg/polygon_stamped.hpp"
+
+/// [#64] The boat's published footprint (nav2 local_costmap/published_footprint),
+/// rendered as a georeferenced outline polygon on the map so the operator can
+/// judge close-quarters clearance. A non-widget ROS object that draws via its
+/// GeoGraphicsItem under the "Boat Footprint" Map layer. Mirrors CollisionMonitor
+/// (PolygonStamped -> TF-gated bridge -> geographic vertices -> scene), minus the
+/// danger-zone kind/active-state machinery.
+class Footprint : public camp_ros::ROSObject, public GeoGraphicsItem
+{
+  Q_OBJECT
+  Q_INTERFACES(QGraphicsItem)
+public:
+  // Reuse the collision-monitor polygon payload (a generic "polygon as geographic
+  // vertices"); it carries no collision-specific state.
+  using PayloadT = std::shared_ptr<camp_collision_monitor::CollisionPolygonPayload>;
+
+  Footprint(QObject* parent = nullptr, QGraphicsItem* parentItem = nullptr);
+
+  QRectF boundingRect() const override;
+  void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
+  int type() const override { return FootprintType; }
+
+  /// Subscribe to a geometry_msgs/PolygonStamped footprint topic.
+  void setTopic(std::string topic);
+
+  /// (Re)create the subscription when the ROS node becomes available.
+  void onNodeUpdated() override;
+
+public slots:
+  /// Repaint on chart change (positions are absolute Web-Mercator).
+  void updateBackground();
+
+private:
+  void onPolygonPayload(PayloadT data);
+  QPainterPath polygonPath() const;
+
+  std::string topic_;
+  std::unique_ptr<camp_ros::TfTopicBridge<geometry_msgs::msg::PolygonStamped, PayloadT>> bridge_;
+  std::vector<QGeoCoordinate> points_;
+  QColor color_ = QColor(0, 160, 255);  // boat-blue outline
+};
+
+#endif

--- a/src/camp/footprint/footprint_manager.cpp
+++ b/src/camp/footprint/footprint_manager.cpp
@@ -1,0 +1,49 @@
+#include "footprint_manager.h"
+
+#include <QTimer>
+
+#include "footprint/footprint.h"
+
+FootprintManager::FootprintManager(QObject* parent):
+  camp_ros::ROSObject(parent)
+{
+  scan_timer_ = new QTimer(this);
+  connect(scan_timer_, &QTimer::timeout, this, &FootprintManager::scanForSources);
+  scan_timer_->start(1000);
+}
+
+void FootprintManager::scanForSources()
+{
+  if(!node_)
+    return;
+
+  auto topics = node_->get_topic_names_and_types();
+  for(const auto& topic: topics)
+  {
+    const auto& name = topic.first;
+    // Match nav2's `.../local_costmap/published_footprint` robustly to whatever
+    // namespace prefix the udp_bridge applies (e.g. /bizzy/...).
+    if(name.find("published_footprint") == std::string::npos)
+      continue;
+    if(footprints_.find(name) != footprints_.end())
+      continue;
+    for(const auto& type: topic.second)
+    {
+      if(type == "geometry_msgs/msg/PolygonStamped")
+      {
+        auto* fp = new Footprint(this, m_anchor);
+        fp->setObjectName(name.c_str());
+        fp->nodeStarted(node_, transform_buffer_);
+        fp->setTopic(name);
+        footprints_[name] = fp;
+        break;
+      }
+    }
+  }
+}
+
+void FootprintManager::updateBackground()
+{
+  for(auto& entry: footprints_)
+    entry.second->updateBackground();
+}

--- a/src/camp/footprint/footprint_manager.cpp
+++ b/src/camp/footprint/footprint_manager.cpp
@@ -21,9 +21,11 @@ void FootprintManager::scanForSources()
   for(const auto& topic: topics)
   {
     const auto& name = topic.first;
-    // Match nav2's `.../local_costmap/published_footprint` robustly to whatever
-    // namespace prefix the udp_bridge applies (e.g. /bizzy/...).
-    if(name.find("published_footprint") == std::string::npos)
+    // PolygonStamped is a generic type, so we match by name. Nav2 publishes
+    // `published_footprint` from BOTH local_costmap and global_costmap (same
+    // boat outline) — match only the local one so we don't draw two overlapping
+    // footprints. The substring is namespace-prefix agnostic (e.g. /bizzy/...).
+    if(name.find("local_costmap/published_footprint") == std::string::npos)
       continue;
     if(footprints_.find(name) != footprints_.end())
       continue;

--- a/src/camp/footprint/footprint_manager.h
+++ b/src/camp/footprint/footprint_manager.h
@@ -1,0 +1,39 @@
+#ifndef CAMP_FOOTPRINT_MANAGER_H
+#define CAMP_FOOTPRINT_MANAGER_H
+
+#include <map>
+#include <string>
+
+#include "ros/ros_object.h"
+
+class QTimer;
+class QGraphicsItem;
+class Footprint;
+
+/// [#64] Discovers boat-footprint topics (nav2 `.../published_footprint`,
+/// geometry_msgs/PolygonStamped) and renders each under the "Boat Footprint"
+/// Map layer in the Layers tab. Non-widget ROS object; visibility is the layer's
+/// checkbox. Mirrors CollisionMonitorManager.
+class FootprintManager: public camp_ros::ROSObject
+{
+  Q_OBJECT
+public:
+  explicit FootprintManager(QObject* parent = nullptr);
+
+  /// The "Boat Footprint" Map layer (in topLevelLayers) that footprints parent
+  /// to. Set once by MainWindow after the project/map exists.
+  void setAnchor(QGraphicsItem* anchor) { m_anchor = anchor; }
+
+public slots:
+  void updateBackground();
+
+private slots:
+  void scanForSources();
+
+private:
+  std::map<std::string, Footprint*> footprints_;
+  QTimer* scan_timer_ = nullptr;
+  QGraphicsItem* m_anchor = nullptr;
+};
+
+#endif

--- a/src/camp/geographicsitem.h
+++ b/src/camp/geographicsitem.h
@@ -30,6 +30,7 @@ public:
         GridType,
         AvoidAreaType,
         CollisionMonitorType,
+        FootprintType,
     };
     
     GeoGraphicsItem(QGraphicsItem *parentItem = Q_NULLPTR);

--- a/src/camp/mainwindow.cpp
+++ b/src/camp/mainwindow.cpp
@@ -19,6 +19,7 @@
 #include "ais/ais_manager.h"
 #include "platform_manager/platform.h"
 #include "collision_monitor/collision_monitor_manager.h"
+#include "footprint/footprint_manager.h"
 
 #include "map/map.h"
 #include "map/layer.h"
@@ -118,6 +119,16 @@ MainWindow::MainWindow(QWidget *parent) :
     m_collision_monitor_manager->setAnchor(collision_layer);
     connect(m_ui->rosLink, &ROSLink::rosConnected, m_collision_monitor_manager, &CollisionMonitorManager::nodeStarted);
     connect(project, &AutonomousVehicleProject::backgroundUpdated, m_collision_monitor_manager, &CollisionMonitorManager::updateBackground);
+
+    // [#64] Boat footprint lives under a non-removable "Boat Footprint" layer in
+    // the Layers tab (checkbox toggles it). Discovers nav2 published_footprint
+    // PolygonStamped topics and renders the outline; same pattern as collision.
+    m_footprint_manager = new FootprintManager(this);
+    auto* footprint_layer = new camp::map::Layer(project->map()->topLevelLayers(), "Boat Footprint");
+    footprint_layer->setRemovable(false);
+    m_footprint_manager->setAnchor(footprint_layer);
+    connect(m_ui->rosLink, &ROSLink::rosConnected, m_footprint_manager, &FootprintManager::nodeStarted);
+    connect(project, &AutonomousVehicleProject::backgroundUpdated, m_footprint_manager, &FootprintManager::updateBackground);
 
     m_ui->rosLink->connectROS();
 

--- a/src/camp/mainwindow.h
+++ b/src/camp/mainwindow.h
@@ -11,6 +11,7 @@ class MainWindow;
 
 class AISManager;
 class CollisionMonitorManager;
+class FootprintManager;
 
 class AutonomousVehicleProject;
 
@@ -82,6 +83,7 @@ private:
     QString m_workspace_path;
     AISManager* m_ais_manager = nullptr;
     CollisionMonitorManager* m_collision_monitor_manager = nullptr;
+    FootprintManager* m_footprint_manager = nullptr;
 
     // [#59 PR5] Guard so camp2's ros::Node (grids/markers/geometry) is attached
     // to the Map's ToolsManager only once, on the first ROS connect.


### PR DESCRIPTION
## Summary

Adds a boat-footprint overlay to CAMP so the operator can judge close-quarters
clearance. Closes #64.

During the 2026-06-02 deployment the operator noticed no boat footprint in CAMP;
`/<ns>/local_costmap/published_footprint` (PolygonStamped, ~3.2 Hz) was healthy
at the operator station but CAMP had zero footprint references — a feature gap.

## What it does

- **`Footprint`** (`camp_ros::ROSObject` + `GeoGraphicsItem`) — subscribes a
  `geometry_msgs/PolygonStamped` footprint topic via the TF-gated `TopicBridge`,
  reusing `camp_collision_monitor::convertPolygon` to transform each vertex to
  earth → geographic, and draws the outline. Mirrors `CollisionMonitor` minus the
  danger-zone kind/active-state machinery.
- **`FootprintManager`** (`camp_ros::ROSObject`) — discovers
  `published_footprint` topics and parents each `Footprint` under a
  non-removable **"Boat Footprint"** Map layer in the Layers tab. Visibility is
  the layer's checkbox — the same layer-based pattern the AIS / Collision
  managers adopted in #59 (no separate window).

Renders with or without a chart (Web-Mercator scene), independent of OSM/WMTS.

## Test

- `colcon build` + `colcon test` — **48 tests, 0 failures**.
- Offscreen start/stop clean (no crash/abort).
- **Sim-verify (operator gate):** the boat outline appears and tracks the
  vehicle; the "Boat Footprint" layer checkbox toggles it.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
