### PR TITLE
Fix use-after-free crash on trackline removal (closes #65)

### DIFF
--- a/src/camp/autonomousvehicleproject.cpp
+++ b/src/camp/autonomousvehicleproject.cpp
@@ -808,13 +808,43 @@ void AutonomousVehicleProject::updateMission(const QModelIndex& index)
 
 void AutonomousVehicleProject::deleteItems(const QModelIndexList &indices)
 {
+    // [#65] Resolve to items first, then delete only the TOPMOST selected ones.
+    // If a parent (e.g. a trackline, group, or survey area) and one of its
+    // descendants (e.g. a waypoint) are both selected, deleting the parent frees
+    // the descendant — deleting it afterwards would removeItem()/qobject_cast a
+    // freed pointer (the trackline-removal crash, #65). Deleting a parent already
+    // takes its children with it.
+    std::vector<MissionItem*> items;
     for(auto index: indices)
-        deleteItem(index);
+        if(auto* item = itemFromIndex(index))
+            items.push_back(item);
+
+    for(auto* item: items)
+    {
+        bool has_selected_ancestor = false;
+        for(QObject* a = item->parent(); a && !has_selected_ancestor; a = a->parent())
+            has_selected_ancestor = std::find(items.begin(), items.end(), a) != items.end();
+        if(!has_selected_ancestor)
+            deleteItem(item);
+    }
 }
 
 void AutonomousVehicleProject::deleteItem(const QModelIndex &index)
 {
     MissionItem *item = itemFromIndex(index);
+    // [#65] Defensive: a stale index (e.g. an item already freed as a child of a
+    // previously-deleted parent) resolves to no/garbage item — never touch it.
+    if(!item)
+        return;
+    // [#65] Clear selection/group bookkeeping if it points at the item being
+    // deleted (or a descendant of it — deleting a parent frees its children).
+    // Otherwise endRemoveRows below fires the tree's currentChanged cascade,
+    // which dereferences the now-freed m_currentSelected → use-after-free.
+    for(MissionItem* s = m_currentSelected; s; s = qobject_cast<MissionItem*>(s->parent()))
+        if(s == item) { m_currentSelected = nullptr; break; }
+    for(MissionItem* g = m_currentGroup; g; g = qobject_cast<MissionItem*>(g->parent()))
+        if(g == item) { m_currentGroup = m_root; break; }
+
     GeoGraphicsMissionItem *ggi = qobject_cast<GeoGraphicsMissionItem*>(item);
     if(ggi)
     {


### PR DESCRIPTION
## Summary

Fixes the CAMP crash on trackline removal (`QGraphicsScene::removeItem` /
`TrackLine`) observed on deployment rolker/unh_echoboats_project11#211. Closes #65.

No core dump was captured, so this is a **fix-by-audit** of the removal path —
which turned up two concrete use-after-free vectors, both matching the crash
signature.

## Root causes

**1. `deleteItems()` wasn't safe against co-selected ancestor/descendant.**
It looped `deleteItem()` over the raw selection list. If a parent (trackline,
group, survey area) and one of its descendants (a waypoint) were both selected,
deleting the parent freed the descendant — and the next `deleteItem()` did
`removeItem()` / `qobject_cast` on a **freed pointer**. That's the
`QGraphicsScene::removeItem`-on-a-`TrackLine` crash.
*Fix:* resolve indices to items first, then delete only the **topmost** selected
items (a parent already removes its children).

**2. `m_currentSelected` / `m_currentGroup` were never cleared on delete.**
Deleting the *selected* item left them dangling, and `endRemoveRows()` fires the
tree's `currentChanged` cascade, which dereferences `m_currentSelected`.
*Fix:* clear them when the deleted item is (or is an ancestor of) the current
selection/group; also early-out on a stale/garbage index.

## Test

- `colcon build` + `colcon test` — **48 tests, 0 failures**.
- A unit test isn't practical: `AutonomousVehicleProject` lives in the executable
  target (not a library), so a gtest would pull in most of the app.
- **Sim-verify (operator gate):**
  - Select a trackline, delete it — no crash, removed.
  - Multi-select a trackline **and** one of its waypoints, delete — no crash,
    both removed.
  - Delete the currently-selected item, then click another — no crash.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
