### PR TITLE
markers: DELETEALL clears every namespace (fix #59 parity regression)

### DIFF
--- a/src/camp2/ros/markers/markers.cpp
+++ b/src/camp2/ros/markers/markers.cpp
@@ -84,6 +84,20 @@ MarkerNamespace* Markers::markerNamespace(const QString& marker_namespace) const
 
 void Markers::updateMarker(const MarkerData& data)
 {
+  // [#70] DELETEALL clears EVERY namespace per the visualization_msgs spec, not
+  // just the message's own ns (which is conventionally empty). Fan it out to all
+  // existing MarkerNamespaces; routing it to a single namespace (the previous
+  // behavior) left markers in every other namespace as stale visuals on the
+  // operator's map. Each MarkerNamespace::updateMarker handles DELETEALL by
+  // clearing its own markers.
+  if(data.marker.action == visualization_msgs::msg::Marker::DELETEALL)
+  {
+    for(auto item: childItems())
+      if(auto* ns = qgraphicsitem_cast<MarkerNamespace*>(item))
+        ns->updateMarker(data);
+    return;
+  }
+
   auto marker_namespace = markerNamespace(data.marker.ns.c_str());
   if(!marker_namespace)
     marker_namespace = new MarkerNamespace(this, node_, data.marker.ns.c_str());


### PR DESCRIPTION
## Summary

Fixes the **DELETEALL spec-violation regression** from the camp→camp2 markers
replacement (#59). Addresses the headline must-fix of #70; the remaining marker
port items in that issue stay open.

## The bug

`visualization_msgs` spec: a `DELETEALL` marker clears **every** marker
regardless of namespace. camp did this; the camp2 markers that replaced it (PR5)
route every marker — DELETEALL included — to the single `MarkerNamespace`
matching the message's `ns` (conventionally empty). So a publisher clearing
itself with DELETEALL only cleared the `""` namespace, and **markers in every
other namespace lingered as stale visuals** on the operator's map.

## Fix

Detect `DELETEALL` in `Markers::updateMarker` and fan it out to **all**
`MarkerNamespace`s (each already clears its own markers). One change, no behavior
change for ADD/MODIFY/DELETE.

## Test

- `colcon build` + `colcon test` — **48 tests, 0 failures**.
- `Markers` isn't unit-testable in isolation (needs a live `Node` + scene tree),
  so no gtest.
- **Sim-verify:** publish markers in multiple namespaces, then a DELETEALL —
  every namespace's markers clear (not just the empty one).

Remaining #70 items (separate, not in this PR): DELETE object/namespace pruning,
TEXT `scale.z` font sizing, already-expired/empty-frame ingest drops,
unknown-action warn.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
