### PR TITLE
Fix upside-down TEXT_VIEW_FACING markers (closes #76)

### DIFF
--- a/.agent/work-plans/issue-76/progress.md
+++ b/.agent/work-plans/issue-76/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 76
+---
+
+# Issue #76 — Upside down text
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-09
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-76 at `55d36ce`
+**Mode**: pre-push
+**Depth**: Light (reason: single low-risk C++ statement + comment)
+**Must-fix**: 0 | **Suggestions**: 0
+
+### Findings
+- [ ] No issues found. LGTM.

--- a/src/camp2/ros/markers/marker.cpp
+++ b/src/camp2/ros/markers/marker.cpp
@@ -88,6 +88,13 @@ void Marker::updateMarker(const MarkerData& data)
       case visualization_msgs::msg::Marker::TEXT_VIEW_FACING:
       {
         auto text = new QGraphicsSimpleTextItem(data.marker.text.c_str(), this);
+        // The map view flips the Y axis so north renders up (ProjectView applies
+        // scale(1.0, -1.0); Web Mercator is Y-up, QGraphicsView is Y-down). A plain
+        // child item inherits that flip and renders upside-down. ItemIgnoresTransformations
+        // keeps the text screen-aligned, upright, and constant-size — the correct behavior
+        // for TEXT_VIEW_FACING (a billboard in rviz) and the same convention camp's other
+        // labels use (see geographicsitem.cpp, vector/point.cpp).
+        text->setFlag(QGraphicsItem::ItemIgnoresTransformations);
         text->setBrush(b);
         break;
       }


### PR DESCRIPTION
## Summary

`TEXT_VIEW_FACING` markers (e.g. the collision-avoidance labels along survey
lines) rendered upside-down on the first deployment after the camp2 map-system
port (#59).

## Root cause

The map view flips the Y axis so north renders up — `ProjectView` applies
`scale(1.0, -1.0)` (Web Mercator is Y-up, a `QGraphicsView` is Y-down; see
`projectview.cpp:43`, ADR-0002). Every child graphics item inherits that flip.
The camp2 marker port created the `TEXT_VIEW_FACING` text item as a plain child
(`src/camp2/ros/markers/marker.cpp`), so the glyphs inherited the view flip and
rendered upside-down.

## Fix

Set `ItemIgnoresTransformations` on the text item. This keeps the text
screen-aligned, upright, and constant-size regardless of zoom/flip — which is:

- **The correct semantics** for `TEXT_VIEW_FACING` (a screen-facing billboard in rviz), and
- **The existing camp convention** for labels — `geographicsitem.cpp:17` and
  `vector/point.cpp:11` already use the same flag.

One line plus an explanatory comment.

## Testing

- camp builds clean in the layer worktree.
- `/review-code` (Light tier): static analysis + Copilot adversarial both clean.
- **Visual confirmation pending**: needs the marker stream live in CAMP (a
  deployment or bag replay) to see the labels render right-side up — not
  reproducible from a headless build.

Closes #76. Part of the #59 map-system port parity follow-ups.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
