### PR TITLE
markers: port DELETE/ingest/warn parity items from camp (#70)

### DIFF
--- a/.agent/work-plans/issue-70/progress.md
+++ b/.agent/work-plans/issue-70/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 70
+---
+
+# Issue #70 — Markers replacement shipped without parity: DELETEALL spec violation + 5 unported camp behaviors (#59 regression)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-09 07:12 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-70 at `e27652d`
+**Mode**: pre-push
+**Depth**: Standard (reason: ~120-line C++ change touching QGraphicsItem/Map-model object lifecycle)
+**Must-fix**: 1 (fixed before push) | **Suggestions**: 2
+
+### Findings
+- [x] (must-fix) Raw `delete` of Marker/MarkerNamespace bypassed the Map QAbstractItemModel (ADR-0003), leaving the Layers-tab tree view with dangling rows (use-after-free). Confirmed independently by Claude + Copilot adversarial passes. Fixed: added `Layer::removeFromMap()` (canonical detach-through-model path) and routed all marker/namespace deletion + the existing "Remove" action through it — `src/camp2/map/layer.cpp`, `src/camp2/ros/markers/{markers,marker_namespace}.cpp`
+- [x] (suggestion) Throttled log calls constructed local system-time `rclcpp::Clock`s; switched to the node clock so intervals track sim time under use_sim_time — `src/camp2/ros/markers/markers.cpp`
+- [ ] (suggestion) MODIFY action renders nothing (clears visuals, draws only for ADD). Pre-existing on jazzy, NOT a regression of this change; worth a follow-up to treat MODIFY as ADD in the guard + render switch — `marker.cpp:33`, `markers.cpp`

--- a/docs/parity/markers.md
+++ b/docs/parity/markers.md
@@ -35,16 +35,16 @@ the child list via `qgraphicsitem_cast`. Positioning is Web Mercator
 | SPHERE | `markers.cpp:96-101` | `marker.cpp:53-59` | parity | keep camp2 |
 | LINE_STRIP | `markers.cpp:102-118` | `marker.cpp:60-87` | parity | keep camp2 |
 | LINE_LIST | `markers.cpp:119-144` | `marker.cpp:60-87` | parity | keep camp2 |
-| TEXT_VIEW_FACING | `markers.cpp:145-154` (font scaled by `scale.z`) | `marker.cpp:88-93` (no scale) | differs | **port camp's font sizing into camp2 text branch** |
+| TEXT_VIEW_FACING | `markers.cpp:145-154` (font scaled by `scale.z`) | `marker.cpp:88-93` (no scale) | differs | font sizing tracked with the TEXT-rendering work in **#76 / PR #78** (same code path); not in #70 |
 | **CUBE** | not handled (`markers.cpp:155-157` warn) | `marker.cpp:46-52` | camp2-only (keep) | inherit |
 | CYLINDER / CUBE_LIST / SPHERE_LIST / POINTS / MESH / TRIANGLE_LIST / ARROW | not handled | not handled | parity (gap) | out of scope unless needed |
 | Action ADD/MODIFY (0) | `markers.cpp:251-264` | `marker.cpp:33-97` | parity | keep camp2 |
-| **Action DELETE (2)** | `markers.cpp:265-271` (erases id) | visuals cleared (`marker.cpp:27-32`) + `checkExpired` action!=0 (`marker.cpp:110`); **`Marker`/`MarkerNamespace` objects leaked** | differs | **port real object removal + prune empty namespaces** |
-| **Action DELETEALL (3)** | `markers.cpp:272-276` (clears **all** ns) | `marker_namespace.cpp:19-24` clears **one** ns only | differs (**regression**) | **fix: clear every namespace per spec** |
-| Unknown action handling | warns (`markers.cpp:277-280`) | silent | camp-only (port) | add warn log |
+| **Action DELETE (2)** | `markers.cpp:265-271` (erases id) | visuals cleared (`marker.cpp:27-32`) + `checkExpired` action!=0 (`marker.cpp:110`); **`Marker`/`MarkerNamespace` objects leaked** | differs | ✅ **#70**: `MarkerNamespace::updateMarker` deletes the `Marker` object; `Markers::pruneEmptyNamespaces` drops the emptied namespace |
+| **Action DELETEALL (3)** | `markers.cpp:272-276` (clears **all** ns) | `marker_namespace.cpp:19-24` clears **one** ns only | differs (**regression**) | ✅ **#70 / PR #75**: fans out to every namespace; this PR also deletes the `Marker` objects + prunes namespaces |
+| Unknown action handling | warns (`markers.cpp:277-280`) | silent | camp-only (port) | ✅ **#70**: throttled warn in `Markers::updateMarker` |
 | Lifetime expiry | one-shot per ADD + `purgeExpiredMarkers` (`markers.cpp:254-263,287-311`) | per-Marker 1 Hz poll (`marker.cpp:106-118`) | differs | both work; keep camp2 |
-| Already-expired drop at ingest | `markers_converter.h:61-68` | none | camp-only (port) | add pre-drop in `addMarkers` |
-| Empty frame_id drop | `markers_converter.h:69-75` | none | camp-only (port) | add explicit guard |
+| Already-expired drop at ingest | `markers_converter.h:61-68` | none | camp-only (port) | ✅ **#70**: pre-drop in `addMarkers` (non-zero-stamp guard mirrors `checkExpired`) |
+| Empty frame_id drop | `markers_converter.h:69-75` | none | camp-only (port) | ✅ **#70**: explicit guard in `addMarkers` |
 | Namespace+id keying | nested `std::map` (`markers.h:52`) | scene-graph tree (`markers.cpp:74-83`, `marker_namespace.cpp:26-44`) | differs | keep camp2 tree |
 | Color (RGBA) | pen a=a, brush a=a/2 (half-alpha fill) (`markers.cpp:70,79`) | pen+brush full a=a (`marker.cpp:38-42`) | differs (UX) | **DECIDED 2026-06-02: make fill alpha a config option** (don't hardcode either). Wire a fill-opacity setting during the markers migration; pick the default at PR5 |
 | Pose / yaw | `markers_converter.h:106` + path rotate | `markers.cpp:62` + `setRotation` (`marker.cpp:36`) | parity | keep camp2 |
@@ -56,13 +56,20 @@ the child list via `qgraphicsitem_cast`. Positioning is Web Mercator
 
 ## Direct answer: do we lose DELETE/DELETEALL, and does expiry subsume them?
 
+> **Resolved (#70).** DELETEALL fan-out landed in PR #75; DELETE object removal,
+> namespace pruning, the two ingest drops, and the unknown-action warn landed in
+> the #70 follow-up PR. Bullets below are the original analysis, kept for context.
+
 - **DELETE (2):** Not a hard *visual* regression (camp2 clears children), **but**
   camp2 leaks empty `Marker`/`MarkerNamespace` objects camp does not. **Port:
   actually remove the `Marker` item + prune empty namespaces on DELETE.**
+  → *Done:* `MarkerNamespace::updateMarker` now deletes the `Marker` and
+  `Markers::pruneEmptyNamespaces` drops the emptied namespace.
 - **DELETEALL (3):** **Real semantic regression.** camp clears **all**
   namespaces (`markers.cpp:272-275`, per the visualization_msgs spec); camp2
   only clears the message's single namespace (`marker_namespace.cpp:19-24`).
-  **Fix before retiring camp's markers.**
+  **Fix before retiring camp's markers.** → *Done in PR #75* (fan-out), extended
+  here to delete the `Marker` objects and prune namespaces.
 - **Does the expiry timer subsume them?** **No.** The timer handles *lifetime*
   removal; it provides neither the all-namespace `DELETEALL` fan-out nor object
   cleanup. Complementary, not a substitute — `DELETEALL` must be fixed

--- a/src/camp2/map/layer.cpp
+++ b/src/camp2/map/layer.cpp
@@ -44,20 +44,24 @@ void Layer::contextMenu(QMenu* menu)
 
   if(!removable_)
     return;
-  // [#59 ADR-0003] Detach through the Map model (fires rowsAboutToBeRemoved so
-  // owners can sync their bookkeeping), drop it from the scene so it stops
-  // rendering at once, then delete after the menu event unwinds.
   QAction* remove_action = menu->addAction("Remove");
   connect(remove_action, &QAction::triggered, this, [this]()
   {
-    if(auto* m = parentMap())
-      m->setMapItemParent(this, nullptr);
-    if(scene())
-      scene()->removeItem(this);
-    deleteLater();
+    removeFromMap();
   });
 }
 
+void Layer::removeFromMap()
+{
+  // [#59 ADR-0003] Detach through the Map model (fires rowsAboutToBeRemoved so
+  // owners can sync their bookkeeping), drop it from the scene so it stops
+  // rendering at once, then delete after the current event unwinds.
+  if(auto* m = parentMap())
+    m->setMapItemParent(this, nullptr);
+  if(scene())
+    scene()->removeItem(this);
+  deleteLater();
+}
 
 void Layer::updateFlags(Qt::ItemFlags& flags) const
 {

--- a/src/camp2/map/layer.h
+++ b/src/camp2/map/layer.h
@@ -30,6 +30,15 @@ public:
   void setRemovable(bool removable) { removable_ = removable; }
   bool isRemovable() const { return removable_; }
 
+  /// [#59 ADR-0003] Detach this layer from the Map model (firing
+  /// rowsAboutToBeRemoved so owners can sync their bookkeeping), drop it from
+  /// the scene so it stops rendering at once, then delete it after the current
+  /// event unwinds. This is the only correct way to remove a Layer/MapItem: a
+  /// raw `delete` bypasses the model and leaves the Layers-tab tree view with
+  /// dangling rows. The "Remove" context action and programmatic owners (e.g.
+  /// the markers managers deleting cleared/expired markers) share this path.
+  void removeFromMap();
+
 protected:
   /// [#59 ADR-0003] Adds a "Remove" entry (unless setRemovable(false)). Detaches
   /// through the Map model — owners that track specific layers (e.g. the

--- a/src/camp2/ros/markers/marker_namespace.cpp
+++ b/src/camp2/ros/markers/marker_namespace.cpp
@@ -16,10 +16,24 @@ MarkerNamespace::MarkerNamespace(MapItem* parent, Node* node, QString marker_nam
 void MarkerNamespace::updateMarker(const MarkerData& data)
 {
   auto markers_map = markers();
+
+  // [#70] DELETE/DELETEALL remove the Marker objects outright. The port only
+  // cleared each Marker's visual children, leaving empty Marker husks in the
+  // scene tree and the Layers list. removeFromMap() detaches each Marker through
+  // the Map model (ADR-0003) before deleting it; Markers::pruneEmptyNamespaces
+  // then drops this namespace once it is emptied.
   if(data.marker.action == visualization_msgs::msg::Marker::DELETEALL)
   {
     for(auto m: markers_map)
-      m.second->updateMarker(data);
+      m.second->removeFromMap();
+    return;
+  }
+
+  if(data.marker.action == visualization_msgs::msg::Marker::DELETE)
+  {
+    auto it = markers_map.find(data.marker.id);
+    if(it != markers_map.end())
+      it->second->removeFromMap();
     return;
   }
 
@@ -29,6 +43,11 @@ void MarkerNamespace::updateMarker(const MarkerData& data)
   else
     marker = markers_map[data.marker.id];
   marker->updateMarker(data);
+}
+
+bool MarkerNamespace::isEmpty() const
+{
+  return markers().empty();
 }
 
 std::map<uint32_t, Marker*> MarkerNamespace::markers() const

--- a/src/camp2/ros/markers/marker_namespace.h
+++ b/src/camp2/ros/markers/marker_namespace.h
@@ -29,11 +29,15 @@ public:
   }
 
 
+  // True when this namespace holds no markers — used by Markers to prune it
+  // after a DELETE/DELETEALL empties it. [#70]
+  bool isEmpty() const;
+
 public slots:
   void updateMarker(const MarkerData& data);
 
 private:
-  std::map<uint32_t, Marker*> markers() const;  
+  std::map<uint32_t, Marker*> markers() const;
 
 };
 

--- a/src/camp2/ros/markers/markers.cpp
+++ b/src/camp2/ros/markers/markers.cpp
@@ -54,7 +54,7 @@ void Markers::addMarkers(const std::vector<visualization_msgs::msg::Marker> &mar
   // use_sim_time is set, rather than a local system-time clock.
   auto clock = node_->node()->get_clock();
   auto now = clock->now();
-  for(auto m: markers)
+  for(const auto& m: markers)
   {
     if(m.action == visualization_msgs::msg::Marker::ADD)
     {
@@ -63,9 +63,13 @@ void Markers::addMarkers(const std::vector<visualization_msgs::msg::Marker> &mar
       // moment later. The non-zero-stamp guard mirrors Marker::checkExpired and
       // avoids comparing against a default-constructed (zero) stamp.
       // Ported from camp's markers_converter drop checks.
-      if(rclcpp::Time(m.header.stamp).nanoseconds() != 0 &&
+      // Construct the stamp in the node clock's time domain so the comparison
+      // against `now` is valid under use_sim_time (rclcpp::Time rejects mixing
+      // clock types, and the message stamp would otherwise default to ROS time).
+      const rclcpp::Time stamp(m.header.stamp, clock->get_clock_type());
+      if(stamp.nanoseconds() != 0 &&
          rclcpp::Duration(m.lifetime).nanoseconds() != 0 &&
-         rclcpp::Time(m.header.stamp) + rclcpp::Duration(m.lifetime) < now)
+         stamp + rclcpp::Duration(m.lifetime) < now)
       {
         RCLCPP_DEBUG_STREAM_THROTTLE(node_->node()->get_logger(), *clock, 5000, "Dropping already-expired marker " << m.ns << ": " << m.id);
         continue;

--- a/src/camp2/ros/markers/markers.cpp
+++ b/src/camp2/ros/markers/markers.cpp
@@ -50,8 +50,34 @@ void Markers::markerCallback(const visualization_msgs::msg::Marker &data)
 
 void Markers::addMarkers(const std::vector<visualization_msgs::msg::Marker> &markers)
 {
+  // Throttle against the node's clock so log intervals track sim time when
+  // use_sim_time is set, rather than a local system-time clock.
+  auto clock = node_->node()->get_clock();
+  auto now = clock->now();
   for(auto m: markers)
   {
+    if(m.action == visualization_msgs::msg::Marker::ADD)
+    {
+      // [#70] Drop markers that are already expired on arrival. Without this
+      // they'd be added, drawn once, then cleared by the 1 Hz expiry poll a
+      // moment later. The non-zero-stamp guard mirrors Marker::checkExpired and
+      // avoids comparing against a default-constructed (zero) stamp.
+      // Ported from camp's markers_converter drop checks.
+      if(rclcpp::Time(m.header.stamp).nanoseconds() != 0 &&
+         rclcpp::Duration(m.lifetime).nanoseconds() != 0 &&
+         rclcpp::Time(m.header.stamp) + rclcpp::Duration(m.lifetime) < now)
+      {
+        RCLCPP_DEBUG_STREAM_THROTTLE(node_->node()->get_logger(), *clock, 5000, "Dropping already-expired marker " << m.ns << ": " << m.id);
+        continue;
+      }
+      // [#70] Drop markers with no frame_id — the transform to earth can't be
+      // resolved, so they would only throw and spam the catch below every frame.
+      if(m.header.frame_id.empty())
+      {
+        RCLCPP_DEBUG_STREAM_THROTTLE(node_->node()->get_logger(), *clock, 1000, "Dropping marker with empty frame_id " << m.ns << ": " << m.id);
+        continue;
+      }
+    }
     try
     {
       MarkerData marker_data;
@@ -65,8 +91,7 @@ void Markers::addMarkers(const std::vector<visualization_msgs::msg::Marker> &mar
     }
     catch (tf2::TransformException &ex)
     {
-      rclcpp::Clock clock;
-      RCLCPP_WARN_STREAM_THROTTLE(node_->node()->get_logger(), clock, 2000, "Unable to find transform to earth for marker " << m.ns << ": " << m.id << " what: " << ex.what());
+      RCLCPP_WARN_STREAM_THROTTLE(node_->node()->get_logger(), *clock, 2000, "Unable to find transform to earth for marker " << m.ns << ": " << m.id << " what: " << ex.what());
     }
   }
 }
@@ -84,24 +109,62 @@ MarkerNamespace* Markers::markerNamespace(const QString& marker_namespace) const
 
 void Markers::updateMarker(const MarkerData& data)
 {
+  const auto action = data.marker.action;
+
   // [#70] DELETEALL clears EVERY namespace per the visualization_msgs spec, not
   // just the message's own ns (which is conventionally empty). Fan it out to all
   // existing MarkerNamespaces; routing it to a single namespace (the previous
   // behavior) left markers in every other namespace as stale visuals on the
   // operator's map. Each MarkerNamespace::updateMarker handles DELETEALL by
-  // clearing its own markers.
-  if(data.marker.action == visualization_msgs::msg::Marker::DELETEALL)
+  // deleting its own markers; prune the namespaces it empties.
+  if(action == visualization_msgs::msg::Marker::DELETEALL)
   {
     for(auto item: childItems())
       if(auto* ns = qgraphicsitem_cast<MarkerNamespace*>(item))
         ns->updateMarker(data);
+    pruneEmptyNamespaces();
+    return;
+  }
+
+  // [#70] Warn on unrecognized actions instead of silently creating dead state
+  // (the camp original logged this; the camp2 port dropped it).
+  if(action != visualization_msgs::msg::Marker::ADD &&
+     action != visualization_msgs::msg::Marker::MODIFY &&
+     action != visualization_msgs::msg::Marker::DELETE)
+  {
+    RCLCPP_WARN_STREAM_THROTTLE(node_->node()->get_logger(), *node_->node()->get_clock(), 5000, "Unknown marker action " << static_cast<int>(action) << " for " << data.marker.ns << ": " << data.marker.id);
     return;
   }
 
   auto marker_namespace = markerNamespace(data.marker.ns.c_str());
+
+  // [#70] A DELETE for a namespace we don't track is a no-op — never create a
+  // namespace just to delete from it. Prune the namespace if this empties it.
+  if(action == visualization_msgs::msg::Marker::DELETE)
+  {
+    if(marker_namespace)
+    {
+      marker_namespace->updateMarker(data);
+      pruneEmptyNamespaces();
+    }
+    return;
+  }
+
+  // ADD / MODIFY
   if(!marker_namespace)
     marker_namespace = new MarkerNamespace(this, node_, data.marker.ns.c_str());
   marker_namespace->updateMarker(data);
+}
+
+void Markers::pruneEmptyNamespaces()
+{
+  // removeFromMap() detaches each namespace through the Map model (ADR-0003),
+  // which calls setParentItem(nullptr) synchronously — so an emptied namespace
+  // leaves childItems() within this loop and won't be revisited. [#70]
+  for(auto item: childItems())
+    if(auto* ns = qgraphicsitem_cast<MarkerNamespace*>(item))
+      if(ns->isEmpty())
+        ns->removeFromMap();
 }
 
 }  // namespace markers

--- a/src/camp2/ros/markers/markers.h
+++ b/src/camp2/ros/markers/markers.h
@@ -41,6 +41,10 @@ private:
 
   MarkerNamespace * markerNamespace(const QString& marker_namepsace) const;
 
+  // Delete MarkerNamespaces left empty by a DELETE/DELETEALL so they don't
+  // linger as husks in the scene tree and the Layers list. [#70]
+  void pruneEmptyNamespaces();
+
 private slots:
   void updateMarker(const MarkerData& data);
 


### PR DESCRIPTION
## Summary

Completes the camp→camp2 markers parity gap from #70. The headline **DELETEALL**
must-fix already landed in PR #75; this PR ports the remaining flagged behaviors
and fixes a use-after-free found in pre-push review.

## Changes

**`src/camp2/ros/markers` — parity items:**
- **DELETE / DELETEALL now remove the `Marker` objects** (not just their visual
  children), and `Markers::pruneEmptyNamespaces` drops any `MarkerNamespace` they
  empty. The port previously leaked empty `Marker`/`MarkerNamespace` husks into
  the scene tree and the Layers list. A DELETE for an untracked namespace is now a
  clean no-op instead of *creating* a namespace (and an empty marker) just to
  delete from it.
- **Ingest drops** in `addMarkers`: markers already expired on arrival (non-zero
  stamp guard mirrors `Marker::checkExpired`) and markers with an empty
  `frame_id`. Ported from camp's `markers_converter` drop checks.
- **Unknown-action warn** (throttled) instead of silently creating dead state,
  matching the camp original. Throttles use the node clock so intervals track sim
  time under `use_sim_time`.

**`src/camp2/map` (Layer) — correctness fix from review:**
- Added **`Layer::removeFromMap()`**, the canonical ADR-0003 removal: detach
  through the `Map` model (so `rowsAboutToBeRemoved` fires), drop from the scene,
  then `deleteLater()`. A raw `delete` of a `Marker`/`MarkerNamespace` — both are
  `Map` model rows — would leave the Layers-tab tree view with dangling rows
  (use-after-free). The existing "Remove" context action now shares this path
  instead of duplicating it. `setMapItemParent(nullptr)` detaches from
  `childItems()` synchronously, so `pruneEmptyNamespaces` still sees the emptied
  namespace in the same pass.

## Out of scope

- **TEXT_VIEW_FACING font sizing** (the remaining #70 checklist item) is left to
  **#76 / PR #78**, which owns the TEXT rendering path in `marker.cpp` — doing it
  here would collide with that in-flight PR.
- **MODIFY action** renders nothing (clears visuals, draws only for ADD). This is
  pre-existing on `jazzy`, **not** a regression of this change; flagged as a
  follow-up.

## Test

- `colcon build` + `colcon test` — **48 tests, 0 failures**.
- The markers scene-tree logic needs a live `Node` + `QGraphicsScene` + `Map`
  model, so it is **sim-verified** rather than unit tested (per PR #75's
  precedent).
- **Sim-verify (operator-driven):** publish markers across multiple namespaces,
  then (a) a per-id DELETE and (b) a DELETEALL — confirm the markers disappear AND
  their rows vanish from the Layers tab with no stale entries or crash on
  subsequent Layers-tab interaction.

## Review

Pre-push `/review-code` (Standard) run. Both the Claude and Copilot adversarial
specialists independently flagged the model-detach use-after-free; fixed before
push via `removeFromMap()`. Parity matrix in `docs/parity/markers.md` updated.

Closes #70

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
