### PR TITLE
map_tree_view: InternalMove drag-drop mode to restore layer reordering (closes #81)

### DIFF
--- a/.agent/work-plans/issue-81/progress.md
+++ b/.agent/work-plans/issue-81/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 81
+---
+
+# Issue #81 — Layers-tab drag-to-reorder no longer works (regression from #59 port)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-09 11:57 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-81 at `34ee153`
+**Mode**: pre-push
+**Depth**: Light (reason: 1 file, 7 lines, non-governance Qt view config)
+**Must-fix**: 0 | **Suggestions**: 0
+
+### Findings
+- [ ] No issues found. LGTM. Static analysis clean on changed lines (the lone cppcheck `unknownMacro`/`slots` note is on unchanged map_view.h). Copilot Adversarial suppressed by reviewer judgment — trivial change, and the merge gate already waits for a PR-side Copilot review.

--- a/src/camp2/map_tree_view/map_tree_view.cpp
+++ b/src/camp2/map_tree_view/map_tree_view.cpp
@@ -13,8 +13,13 @@ MapTreeView::MapTreeView(QWidget *parent):
   QTreeView(parent)
 {
   setHeaderHidden(true);
-  setDragEnabled(true);
-  viewport()->setAcceptDrops(true);
+  // InternalMove (not the individual drag/accept flags) is required for layer
+  // reordering. In plain DragDrop mode the view runs its own clearOrRemove() on
+  // the source rows after a MoveAction drop, on top of Map::dropMimeData() having
+  // already moved the item — a double-handling that makes the reorder fail to
+  // take. InternalMove configures dragEnabled + acceptDrops AND makes the view
+  // trust the model's dropMimeData() to perform the whole move (issue #81).
+  setDragDropMode(QAbstractItemView::InternalMove);
   setDropIndicatorShown(true);
   setItemDelegate( new MapItemDelegate(this));
 }


### PR DESCRIPTION
## Summary

Restores **Layers-tab drag-to-reorder**, which stopped working after the #59 camp2 layer-system port.

`MapTreeView` set `setDragEnabled(true)` + `viewport()->setAcceptDrops(true)` but left the view in
the default (non-`InternalMove`) drag-drop mode. In that mode, after a `MoveAction` drop the view
runs its own `clearOrRemove()` on the (now-stale) source rows — on top of `Map::dropMimeData()`
having already performed the move (`beginRemoveRows` + `setParentItem` + `stackBefore` +
`beginInsertRows`). That double-handling leaves the reorder not taking.

Switching to `QAbstractItemView::InternalMove` configures `dragEnabled` + `acceptDrops` *and* makes
the view trust `dropMimeData()` to perform the whole move (no `clearOrRemove`), restricted to
internal moves — exactly layer reordering.

## Why it matters

Reordering restacks rendering via `stackBefore`, so this is also the manual operator workaround for
overlays (footprint, collision zones) being hidden behind the costmap (#80) until a deliberate
Z-order convention lands.

## Testing

- Built `camp` clean in the worktree.
- Verified in the simulator (BEN): dragging layers in the Layers tab now reorders them and restacks
  rendering correctly.

Closes #81. Related: #80 (layer Z-order/stacking), #82 (chart-layer dedup).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
