### PR TITLE
Layers tab: make leaf layers drag-only so reorder lands anywhere (#84)

### DIFF
--- a/.agent/work-plans/issue-84/progress.md
+++ b/.agent/work-plans/issue-84/progress.md
@@ -1,0 +1,24 @@
+---
+issue: 84
+---
+
+# Issue #84 — Layers tab: drag-drop layer reorder collapses to the first spot
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-10 06:46 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-84 at `62e2316`
+**Mode**: pre-push
+**Depth**: Light (reason: small, low-risk — one flag removal + tests)
+**Must-fix**: 0 | **Suggestions**: 3 (all addressed before push)
+
+### Findings
+- [x] (suggestion) `LayerListAcceptsDrops` could false-pass on an invalid index — added `ASSERT_TRUE(...isValid())` — `test/test_map_model.cpp`
+- [x] (suggestion) `DropReordersToTargetRow` implicitly depended on Map's 3 default tile layers — added an initial-order assertion — `test/test_map_model.cpp`
+- [x] (suggestion) `layer.cpp` comment implied nested-child layers don't exist yet (they do: markers/grids) — reworded — `src/camp2/map/layer.cpp`
+- [ ] (note) No test drives the view-side OnItem→Above/Below conversion that is the literal bug (Qt QTreeView behavior; not unit-testable) — manual sim confirm requested in PR #87
+
+Two independent adversarial reviewers (fresh-context Claude + Copilot CLI) confirmed the fix is sound with no must-fix issues.

--- a/.agent/work-plans/issue-84/progress.md
+++ b/.agent/work-plans/issue-84/progress.md
@@ -22,3 +22,19 @@ issue: 84
 - [ ] (note) No test drives the view-side OnItem→Above/Below conversion that is the literal bug (Qt QTreeView behavior; not unit-testable) — manual sim confirm requested in PR #87
 
 Two independent adversarial reviewers (fresh-context Claude + Copilot CLI) confirmed the fix is sound with no must-fix issues.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-10 07:20 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #87 at `2e47f65`
+**Sources**: 2 (Copilot R1 @ `62e2316`, Local Review (Pre-Push) @ `62e2316`)
+**Cross-source confirmations**: 0
+**CI**: none configured (camp has no CI)
+
+### Findings
+- [ ] (low, Copilot) `WarningTrap` is constructed after `QAbstractItemModelTester`, so the tester's constructor-time validation warnings go untrapped — swap so `WarningTrap` precedes the tester (applies to all four pairs: lines 77–78, 94–95, 121–122, 251–252) — `test/test_map_model.cpp`
+
+### False positives
+- (none)

--- a/src/camp2/map/layer.cpp
+++ b/src/camp2/map/layer.cpp
@@ -69,7 +69,21 @@ void Layer::updateFlags(Qt::ItemFlags& flags) const
   flags |= Qt::ItemIsEditable;
   flags |= Qt::ItemIsUserCheckable;
   flags |= Qt::ItemIsDragEnabled;
-  flags |= Qt::ItemIsDropEnabled;
+  // [#84] A leaf layer must NOT be drop-enabled. Reordering happens by dropping
+  // a layer onto the gap between rows, which targets the LayerList (the layer's
+  // parent) and is handled by Map::dropMimeData. When the drop lands in the
+  // middle of a *row*, QAbstractItemView treats it as a drop ONTO that row
+  // (OnItem) — but only converts it to an Above/Below (between-row) drop if the
+  // target row is not ItemIsDropEnabled (see QAbstractItemViewPrivate::position).
+  // A Layer has no working canDropMimeData (MapItem's returns false: layers are
+  // not drop containers), so leaving the flag set made every mid-row drop read
+  // as a forbidden OnItem drop — reordering only worked in the thin between-row
+  // margins, which presented as "drops only land at the first spot". Dropping
+  // the flag lets OnItem become a between-row drop everywhere, so the reorder
+  // works wherever the row is. Some Layer subclasses (markers, grids) already
+  // nest children, but none accept drops, so this is correct for all of them
+  // today. A layer that should accept drops *into* it must re-add this flag
+  // *and* override canDropMimeData.
 }
 
 void Layer::readSettings()

--- a/test/test_map_model.cpp
+++ b/test/test_map_model.cpp
@@ -19,6 +19,7 @@
 
 #include <QApplication>
 #include <QAbstractItemModelTester>
+#include <QMimeData>
 
 #include "map/map.h"
 #include "map/layer.h"

--- a/test/test_map_model.cpp
+++ b/test/test_map_model.cpp
@@ -136,6 +136,140 @@ TEST(MapModel, ReorderKeepsModelValid)
   EXPECT_EQ(trap.messages(), 0) << "model-protocol warning during reorder";
 }
 
+// ---- helpers for the drag-drop reorder path (issue #84) ----
+
+namespace
+{
+// Index of the LayerList container under the model root.
+QModelIndex layerListIndex(Map& map)
+{
+  const int n = map.rowCount(QModelIndex());
+  for(int i = 0; i < n; ++i)
+  {
+    auto idx = map.index(i, 0, QModelIndex());
+    if(reinterpret_cast<MapItem*>(idx.internalPointer()) == map.topLevelLayers())
+      return idx;
+  }
+  return QModelIndex();
+}
+
+// Display order (top -> bottom) of layer names under the LayerList.
+QStringList displayOrder(Map& map)
+{
+  QStringList out;
+  auto parent = layerListIndex(map);
+  const int n = map.rowCount(parent);
+  for(int i = 0; i < n; ++i)
+    out << map.index(i, 0, parent).data(Qt::EditRole).toString();
+  return out;
+}
+
+// Index of the layer named `name` under the LayerList (search by display).
+QModelIndex layerIndex(Map& map, const QString& name)
+{
+  auto parent = layerListIndex(map);
+  const int n = map.rowCount(parent);
+  for(int i = 0; i < n; ++i)
+  {
+    auto idx = map.index(i, 0, parent);
+    if(idx.data(Qt::EditRole).toString() == name)
+      return idx;
+  }
+  return QModelIndex();
+}
+
+// Drive a reorder exactly as the view does: build the model's own mime for the
+// dragged layer, then ask the model to drop it at display `row` under LayerList.
+bool dropLayerAt(Map& map, const QString& name, int row)
+{
+  auto src = layerIndex(map, name);
+  auto* mime = map.mimeData({src});
+  bool ok = map.dropMimeData(mime, Qt::MoveAction, row, 0, layerListIndex(map));
+  delete mime;
+  return ok;
+}
+} // namespace
+
+// [#84] Drag-drop reorder regression coverage for the Layers tab.
+//
+// The "drops only land at the first spot" bug was a view/flags interaction, not
+// a model-math bug: a leaf Layer was ItemIsDropEnabled, so a drop in the middle
+// of its row stayed an OnItem drop (which Map::dropMimeData rejects) instead of
+// being converted by QAbstractItemView to an Above/Below drop targeting the
+// LayerList. These tests lock both halves of the fix:
+//   1. flag contract — a leaf layer is draggable but NOT a drop target, while
+//      the LayerList container is; this is what makes the view convert mid-row
+//      drops into between-row (reorderable) drops.
+//   2. drop-path correctness — driving Map::dropMimeData through the LayerList
+//      parent (the exact call the view makes for a between-row drop) places the
+//      layer at the requested display row.
+
+// A leaf layer must be drag-enabled but not drop-enabled (see Layer::updateFlags).
+TEST(MapModel, LeafLayerIsDraggableNotDroppable)
+{
+  Map map;
+  new Layer(map.topLevelLayers(), "leaf");
+  auto idx = layerIndex(map, "leaf");
+  ASSERT_TRUE(idx.isValid());
+  const auto f = map.flags(idx);
+  EXPECT_TRUE(f & Qt::ItemIsDragEnabled) << "layer should be draggable";
+  EXPECT_FALSE(f & Qt::ItemIsDropEnabled)
+      << "a drop-enabled leaf layer keeps mid-row drops as forbidden OnItem drops "
+         "(issue #84) — reordering then only works in the between-row margins";
+}
+
+// The LayerList container is the reorder drop target.
+TEST(MapModel, LayerListAcceptsDrops)
+{
+  Map map;
+  auto idx = layerListIndex(map);
+  // Guard against a false pass: flags() on an invalid index does not reflect the
+  // LayerList's own flags, so the EXPECT below would be meaningless.
+  ASSERT_TRUE(idx.isValid());
+  EXPECT_TRUE(map.flags(idx) & Qt::ItemIsDropEnabled);
+}
+
+// Dropping a layer at a display row reorders it there — and keeps the model
+// protocol valid (no QAbstractItemModelTester warnings) on the drop path.
+TEST(MapModel, DropReordersToTargetRow)
+{
+  // Each case: drag `who` to display `row`; expect `who` at display index `at`
+  // among the three user layers. Initial display order is [c, b, a, defaults...]
+  // (last-created renders on top, so shows first). Standard Qt move-before-row
+  // semantics: an item dragged downward past its own slot lands one row earlier.
+  struct Case { const char* who; int row; int at; };
+  const Case cases[] = {
+    {"a", 0, 0},  // bottom layer to the very top
+    {"a", 1, 1},  // bottom layer into the middle
+    {"c", 2, 1},  // top layer dragged down one slot (before old row 2 -> lands at 1)
+    {"c", 3, 2},  // top layer to the bottom of the user layers
+  };
+
+  for(const auto& c : cases)
+  {
+    Map m;
+    QAbstractItemModelTester tester(&m, QAbstractItemModelTester::FailureReportingMode::Warning);
+    WarningTrap trap;
+    new Layer(m.topLevelLayers(), "a");
+    new Layer(m.topLevelLayers(), "b");
+    new Layer(m.topLevelLayers(), "c");
+
+    // The row numbers above assume the user layers occupy the top three display
+    // rows in this order. Map seeds default tile layers (openstreetmap, etc.)
+    // below them; assert the prefix so a change to those defaults fails loudly
+    // here instead of silently shifting what each `row` means.
+    ASSERT_EQ(displayOrder(m).mid(0, 3), (QStringList{"c", "b", "a"}));
+
+    ASSERT_TRUE(dropLayerAt(m, c.who, c.row)) << "drop " << c.who << " @ row " << c.row;
+    const auto order = displayOrder(m);
+    EXPECT_EQ(order.indexOf(c.who), c.at)
+        << "drop " << c.who << " @ row " << c.row
+        << " -> " << order.join(",").toStdString();
+    EXPECT_EQ(trap.messages(), 0)
+        << "model-protocol warning on drop " << c.who << " @ row " << c.row;
+  }
+}
+
 int main(int argc, char** argv)
 {
   // Map builds a QGraphicsScene and MapItem ctors touch qApp, so a QApplication

--- a/test/test_map_model.cpp
+++ b/test/test_map_model.cpp
@@ -74,8 +74,8 @@ QList<MapItem*> topLevelLayerItems(Map& map)
 TEST(MapModel, StackedInsertsKeepModelValid)
 {
   Map map;
-  QAbstractItemModelTester tester(&map, QAbstractItemModelTester::FailureReportingMode::Warning);
   WarningTrap trap;
+  QAbstractItemModelTester tester(&map, QAbstractItemModelTester::FailureReportingMode::Warning);
 
   const int before = topLevelLayerItems(map).size();
   for(int i = 0; i < 3; ++i)
@@ -91,8 +91,8 @@ TEST(MapModel, StackedInsertsKeepModelValid)
 TEST(MapModel, DetachAndDeleteRemovesOneRow)
 {
   Map map;
-  QAbstractItemModelTester tester(&map, QAbstractItemModelTester::FailureReportingMode::Warning);
   WarningTrap trap;
+  QAbstractItemModelTester tester(&map, QAbstractItemModelTester::FailureReportingMode::Warning);
 
   const int before = topLevelLayerItems(map).size();
   Layer* a = new Layer(map.topLevelLayers(), "a");
@@ -118,8 +118,8 @@ TEST(MapModel, DetachAndDeleteRemovesOneRow)
 TEST(MapModel, ReorderKeepsModelValid)
 {
   Map map;
-  QAbstractItemModelTester tester(&map, QAbstractItemModelTester::FailureReportingMode::Warning);
   WarningTrap trap;
+  QAbstractItemModelTester tester(&map, QAbstractItemModelTester::FailureReportingMode::Warning);
 
   const int before = topLevelLayerItems(map).size();
   Layer* a = new Layer(map.topLevelLayers(), "a");
@@ -248,8 +248,8 @@ TEST(MapModel, DropReordersToTargetRow)
   for(const auto& c : cases)
   {
     Map m;
-    QAbstractItemModelTester tester(&m, QAbstractItemModelTester::FailureReportingMode::Warning);
     WarningTrap trap;
+    QAbstractItemModelTester tester(&m, QAbstractItemModelTester::FailureReportingMode::Warning);
     new Layer(m.topLevelLayers(), "a");
     new Layer(m.topLevelLayers(), "b");
     new Layer(m.topLevelLayers(), "c");


### PR DESCRIPTION
## Summary

Fixes the Layers-tab drag-drop reorder bug (#84): reordering a layer "only landed at the first spot."

**Root cause** (view/flags interaction, not model math): leaf layers in `camp::map::Map` were `ItemIsDropEnabled`, but `Layer` inherits `MapItem::canDropMimeData` which returns `false` — no leaf layer is a working drop target. With the row drop-enabled, `QAbstractItemView` keeps a drop in the middle of a layer row as an `OnItem` drop, which `Map::dropMimeData` rejects (`col == -1`). Only the thin between-row margins (parent = `LayerList`) succeeded, which presented as "drops only land at the first spot."

**Fix:** drop `Qt::ItemIsDropEnabled` from leaf layers (they stay drag-enabled). `QAbstractItemViewPrivate::position` then converts a mid-row `OnItem` drop into an Above/Below (between-row) drop targeting the `LayerList` — the path that already reorders correctly. The `LayerList` container remains the drop target.

## Verification

- Traced the drop path and confirmed at the model level (via a temporary diagnostic harness, now replaced by assertions) that `dropMimeData` through the `LayerList` parent already reorders every layer to the requested display row with **zero** `QAbstractItemModelTester` warnings — so the bug was purely the view not routing mid-row drops to that path.
- `test_map_model` (6 tests) passes.

## Tests added to `test/test_map_model.cpp`

- `LeafLayerIsDraggableNotDroppable` — locks the flag contract (drag yes, drop no) that makes the view convert mid-row drops.
- `LayerListAcceptsDrops` — the container is the drop target (guards against a false pass on an invalid index).
- `DropReordersToTargetRow` — drives `Map::dropMimeData` through the `LayerList` parent at several rows and asserts the resulting display order, with a clean `QAbstractItemModelTester` on the drop path. Asserts the initial layer order so the implicit dependency on Map's default tile layers fails loudly if those change.

## Known limitation

These are model-level tests. The literal #84 trigger — the view-side `OnItem`→`Above/Below` conversion — depends on Qt `QTreeView` behavior that a unit test cannot drive; the suite locks the fix's preconditions and the drop-path correctness, not the end-to-end drag. Worth a quick manual confirm in the running sim (drag a layer in the Layers tab and drop it mid-row onto another layer).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
