### PR TITLE
Fix mission-item delete crash (#86) and rename regression (#85)

### DIFF
--- a/.agent/work-plans/issue-86/plan.md
+++ b/.agent/work-plans/issue-86/plan.md
@@ -1,0 +1,73 @@
+---
+issue: 86
+---
+
+# Issue #86 — CAMP: crashes when deleting mission items
+
+## Problem
+
+CAMP crashed repeatably when deleting mission items (waypoint / line / task)
+during 2026-06-09 student operations. The prior delete-crash fix #65 (`50ad308`,
+2026-06-07) hardened the `AutonomousVehicleProject` selection/group bookkeeping
+and the multi-select topmost-resolution, but a residual use-after-free survives.
+
+## Root cause
+
+The five **detail panels** in the right-hand pane each store a **raw pointer**
+to the mission item they display, and that pointer is **never cleared when the
+item is deleted**:
+
+| Panel | Pointer | Guards on deref slots? |
+|-------|---------|------------------------|
+| `WaypointDetails` | `m_waypoint` | `onLocationChanged()` **unguarded** |
+| `TrackLineDetails` | `m_trackLine` | `onTrackLineUpdated()` **unguarded**; pointer also uninitialized in ctor |
+| `SurveyPatternDetails` | `m_surveyPattern` | `onSurveyPatternUpdated()` / `updateSurveyPattern()` **unguarded**; pointer also uninitialized in ctor |
+| `BehaviorDetails` | `m_behavior` | `if(m_behavior)` — **useless**: dangling-but-non-null after delete |
+| `OrbitDetails` | `orbit_` | `if(orbit_)` — **useless**: dangling-but-non-null after delete |
+
+`DetailsView::onCurrentItemChanged()` hides the panel when the selection goes
+invalid but does **not** clear these pointers (detailsview.cpp:138-142). When a
+displayed item is deleted, the panel keeps a dangling pointer; the next
+interaction with the (briefly still-focused) panel — a `editingFinished` /
+`textChanged` / `stateChanged` slot, or a queued `…Updated` signal — dereferences
+freed memory. The `if(ptr)` guards on Orbit/Behavior do not help because the raw
+pointer is never set to null, so the guard tests a stale non-null value. This
+matches the operator report of *several* crashes (interaction-timing dependent,
+not every delete).
+
+A secondary hazard: `AutonomousVehicleProject::deleteItem()` does a **synchronous
+`delete item`** in the middle of the `beginRemoveRows … endRemoveRows` model
+cascade (autonomousvehicleproject.cpp:862-865), rather than the safer
+`deleteLater()` idiom the camp2 layer-delete path already uses (layer.cpp:54-64).
+
+## Fix
+
+1. **Detail-panel pointer lifetime (root-cause fix).** Change each panel's stored
+   raw pointer to `QPointer<T>` (auto-nulls on `QObject` destruction —
+   `MissionItem : QObject`). This makes the existing `if(ptr)` guards correct and
+   the uninitialized-pointer cases safe (QPointer default-constructs to null).
+   Add `if(!ptr) return;` guards to the unguarded deref slots
+   (`onLocationChanged`, `onTrackLineUpdated`, `onSurveyPatternUpdated`,
+   `updateSurveyPattern`).
+
+2. **Deferred deletion (defense-in-depth).** In `deleteItem()`, complete the
+   `beginRemoveRows / removeChildMissionItem / endRemoveRows` model removal with
+   the item still alive, then `item->deleteLater()` — mirroring the camp2 layer
+   pattern so connected slots unwind before the object dies.
+
+## Verification
+
+- Build `camp`.
+- Sim repro: load/build a mission, select then delete each item type (waypoint,
+  trackline with child waypoints, survey pattern, survey area, behavior, orbit,
+  and a whole-mission multi-select) while its detail panel is shown. No crash.
+
+## Testability gap (follow-up)
+
+A CI `QAbstractItemModelTester` harness for the delete path (mirroring
+`test/test_map_model.cpp` for the camp2 map model) is **blocked**: the mission
+model (`AutonomousVehicleProject` + mission items) is compiled directly into the
+`CCOMAutonomousMissionPlanner` executable and pulls in ROS deps via
+`mission_manager.h` / `platform.h` — there is no library seam like `camp_map` to
+link against. Extracting a ROS-free mission-model library is a separate,
+larger refactor. File a follow-up issue.

--- a/.agent/work-plans/issue-86/progress.md
+++ b/.agent/work-plans/issue-86/progress.md
@@ -1,0 +1,33 @@
+---
+issue: 86
+---
+
+# Issue #86 — CAMP: crashes when deleting mission items
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-10 11:35 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: changes-requested → addressed
+
+**Branch**: feature/issue-86 at `6acabc5`
+**Mode**: pre-push
+**Depth**: Deep (reason: use-after-free / lifecycle fix in a deployed safety-relevant GUI)
+**Static analysis**: skipped (pre-commit/ament; clang LSP noise only — no Qt include paths)
+**Copilot Adversarial**: run (2 cross-model passes)
+**Must-fix**: 2 | **Suggestions**: 0
+
+### Findings
+- [x] (must-fix, Copilot) `MainWindow::setCurrent` dereferenced `itemFromIndex(index)` with no null check; `currentChanged` fires with an invalid index when the selected item is deleted → synchronous null-deref crash. Likely the primary #86 crash. Fixed: null-guard + clear fields — `src/camp/mainwindow.cpp:177`
+- [x] (must-fix, Copilot) `deleteItem` used `pi`/`rownum` unguarded; `pi` null for orphaned parent and `rownum == -1` for already-detached item → `beginRemoveRows(p,-1,-1)` asserts (window widened by the new `deleteLater`). Fixed: `rownum < 0` guard + free without touching model rows — `src/camp/autonomousvehicleproject.cpp:860`
+
+### Confirmed correct (Claude adversarial, independent)
+- QPointer valid for all five panel types (`MissionItem : QObject`; QObject is first base in the multiple-inheritance chain).
+- `delete`→`deleteLater()` introduces no new model-protocol inconsistency: `removeChildMissionItem` is synchronous, so `rowCount`/child indexing stay consistent; only the C++ free is deferred. Strictly safer for the `deleteItems()` topmost-ancestor walk.
+- No remaining unguarded QPointer derefs in the five detail panels after the fix.
+
+### Out-of-scope observations (pre-existing on jazzy, not fixed here)
+- `SurveyPatternDetails::setSurveyPattern` / `TrackLineDetails::setTrackLine` reconnect their update signal without disconnecting the prior connection. Benign (connections die with the item); untouched.
+
+### Testability gap (follow-up)
+- No CI `QAbstractItemModelTester` harness for the delete path: the mission model is welded into the `CCOMAutonomousMissionPlanner` executable (ROS deps via `mission_manager.h`/`platform.h`), with no `camp_map`-style library seam. Extracting a ROS-free mission-model library is a separate refactor — file a follow-up.

--- a/src/camp/autonomousvehicleproject.cpp
+++ b/src/camp/autonomousvehicleproject.cpp
@@ -858,7 +858,18 @@ void AutonomousVehicleProject::deleteItem(const QModelIndex &index)
     // via the Layers-tab Remove action (see onChartLayerRemoved).
     QModelIndex p = parent(index);
     MissionItem * pi = itemFromIndex(p);
-    int rownum = pi->childMissionItems().indexOf(item);
+    // [#86] Guard the parent/row lookup. pi is null if parent(index) is invalid
+    // (an orphaned or root-edge item); rownum is -1 if the item is no longer in
+    // its parent's child list (a re-entrant or double delete reaching a still-
+    // alive, already-detached item — a window the deleteLater() below widens).
+    // Either way there is nothing to remove from the model: just free the item.
+    // beginRemoveRows(p,-1,-1) would otherwise be an invalid range and assert.
+    int rownum = pi ? pi->childMissionItems().indexOf(item) : -1;
+    if(rownum < 0)
+    {
+        item->deleteLater();
+        return;
+    }
     // [#86] Complete the model removal with the item still alive, then defer the
     // delete. The old synchronous `delete item` ran mid-cascade (before
     // endRemoveRows), so any slot reached by endRemoveRows' currentChanged could

--- a/src/camp/autonomousvehicleproject.cpp
+++ b/src/camp/autonomousvehicleproject.cpp
@@ -915,6 +915,19 @@ MissionItem * AutonomousVehicleProject::currentSelected() const
     return m_currentSelected;
 }
 
+void AutonomousVehicleProject::renameItem(MissionItem * item, const QString & label)
+{
+    // [#85] Apply the new label and tell the view. data() returns objectName for
+    // DisplayRole, so a dataChanged on the item's index (all roles by default) is
+    // what makes the tree refresh the displayed name after a rename.
+    if(!item)
+        return;
+    item->setObjectName(label);
+    QModelIndex idx = indexFromItem(item);
+    if(idx.isValid())
+        emit dataChanged(idx, idx);
+}
+
 QModelIndex AutonomousVehicleProject::index(int row, int column, const QModelIndex& parent) const
 {
     if(column != 0 || row < 0)

--- a/src/camp/autonomousvehicleproject.cpp
+++ b/src/camp/autonomousvehicleproject.cpp
@@ -859,10 +859,16 @@ void AutonomousVehicleProject::deleteItem(const QModelIndex &index)
     QModelIndex p = parent(index);
     MissionItem * pi = itemFromIndex(p);
     int rownum = pi->childMissionItems().indexOf(item);
+    // [#86] Complete the model removal with the item still alive, then defer the
+    // delete. The old synchronous `delete item` ran mid-cascade (before
+    // endRemoveRows), so any slot reached by endRemoveRows' currentChanged could
+    // touch a freed object. deleteLater() — the same idiom the camp2 layer-delete
+    // path uses (camp::map::Layer::removeFromMap) — lets connected slots unwind
+    // first; QPointer observers in the detail panels null out when it finally dies.
     beginRemoveRows(p,rownum,rownum);
     pi->removeChildMissionItem(item);
-    delete item;
     endRemoveRows();
+    item->deleteLater();
 }
 
 void AutonomousVehicleProject::deleteItem(MissionItem *item)

--- a/src/camp/autonomousvehicleproject.h
+++ b/src/camp/autonomousvehicleproject.h
@@ -114,6 +114,12 @@ public:
     QModelIndex index(int row, int column, const QModelIndex & parent) const override;
     QModelIndex parent(const QModelIndex & child) const override;
     QModelIndex indexFromItem(MissionItem * item) const;
+
+    // [#85] Rename a mission item and notify the view. setObjectName alone
+    // changes the label the tree displays (data() returns objectName for
+    // DisplayRole) but emits no model signal, so the view never refreshes —
+    // the rename silently has no visible effect. Route renames through here.
+    void renameItem(MissionItem * item, const QString & label);
     
     Qt::DropActions supportedDropActions() const override;
     

--- a/src/camp/behaviordetails.h
+++ b/src/camp/behaviordetails.h
@@ -2,6 +2,7 @@
 #define BEHAVIORDETAILS_H
 
 #include <QWidget>
+#include <QPointer>
 
 namespace Ui
 {
@@ -27,7 +28,7 @@ private slots:
 
 private:
     Ui::BehaviorDetails* ui;
-    Behavior *m_behavior;
+    QPointer<Behavior> m_behavior;
 };
 
 #endif // BEHAVIORDETAILS_H

--- a/src/camp/detailsview.cpp
+++ b/src/camp/detailsview.cpp
@@ -154,7 +154,7 @@ void DetailsView::onRenamedPushButton_clicked()
                                          tr("New label:"), QLineEdit::Normal,
                                          mi->objectName(), &ok);
     if (ok && !text.isEmpty())
-        mi->setObjectName(text);
+        m_project->renameItem(mi, text);
     }
 }
 

--- a/src/camp/mainwindow.cpp
+++ b/src/camp/mainwindow.cpp
@@ -175,6 +175,19 @@ void MainWindow::setCurrent(const QModelIndex &index, const QModelIndex &previou
     //m_ui->treeView->setCurrentIndex(index);
     //project->setCurrent(index);
     MissionItem* i = project->itemFromIndex(index);
+    // [#86] currentChanged fires with an invalid index when the selection is
+    // cleared — which happens when the selected mission item is deleted
+    // (endRemoveRows leaves no current row, e.g. last item or a whole-mission
+    // select-all delete). itemFromIndex then returns nullptr; dereferencing it
+    // here was a synchronous crash on the delete path. Clear the fields instead.
+    if(!i)
+    {
+        m_ui->speedLineEdit->clear();
+        m_ui->throttleLineEdit->clear();
+        m_ui->priorityLineEdit->clear();
+        m_ui->taskDataLineEdit->clear();
+        return;
+    }
     m_ui->speedLineEdit->setText(QString::number(i->speed()));
     emit speedUpdated(i->speed());
     m_ui->throttleLineEdit->setText(QString::number(i->throttle()*100.0));

--- a/src/camp/orbitdetails.h
+++ b/src/camp/orbitdetails.h
@@ -2,6 +2,7 @@
 #define ORBITDETAILS_H
 
 #include <QWidget>
+#include <QPointer>
 #include "ui_orbitdetails.h"
 
 
@@ -28,7 +29,7 @@ private slots:
 
 private:
     Ui::OrbitDetails ui_;
-    Orbit * orbit_ = nullptr;
+    QPointer<Orbit> orbit_;
 };
 
 #endif

--- a/src/camp/surveypatterndetails.cpp
+++ b/src/camp/surveypatterndetails.cpp
@@ -31,6 +31,8 @@ void SurveyPatternDetails::setSurveyPattern(SurveyPattern *surveyPattern)
 
 void SurveyPatternDetails::onSurveyPatternUpdated()
 {
+    if(!m_surveyPattern)
+        return;
     if(!updating)
     {
         m_updating_ui = true;
@@ -44,6 +46,8 @@ void SurveyPatternDetails::onSurveyPatternUpdated()
 
 void SurveyPatternDetails::updateSurveyPattern()
 {
+    if(!m_surveyPattern)
+        return;
     updating = true;
     m_surveyPattern->setDirectionAndSpacing(ui->headingDoubleSpinBox->value(),ui->lineSpacingEdit->text().toDouble());
     m_surveyPattern->setLineLength(ui->lineLengthLineEdit->text().toDouble());

--- a/src/camp/surveypatterndetails.h
+++ b/src/camp/surveypatterndetails.h
@@ -2,6 +2,7 @@
 #define SURVEYPATTERNDETAILS_H
 
 #include <QWidget>
+#include <QPointer>
 
 namespace Ui {
 class SurveyPatternDetails;
@@ -39,7 +40,7 @@ private slots:
 private:
     Ui::SurveyPatternDetails *ui;
 
-    SurveyPattern * m_surveyPattern;
+    QPointer<SurveyPattern> m_surveyPattern;
     QMetaObject::Connection m_connection;
     bool updating;
     bool m_updating_ui = false;

--- a/src/camp/tracklinedetails.cpp
+++ b/src/camp/tracklinedetails.cpp
@@ -23,5 +23,7 @@ void TrackLineDetails::setTrackLine(TrackLine *trackLine)
 
 void TrackLineDetails::onTrackLineUpdated()
 {
+    if(!m_trackLine)
+        return;
     ui->label->setText(QString::number(m_trackLine->waypoints().length())+" waypoints");
 }

--- a/src/camp/tracklinedetails.h
+++ b/src/camp/tracklinedetails.h
@@ -2,6 +2,7 @@
 #define TRACKLINEDETAILS_H
 
 #include <QWidget>
+#include <QPointer>
 
 namespace Ui {
 class TrackLineDetails;
@@ -23,7 +24,7 @@ public slots:
 
 private:
     Ui::TrackLineDetails *ui;
-    TrackLine *m_trackLine;
+    QPointer<TrackLine> m_trackLine;
 };
 
 #endif // TRACKLINEDETAILS_H

--- a/src/camp/waypointdetails.cpp
+++ b/src/camp/waypointdetails.cpp
@@ -28,6 +28,8 @@ void WaypointDetails::setWaypoint(Waypoint *waypoint)
 
 void WaypointDetails::onLocationChanged()
 {
+    if(!m_waypoint)
+        return;
     //qDebug() << m_waypoint->location();
     //ui->latDisplayLabel->setText(QString::number(m_waypoint->location().latitude(),'f',8));
     //ui->lonDisplayLabel->setText(QString::number(m_waypoint->location().longitude(),'f',8));

--- a/src/camp/waypointdetails.h
+++ b/src/camp/waypointdetails.h
@@ -2,6 +2,7 @@
 #define WAYPOINTDETAILS_H
 
 #include <QWidget>
+#include <QPointer>
 
 namespace Ui {
 class WaypointDetails;
@@ -27,7 +28,7 @@ private slots:
 
 private:
     Ui::WaypointDetails *ui;
-    Waypoint * m_waypoint;
+    QPointer<Waypoint> m_waypoint;
 
     QMetaObject::Connection moveConnection;
 


### PR DESCRIPTION
## Summary

Fixes mission-item manipulation bugs reported during 2026-06-09 student
operations: repeatable **crashes when deleting** mission items (#86) and the
**broken rename** of mission items (#85). The prior delete-crash fix (#65)
hardened `AutonomousVehicleProject`'s own selection bookkeeping; this PR fixes the
**residual** use-after-free / null-deref hazards that survived it, plus the rename
regression.

## Delete crash (#86)

**1. Detail panels held dangling raw pointers.**
The five mission detail panels (`WaypointDetails`, `TrackLineDetails`,
`SurveyPatternDetails`, `BehaviorDetails`, `OrbitDetails`) stored a raw pointer to
the item they display and never cleared it when the item was deleted. After a
delete the next interaction (an `editingFinished` / `textChanged` / `…Updated`
slot on the briefly-still-focused panel) dereferenced freed memory. The `if(ptr)`
guards on Orbit/Behavior didn't help — the raw pointer was never nulled.
Resolved by storing as `QPointer<T>` (auto-nulls on `QObject` destruction;
`MissionItem : QObject`), making the existing guards correct, plus `if(!ptr)
return` guards on the unguarded deref slots.

**2. `MainWindow::setCurrent` null-derefed on deselection.**
Connected to `currentChanged`, it dereferenced `itemFromIndex(index)` with no null
check. `currentChanged` fires with an invalid index when the selection is cleared
— exactly what happens when the selected item is deleted (`endRemoveRows` leaves
no current row; e.g. deleting the last item or a whole-mission select-all). This
was a **synchronous** crash on the delete path and is likely the primary #86
crash. Resolved by null-guarding and clearing the fields.

**3. `deleteItem` lifecycle hardening.**
`deleteItem` did a synchronous `delete item` mid-`beginRemoveRows…endRemoveRows`
cascade. Resolved by completing the model removal with the item alive, then
`item->deleteLater()` (mirroring the camp2 `Layer::removeFromMap` idiom). Also
guards `pi`-null / `rownum < 0` so a stale or re-entrant index can't pass an
invalid range to `beginRemoveRows`.

## Rename regression (#85)

The Rename button set `mi->setObjectName(text)` directly. `data()` returns
`objectName` for `DisplayRole`, but `setObjectName` emits no model signal, so the
tree never re-queried and the new label stayed invisible — the rename looked
broken even though the name had changed. Resolved by adding
`AutonomousVehicleProject::renameItem()`, which applies the label and emits
`dataChanged` for the item's index, with the Rename button routed through it.

## Review

Reviewed with `/review-code` (Deep). Two independent adversarial passes
(fresh-context Claude + cross-model Copilot CLI). The Copilot pass caught the
`MainWindow::setCurrent` null-deref and the `deleteItem` guards, which the first
pass missed — both addressed. See `.agent/work-plans/issue-86/progress.md`.

## Testing

- `camp` builds clean.
- Delete paths **verified in sim** (waypoint / line / task / whole-mission select).
- Rename **pending sim re-check** (relaunch CAMP to pick up the new binary): select
  an item → **Rename** button → new label updates in the tree.

A CI `QAbstractItemModelTester` harness for the mission-model paths is blocked by
the model being welded into the app executable (no library seam) — tracked in #89.

Closes #86
Closes #85

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
