### PR TITLE
main: ignore empty command-line args (don't openBackground(''))

### DIFF
--- a/src/camp/main.cpp
+++ b/src/camp/main.cpp
@@ -27,6 +27,8 @@ int main(int argc, char *argv[])
     for(std::size_t i = 1; i < args.size(); i++)
     {
         QString arg(args[i].c_str());
+        if(arg.isEmpty())  // empty arg (e.g. an empty background_chart) -> ignore
+            continue;
         if(arg.endsWith(".json", Qt::CaseInsensitive))
             //w.open(arg);
             QMetaObject::invokeMethod(&w, "open", Qt::QueuedConnection, Q_ARG(QString, arg));


### PR DESCRIPTION
Closes #91.

CAMP's command-line loop (`src/camp/main.cpp:27-38`) treats any arg that isn't
`.json` or a directory as a background chart → `openBackground(arg)`, with no
empty guard. An empty arg therefore calls `openBackground('')`.

This bites callers that pass the background chart positionally but want **no
chart**: `marine_autonomy/operator_ui_launch.py` always launches CAMP with
`arguments=[<workspace>, background_chart]`, and with `background_chart=''` (the
BizzyBoat-Massabesic sim — rolker/unh_marine_simulation#69) that reaches CAMP as
a real empty `argv` entry (verified: ROS 2 launch passes an empty-string arg
through as an empty `argv`, ARGC includes it).

Fix: skip empty args at the top of the loop (`if (arg.isEmpty()) continue;`).
"No background chart" is also the correct long-term behavior as the map code
moves off background charts. camp builds clean.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
