### PR TITLE
ais: remove dead legacy marine_interfaces/Contact references (frees the Contact name)

### DIFF
--- a/.agent/work-plans/issue-93/plan.md
+++ b/.agent/work-plans/issue-93/plan.md
@@ -1,0 +1,87 @@
+# Plan: ais: remove dead legacy marine_interfaces/Contact references (frees the Contact name)
+
+## Issue
+
+https://github.com/rolker/camp/issues/93
+
+## Context
+
+CAMP's live AIS path runs entirely on `marine_ais_msgs/msg/AISContact`:
+`AISManager::scanForSources` subscribes only to `marine_ais_msgs/msg/AISContact`
+(`ais_manager.cpp:30,36`) → `aisContactCallback` (`:46`), fed by
+`marine_ais_tools/ais_contact_tracker.py`.
+
+The legacy `marine_interfaces::msg::Contact` surface in `ais/*` is dead:
+- `AISManager::contactCallback` is **declared** (`ais_manager.h:40`) but has **no
+  definition** in `ais_manager.cpp` and is never connected to a subscription.
+- The three `const marine_interfaces::msg::Contact&` constructor overloads in
+  `ais_contact.{h,cpp}` have no callers (the live path uses the `AISContact`
+  overloads).
+- Nothing in-tree publishes `marine_interfaces/Contact`.
+
+Removing this dead code frees the `Contact` name so `rolker/unh_marine_autonomy#156`
+can redefine `Contact` as the unified perception contact. This is the prerequisite
+cleanup; #156 task 4 (deleting `marine_interfaces/msg/Contact.msg`) must wait until
+this merges or camp's build breaks on the missing `contact.hpp`.
+
+## Approach
+
+1. **`ais_contact.h`** — remove the legacy `Contact` declarations:
+   - delete `#include "marine_interfaces/msg/contact.hpp"` (line 6)
+   - delete `AISContactDetails(const marine_interfaces::msg::Contact&)` (line 15)
+   - delete `AISContactState(const marine_interfaces::msg::Contact&)` (line 28)
+   - delete `AISReport(const marine_interfaces::msg::Contact&, QObject*)` (line 42)
+2. **`ais_contact.cpp`** — remove the matching definitions:
+   - `AISContactDetails(const marine_interfaces::msg::Contact&)` (lines 13–21)
+   - `AISContactState(const marine_interfaces::msg::Contact&)` (lines 39–53)
+   - `AISReport(const marine_interfaces::msg::Contact&, QObject*)` (lines 93–99)
+3. **`ais_manager.h`** — remove `#include "marine_interfaces/msg/contact.hpp"`
+   (line 5) and the dangling `void contactCallback(const marine_interfaces::msg::Contact&)`
+   declaration (line 40).
+4. **Leave the `marine_interfaces` package dependency in place** —
+   `package.xml`/`CMakeLists.txt` keep it; camp still uses `marine_interfaces` in
+   `mission_manager`, `platform_manager`, `helm_manager`, `nav_source`,
+   `autonomousvehicleproject`. This change touches only `ais/*`.
+5. **Build to verify** — `./ui_ws/build.sh camp` (or build the camp package) to
+   confirm no remaining references and a clean compile.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/camp/ais/ais_contact.h` | Drop legacy `Contact` include + 3 ctor decls |
+| `src/camp/ais/ais_contact.cpp` | Drop the 3 legacy `Contact` ctor definitions |
+| `src/camp/ais/ais_manager.h` | Drop legacy `Contact` include + dead `contactCallback` decl |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Build-verify after removal; confirm no docs reference the removed ctors (none found). Coordinate ordering with #156 task 4 (noted in issue). |
+| Only what's needed | Remove only the dead legacy-`Contact` surface; keep the `marine_interfaces` dep and the live `AISContact` path untouched. |
+| Improve incrementally | Self-contained, reviewable cleanup; no behavior change (dead code only). |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ws ADR-0002 — Worktree isolation | Yes | Work in `issue-camp-93` worktree on `feature/issue-93`; PR into `jazzy`. |
+| ws ADR-0008 — ROS 2 conventions | No | No new package/msg/launch; only removes a message usage. |
+| camp ADR-0003 — backgrounds-as-layers | No | Untouched; the `[#59 ADR-0003]` comments in `ais_contact.cpp` are in the live path and stay. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Remove a message consumer (`ais/*`) | Build still compiles; the `marine_interfaces` dep stays (other packages need it) | Yes — step 4/5 |
+| Frees `Contact` name | `unh_marine_autonomy#156` task 4 may then delete `Contact.msg` | Cross-repo ordering noted in issue; out of scope here |
+
+## Open Questions
+
+- Verification: camp has no CI and no unit tests for `ais/*`, so the gate is a
+  clean build (+ optional sim smoke-check that AIS still renders). Is a build
+  pass sufficient for merge, or do you want a sim-verify of the AIS layer first?
+
+## Estimated Scope
+
+Single small PR (3 files, dead-code removal, no behavior change).

--- a/.agent/work-plans/issue-93/progress.md
+++ b/.agent/work-plans/issue-93/progress.md
@@ -1,0 +1,17 @@
+---
+issue: 93
+---
+
+# Issue #93 — ais: remove dead legacy marine_interfaces/Contact references (frees the Contact name)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-14 11:45 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-93/plan.md` at `a15b6a8`
+**PR**: https://github.com/rolker/camp/pull/94 (`[PLAN]` prefix)
+**Phases**: single
+
+### Open questions
+- [ ] Verification gate: camp has no CI/unit tests for `ais/*` — is a clean build sufficient for merge, or sim-verify the AIS layer renders first?

--- a/.agent/work-plans/issue-93/progress.md
+++ b/.agent/work-plans/issue-93/progress.md
@@ -14,4 +14,20 @@ issue: 93
 **Phases**: single
 
 ### Open questions
-- [ ] Verification gate: camp has no CI/unit tests for `ais/*` — is a clean build sufficient for merge, or sim-verify the AIS layer renders first?
+- [x] Verification gate: build is sufficient (Roland confirmed 2026-06-14 — "build test is enough", no sim-verify needed).
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-14 12:05 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Commit**: `db1ed5f` — ais: remove dead legacy marine_interfaces/Contact references
+**Verification**: `./ui_ws/build.sh camp` — package built clean (2min 4s; only pre-existing unused-parameter warnings in unrelated files).
+
+### What changed
+- Removed 2 `#include "marine_interfaces/msg/contact.hpp"`, 3 legacy `Contact` ctor overloads (`ais_contact.{h,cpp}`), and the dangling `contactCallback` decl (`ais_manager.h`). 40 deletions, no behavior change.
+- `marine_interfaces` package dependency left in place (still used by mission_manager/platform_manager/helm_manager/nav_source).
+- No plan deviations.
+
+### Downstream
+- [ ] Unblocks `rolker/unh_marine_autonomy#156` task 4 (delete `marine_interfaces/msg/Contact.msg`) — only after this PR merges.

--- a/src/camp/ais/ais_contact.cpp
+++ b/src/camp/ais/ais_contact.cpp
@@ -10,16 +10,6 @@ AISContactDetails::AISContactDetails()
 
 }
 
-AISContactDetails::AISContactDetails(const marine_interfaces::msg::Contact& message)
-{
-  mmsi = message.mmsi;
-  name = message.name;
-  dimension_to_bow = message.dimension_to_bow;
-  dimension_to_port = message.dimension_to_port;
-  dimension_to_stbd = message.dimension_to_stbd;
-  dimension_to_stern = message.dimension_to_stern;
-}
-
 AISContactDetails::AISContactDetails(const marine_ais_msgs::msg::AISContact& message)
 {
   mmsi = message.id;
@@ -34,22 +24,6 @@ AISContactDetails::AISContactDetails(const marine_ais_msgs::msg::AISContact& mes
 AISContactState::AISContactState()
 {
 
-}
-
-AISContactState::AISContactState(const marine_interfaces::msg::Contact& message)
-{
-  timestamp = message.header.stamp;
-  location.location.setLatitude(message.position.latitude);
-  location.location.setLongitude(message.position.longitude);
-  if(message.heading < 0)
-    if(message.sog > 0.25)
-      heading = message.cog*180.0/M_PI;
-    else
-      heading = std::nan("");
-  else
-    heading = message.heading*180.0/M_PI;
-  cog = message.cog*180.0/M_PI;
-  sog = message.sog;
 }
 
 AISContactState::AISContactState(const marine_ais_msgs::msg::AISContact& message)
@@ -86,14 +60,6 @@ AISContactState::AISContactState(const marine_ais_msgs::msg::AISContact& message
 }
 
 AISReport::AISReport(QObject *parent):QObject(parent)
-{
-
-}
-
-AISReport::AISReport(const marine_interfaces::msg::Contact& message, QObject *parent):
-  QObject(parent),
-  AISContactDetails(message),
-  AISContactState(message)
 {
 
 }

--- a/src/camp/ais/ais_contact.h
+++ b/src/camp/ais/ais_contact.h
@@ -3,7 +3,6 @@
 
 #include <QObject>
 #include "../ship_track.h"
-#include "marine_interfaces/msg/contact.hpp"
 #include "marine_ais_msgs/msg/ais_contact.hpp"
 #include "../locationposition.h"
 #include "ros/ros_common.h"
@@ -12,7 +11,6 @@
 struct AISContactDetails
 {
   AISContactDetails();
-  AISContactDetails(const marine_interfaces::msg::Contact& message);
   AISContactDetails(const marine_ais_msgs::msg::AISContact& message);
   uint32_t mmsi;
   std::string name;
@@ -25,7 +23,6 @@ struct AISContactDetails
 struct AISContactState
 {
   AISContactState();
-  AISContactState(const marine_interfaces::msg::Contact& message);
   AISContactState(const marine_ais_msgs::msg::AISContact& message);
   rclcpp::Time timestamp;
   LocationPosition location;
@@ -39,7 +36,6 @@ struct AISReport: public QObject, AISContactDetails, AISContactState
   Q_OBJECT
 public:
   AISReport(QObject *parent = nullptr);
-  AISReport(const marine_interfaces::msg::Contact& message, QObject *parent = nullptr);
   AISReport(const marine_ais_msgs::msg::AISContact& message, QObject *parent = nullptr);
 };
 

--- a/src/camp/ais/ais_manager.h
+++ b/src/camp/ais/ais_manager.h
@@ -2,7 +2,6 @@
 #define CAMP_AIS_MANAGER_H
 
 #include "ros/ros_object.h"
-#include "marine_interfaces/msg/contact.hpp"
 #include "marine_ais_msgs/msg/ais_contact.hpp"
 #include "ais_contact.h"
 
@@ -37,7 +36,6 @@ private slots:
   void addAisReport(AISReport *report);
 
 private:
-  void contactCallback(const marine_interfaces::msg::Contact& message);
   void aisContactCallback(const marine_ais_msgs::msg::AISContact& message);
 
   std::map<std::string, rclcpp::Subscription<marine_ais_msgs::msg::AISContact>::SharedPtr > m_sources;


### PR DESCRIPTION
Closes #93

# Plan: ais: remove dead legacy marine_interfaces/Contact references (frees the Contact name)

## Issue

https://github.com/rolker/camp/issues/93

## Context

CAMP's live AIS path runs entirely on `marine_ais_msgs/msg/AISContact`:
`AISManager::scanForSources` subscribes only to `marine_ais_msgs/msg/AISContact`
(`ais_manager.cpp:30,36`) → `aisContactCallback` (`:46`), fed by
`marine_ais_tools/ais_contact_tracker.py`.

The legacy `marine_interfaces::msg::Contact` surface in `ais/*` is dead:
- `AISManager::contactCallback` is **declared** (`ais_manager.h:40`) but has **no
  definition** in `ais_manager.cpp` and is never connected to a subscription.
- The three `const marine_interfaces::msg::Contact&` constructor overloads in
  `ais_contact.{h,cpp}` have no callers (the live path uses the `AISContact`
  overloads).
- Nothing in-tree publishes `marine_interfaces/Contact`.

Removing this dead code frees the `Contact` name so `rolker/unh_marine_autonomy#156`
can redefine `Contact` as the unified perception contact. This is the prerequisite
cleanup; #156 task 4 (deleting `marine_interfaces/msg/Contact.msg`) must wait until
this merges or camp's build breaks on the missing `contact.hpp`.

## Approach

1. **`ais_contact.h`** — remove the legacy `Contact` declarations:
   - delete `#include "marine_interfaces/msg/contact.hpp"` (line 6)
   - delete `AISContactDetails(const marine_interfaces::msg::Contact&)` (line 15)
   - delete `AISContactState(const marine_interfaces::msg::Contact&)` (line 28)
   - delete `AISReport(const marine_interfaces::msg::Contact&, QObject*)` (line 42)
2. **`ais_contact.cpp`** — remove the matching definitions:
   - `AISContactDetails(const marine_interfaces::msg::Contact&)` (lines 13–21)
   - `AISContactState(const marine_interfaces::msg::Contact&)` (lines 39–53)
   - `AISReport(const marine_interfaces::msg::Contact&, QObject*)` (lines 93–99)
3. **`ais_manager.h`** — remove `#include "marine_interfaces/msg/contact.hpp"`
   (line 5) and the dangling `void contactCallback(const marine_interfaces::msg::Contact&)`
   declaration (line 40).
4. **Leave the `marine_interfaces` package dependency in place** —
   `package.xml`/`CMakeLists.txt` keep it; camp still uses `marine_interfaces` in
   `mission_manager`, `platform_manager`, `helm_manager`, `nav_source`,
   `autonomousvehicleproject`. This change touches only `ais/*`.
5. **Build to verify** — `./ui_ws/build.sh camp` (or build the camp package) to
   confirm no remaining references and a clean compile.

## Files to Change

| File | Change |
|------|--------|
| `src/camp/ais/ais_contact.h` | Drop legacy `Contact` include + 3 ctor decls |
| `src/camp/ais/ais_contact.cpp` | Drop the 3 legacy `Contact` ctor definitions |
| `src/camp/ais/ais_manager.h` | Drop legacy `Contact` include + dead `contactCallback` decl |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| A change includes its consequences | Build-verify after removal; confirm no docs reference the removed ctors (none found). Coordinate ordering with #156 task 4 (noted in issue). |
| Only what's needed | Remove only the dead legacy-`Contact` surface; keep the `marine_interfaces` dep and the live `AISContact` path untouched. |
| Improve incrementally | Self-contained, reviewable cleanup; no behavior change (dead code only). |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ws ADR-0002 — Worktree isolation | Yes | Work in `issue-camp-93` worktree on `feature/issue-93`; PR into `jazzy`. |
| ws ADR-0008 — ROS 2 conventions | No | No new package/msg/launch; only removes a message usage. |
| camp ADR-0003 — backgrounds-as-layers | No | Untouched; the `[#59 ADR-0003]` comments in `ais_contact.cpp` are in the live path and stay. |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| Remove a message consumer (`ais/*`) | Build still compiles; the `marine_interfaces` dep stays (other packages need it) | Yes — step 4/5 |
| Frees `Contact` name | `unh_marine_autonomy#156` task 4 may then delete `Contact.msg` | Cross-repo ordering noted in issue; out of scope here |

## Open Questions

- Verification: camp has no CI and no unit tests for `ais/*`, so the gate is a
  clean build (+ optional sim smoke-check that AIS still renders). Is a build
  pass sufficient for merge, or do you want a sim-verify of the AIS layer first?

## Estimated Scope

Single small PR (3 files, dead-code removal, no behavior change).
