### PR TITLE
I4: GGGS-tiled raster map layer (offscreen-FBO warp, store tree, colormap, persistence) (#90)

### DIFF
--- a/.agent/work-plans/issue-90/plan.md
+++ b/.agent/work-plans/issue-90/plan.md
@@ -27,26 +27,31 @@ pan/zoom, and band-select + colormap become **shader uniforms** (instant switch,
 
 ## Approach — slices (stacked PRs on `feature/issue-90`)
 
-**Slice 1 — GL plumbing + registered static tile (de-risks #175 acceptance 1).**
-1. Switch `MapView` viewport to `QOpenGLWidget` so layers can issue native GL; verify
-   existing CPU layers still paint registered over it with a **concrete check**: load a KAP
-   chart (`workspace/13283`), OSM/WMTS tiles, and a marker, confirm registration is
-   pixel-unchanged vs the pre-swap build, and capture a **camp#98 memory baseline**
-   (zoom/pan RSS, GDAL-leak #96) so a regression is detectable. This app-wide viewport swap
-   is the highest-risk step.
-2. New `GggsTileLayer : camp::map::Layer` (pure map, `CAMP_MAP_SOURCES`, no ROS). Load a
-   tile *directory*: glob `*.tif`, read each tile's **native** band + geotransform via GDAL
-   (no warp VRT), upload band as an `R32F` texture; record geographic corner extents.
-3. `paint()` → `beginNativePainting()`: a `QOpenGLShaderProgram` whose **vertex shader
-   replicates `web_mercator::geoToMap` exactly** (R=6378137, `asinh(tan φ)`) over a
-   tessellated mesh. Build the GL MVP from the **live `QPainter::worldTransform()`** (scene→
-   viewport), *not* a hand-rolled ortho — the scene transform is `scale(s, −s)`
-   (`map_view.cpp:19`, math-north → screen-down), so deriving from it makes the Y-flip,
-   pan/zoom, and device-pixel-ratio register automatically. Set GL state explicitly inside
-   the native block: **depth-test off, premultiplied-alpha blend**, so the CPU QPainter
-   layers composite correctly over the GL viewport. Fragment shader = grayscale of the
-   sampled value (sidescan), no-data 0 → transparent. `endNativePainting()`.
-4. `boundingRect()` from the union of tile extents (mapped via `web_mercator::geoToMap`).
+**Slice 1 — GPU warp via offscreen FBO + registered static tile (de-risks #175 acceptance 1).**
+**Rendering decision revised during implementation (2026-06-20):** native GL inside a
+QGraphicsView item (`beginNativePainting`) does **not** get a current GL context on this
+stack — confirmed under a Wayland software backingstore, where the view composites to a
+shared-memory buffer, not a GL surface (it crashed on `QOpenGLFunctions` with a null
+context). Per Roland's call, the layer now renders the GPU warp to an **offscreen
+framebuffer it owns** and presents the result with `QPainter::drawImage()` — portable across
+X11 / Wayland / software GL, and needing **no `QOpenGLWidget` viewport** (that change is
+reverted; no app-wide viewport swap, so the camp#98 risk is moot).
+1. New `GggsTileLayer : camp::map::Layer` (pure map, `CAMP_MAP_SOURCES`, no ROS). Load a tile
+   *directory*: glob `*.tif`, read each tile's **native** band + geotransform via GDAL (no
+   warp VRT), upload band as an `R32F` texture; `boundingRect()` = union of tile extents via
+   `web_mercator::geoToMap`.
+2. The layer owns a `QOpenGLContext` + `QOffscreenSurface`. `renderImage(size)` binds a
+   `QOpenGLFramebufferObject`, draws each tile as a latitude-tessellated mesh through a
+   `QOpenGLShaderProgram` whose **vertex shader replicates `web_mercator::geoToMap` exactly**
+   (R=6378137, `asinh(tan φ)` as `log(t+√(t²+1))`), with an **ortho** mapping the extent to
+   NDC; fragment shader = auto-ranged grayscale, no-data 0 → discard; premultiplied-alpha.
+   `toImage()` returns the warped raster (row 0 = south, so it draws upright once MapView's
+   `scale(s,−s)` view flip puts north up).
+3. `paint()` sizes the render to the extent's on-screen pixels, caches it (re-render on zoom,
+   reuse on pan), and `drawImage(boundingRect(), image)` — registers with the CPU
+   raster/tile/marker layers; no GL needed from the viewport.
+4. Verified headlessly (offscreen GL, no window): `test_gggs_render` warps a synthetic tile
+   and the real store to a QImage; pixel analysis confirms geometry + north-up orientation.
 
 **Slice 2 — warp correctness + multi-tile.** Tune tessellation so Mercator-y error < 0.5 px
 across a tile; confirm shared-edge seams (identical `geoToMap(φ)`) are crack-free; LOD/zoom
@@ -75,10 +80,9 @@ original camp#90 Tier-2 live consumer).
 
 | File | Change |
 |------|--------|
-| `src/camp2/map_view/map_view.cpp` | Set `QOpenGLWidget` viewport (Slice 1) |
-| `src/camp2/raster/gggs_tile_layer.{h,cpp}` | New GL layer: dir load, R32F upload, warp+colormap shaders, paint |
-| `src/camp2/raster/gggs_tile.{h,cpp}` | Per-tile: GDAL native read, geotransform extent, GL texture/mesh, `GridIndex` key |
-| `src/camp2/shaders/*.vert/.frag` (or inline) | geoToMap warp vertex + colormap fragment shaders |
+| `src/camp2/raster/gggs_tile_layer.{h,cpp}` | New layer: dir load, owns offscreen GL context + FBO, warp shaders, `renderImage()`, `drawImage()` in paint (no viewport change) |
+| `src/camp2/raster/gggs_tile.{h,cpp}` | Per-tile: GDAL native read, geotransform extent, lazy R32F texture |
+| inline shaders (in `gggs_tile_layer.cpp`) | geoToMap warp vertex + grayscale fragment (colormap = Slice 3) |
 | `CMakeLists.txt` | Add sources to `CAMP_MAP_SOURCES`; **add `Qt5::Gui` (and `OpenGL` if used) to the `find_package(Qt5 …)` COMPONENTS and the `camp_map` link list** — `QOpenGLShaderProgram`/`QOpenGLFunctions` are in `Qt5::Gui`, `QOpenGLWidget` in `Qt5::Widgets`; don't rely on transitive Widgets |
 | Layer registration (`background_manager.cpp` and/or an "Open tile store" action) | Expose the layer |
 | `test/test_gggs_tile_layer.cpp` | Extent-from-geotransform + **geoToMap parity** (CPU mirror that calls `web_mercator::geoToMap` *directly* so it can't drift from the shader reference; tolerance < 1e-6 relative over φ ∈ [−85°, 85°], sampling Massabesic ~43°N) + no-data unit tests |

--- a/.agent/work-plans/issue-90/plan.md
+++ b/.agent/work-plans/issue-90/plan.md
@@ -1,0 +1,104 @@
+# Plan: GGGS-tiled raster map layer — GPU display-time warp (bathy + sidescan)
+
+## Issue
+
+https://github.com/rolker/camp/issues/90 (broadened; Part of rolker/unh_marine_autonomy#175 and #171)
+
+## Context
+
+camp#90 originally scoped a bathy-only, CPU directory-watching grid layer. Per the
+2026-06-19 decisions it is **broadened** into the unified **GGGS-tiled raster layer**
+(#175 / I4) that renders **both** products from the on-disk tile stores:
+- **sidescan** — 1-band `uint16` backscatter (`marine_sidescan_mosaic` #173, just merged)
+- **bathy** — 3-band `Float64` depth / uncertainty / timestamp (`marine_bathymetry_store`)
+
+Tiles are native-geographic (WGS84) GeoTIFFs named `<level>_<row>_<col>.tif`. CAMP's map
+core (`src/camp2`, Qt 5.15 + GDAL) is **entirely CPU** today: `RasterLayer` GDAL-warps each
+GeoTIFF to EPSG:3857 on load (`raster_layer.cpp:77,125`), colormaps on the CPU
+(`color_map.cpp`), and paints `QPixmap`s in a `QGraphicsScene` (`MapView : QGraphicsView`,
+no GL viewport). #175's decision is to render GGGS tiles via a **GPU display-time warp**
+instead: upload each native lat/lon tile once, warp into Web-Mercator per frame.
+
+**Why GPU warp** (separable): geo→Web-Mercator is `x=R·λ` (longitude linear) and
+`y=R·asinh(tan φ)` (the only nonlinearity, 1-D in latitude) → a tile is a vertically
+tessellated textured mesh (N×1 strip, 4–16 subdivisions sub-pixel). Keeps the store
+canonically GGGS-geographic (ADR-0002 §D2), no producer-side pre-warp, free reproject on
+pan/zoom, and band-select + colormap become **shader uniforms** (instant switch, no reload).
+
+## Approach — slices (stacked PRs on `feature/issue-90`)
+
+**Slice 1 — GL plumbing + registered static tile (de-risks #175 acceptance 1).**
+1. Switch `MapView` viewport to `QOpenGLWidget` so layers can issue native GL; verify
+   existing CPU layers (raster/tiles/markers) still paint correctly over it.
+2. New `GggsTileLayer : camp::map::Layer` (pure map, `CAMP_MAP_SOURCES`, no ROS). Load a
+   tile *directory*: glob `*.tif`, read each tile's **native** band + geotransform via GDAL
+   (no warp VRT), upload band as an `R32F` texture; record geographic corner extents.
+3. `paint()` → `beginNativePainting()`: a `QOpenGLShaderProgram` whose **vertex shader
+   replicates `web_mercator::geoToMap` exactly** (R=6378137, `asinh(tan φ)`) over a
+   tessellated mesh; build the GL ortho/MVP from the `QPainter` scene→viewport transform so
+   tiles register with vector overlays; fragment shader = grayscale of the sampled value
+   (sidescan), no-data 0 → transparent. `endNativePainting()`.
+4. `boundingRect()` from the union of tile extents (mapped via `web_mercator::geoToMap`).
+
+**Slice 2 — warp correctness + multi-tile.** Tune tessellation so Mercator-y error < 0.5 px
+across a tile; confirm shared-edge seams (identical `geoToMap(φ)`) are crack-free; LOD/zoom
+behavior; many tiles without per-frame re-upload (texture cache keyed by `GridIndex` from the
+filename).
+
+**Slice 3 — bands + colormap + watcher.** Depth/Uncertainty band-select (bathy) and colormap
+as shader uniforms (1-D LUT texture); sidescan stays single-band. `QFileSystemWatcher` on the
+store dir → re-upload only changed tiles (matches the mosaicker's incremental flush). Context
+-menu band/colormap controls + `readSettings`/`writeSettings` like `RasterLayer`.
+
+**Slice 4 (deferred — own sub-issue).** Live dirty-region transport (I3 / #86 Phase 6).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/camp2/map_view/map_view.cpp` | Set `QOpenGLWidget` viewport (Slice 1) |
+| `src/camp2/raster/gggs_tile_layer.{h,cpp}` | New GL layer: dir load, R32F upload, warp+colormap shaders, paint |
+| `src/camp2/raster/gggs_tile.{h,cpp}` | Per-tile: GDAL native read, geotransform extent, GL texture/mesh, `GridIndex` key |
+| `src/camp2/shaders/*.vert/.frag` (or inline) | geoToMap warp vertex + colormap fragment shaders |
+| `CMakeLists.txt` | Add sources to `CAMP_MAP_SOURCES`; GL libs (Qt5::Widgets has `QOpenGLWidget`, QtGui has `QOpenGLShaderProgram`/`QOpenGLFunctions`) |
+| Layer registration (`background_manager.cpp` and/or an "Open tile store" action) | Expose the layer |
+| `test/test_gggs_tile_layer.cpp` | Extent-from-geotransform + geoToMap-parity (CPU mirror of the shader) + no-data unit tests |
+| `README` / repo docs | Document the layer |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Only what's needed | Slices 1–3 here; live transport (Slice 4) is a separate sub-issue gated on I3 |
+| Decoupling | Layer reuses GDAL IO + `web_mercator` + `ColorMap` stops; no `gggs` dep (geometry from GeoTIFF geotransform). New GL path is additive — CPU `RasterLayer` stays the static-chart fallback |
+| Simulation-First | De-risk against on-disk static tile sets (sidescan from the #173 Massabesic run; a bathy store epoch) before any live wiring |
+| Safety First | Display/search aid, not control; but mis-registration misleads a search → shader must match `geoToMap` exactly, unit-tested via a CPU mirror |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 §D2 (canonical GGGS-geographic) | Yes | No producer-side pre-warp; tiles stay native-geographic, warped only at display |
+| 0002 §D5 (bathy bands depth/unc/ts) | Yes | Band-select uniform renders depth or uncertainty (Slice 3); ts not rendered (F32 epoch caveat noted) |
+
+## Consequences
+
+| If we change… | Also update… | In plan? |
+|---|---|---|
+| `MapView` viewport → QOpenGLWidget | Verify all existing CPU layers still render; watch camp#98 (OOM/GDAL leak on zoom/pan) doesn't worsen | Yes (Slice 1 verify step) |
+| New shared colormap (camp#63 open) | Converge the 1-D LUT uniform with camp#63's `ColorMap` facility when it lands | Yes — interim LUT now, note follow-up |
+
+## Open Questions
+
+- [ ] **GL integration approach** — recommend `QOpenGLWidget` viewport + `beginNativePainting()`
+  + raw `QOpenGLShaderProgram` (the only Qt-5.15-viable path; QRhi is Qt6). Risk: the viewport
+  swap is app-wide; must verify CPU layers and interaction with camp#98. OK to proceed on this?
+- [ ] **Colormap source** — implement a minimal 1-D LUT uniform now (reusing `ColorMap`'s
+  viridis/turbo/grayscale stops) and converge with camp#63 later, rather than blocking on #63?
+- [ ] **Slicing** — land as stacked PRs (Slice 1 first: GL plumbing + registered static
+  sidescan tile), or one larger PR? Recommend stacked.
+
+## Estimated Scope
+
+**Multiple stacked PRs** on `feature/issue-90` (Slices 1–3). Slice 4 (live transport) = a
+separate follow-on sub-issue of #171, gated on I3.

--- a/.agent/work-plans/issue-90/plan.md
+++ b/.agent/work-plans/issue-90/plan.md
@@ -45,12 +45,23 @@ across a tile; confirm shared-edge seams (identical `geoToMap(φ)`) are crack-fr
 behavior; many tiles without per-frame re-upload (texture cache keyed by `GridIndex` from the
 filename).
 
-**Slice 3 — bands + colormap + watcher.** Depth/Uncertainty band-select (bathy) and colormap
-as shader uniforms (1-D LUT texture); sidescan stays single-band. `QFileSystemWatcher` on the
-store dir → re-upload only changed tiles (matches the mosaicker's incremental flush). Context
--menu band/colormap controls + `readSettings`/`writeSettings` like `RasterLayer`.
+**camp#63 (between Slice 2 and Slice 3) — GPU colormap facility.** Land the GPU half of
+camp#63 *after* Slice 1 provides the GL viewport: adopt `marine_colormap::colormap_glsl()` +
+`bake_lut()` (merged in `marine_colormap#6`) as a reusable CAMP GL colormap helper (palette as
+1-D LUT, range/gain as uniforms), with the offscreen CPU/GPU **parity test** from the rqt
+waterfall consumer (`rqt_operator_tools#48`), plus the CPU shared-core swap so CAMP colors
+match rviz/rqt. Sequencing settled 2026-06-20: **I4 Slice 1 → camp#63 → I4 Slice 3** (the
+facility needs the GL viewport Slice 1 builds; Slice 3 then consumes it — no throwaway LUT).
 
-**Slice 4 (deferred — own sub-issue).** Live dirty-region transport (I3 / #86 Phase 6).
+**Slice 3 — bands + colormap + watcher.** Depth/Uncertainty band-select (bathy) rendered via
+**camp#63's GPU colormap facility** (palette LUT + range/gain uniforms, applied after the warp
+in the same shader); sidescan stays single-band. `QFileSystemWatcher` on the store dir →
+re-upload only changed tiles (matches the mosaicker's incremental flush; this is the original
+camp#90 Tier-1 directory-watcher, now on the GPU layer). Context-menu band/colormap controls +
+`readSettings`/`writeSettings` like `RasterLayer`.
+
+**Slice 4 (deferred — own sub-issue).** Live dirty-region transport (I3 / #86 Phase 6;
+original camp#90 Tier-2 live consumer).
 
 ## Files to Change
 
@@ -86,19 +97,20 @@ store dir → re-upload only changed tiles (matches the mosaicker's incremental 
 | If we change… | Also update… | In plan? |
 |---|---|---|
 | `MapView` viewport → QOpenGLWidget | Verify all existing CPU layers still render; watch camp#98 (OOM/GDAL leak on zoom/pan) doesn't worsen | Yes (Slice 1 verify step) |
-| New shared colormap (camp#63 open) | Converge the 1-D LUT uniform with camp#63's `ColorMap` facility when it lands | Yes — interim LUT now, note follow-up |
+| GPU colormap (camp#63) | camp#63's GPU facility (marine_colormap GLSL+LUT) is built between Slice 2 and Slice 3 and consumed by Slice 3 — no interim/throwaway LUT | Yes — sequenced I4 Slice1 → #63 → Slice3 |
 
 ## Open Questions
 
-- [ ] **GL integration approach** — recommend `QOpenGLWidget` viewport + `beginNativePainting()`
-  + raw `QOpenGLShaderProgram` (the only Qt-5.15-viable path; QRhi is Qt6). Risk: the viewport
-  swap is app-wide; must verify CPU layers and interaction with camp#98. OK to proceed on this?
-- [ ] **Colormap source** — implement a minimal 1-D LUT uniform now (reusing `ColorMap`'s
-  viridis/turbo/grayscale stops) and converge with camp#63 later, rather than blocking on #63?
-- [ ] **Slicing** — land as stacked PRs (Slice 1 first: GL plumbing + registered static
-  sidescan tile), or one larger PR? Recommend stacked.
+- [x] **GL integration approach** → `QOpenGLWidget` viewport + `beginNativePainting()` + raw
+  `QOpenGLShaderProgram` (only Qt-5.15-viable path; QRhi is Qt6). Slice 1 must verify CPU
+  layers still render and watch camp#98 interaction. (Resolved 2026-06-20.)
+- [x] **Colormap source** → not an interim LUT; Slice 3 consumes **camp#63's GPU colormap
+  facility** (`marine_colormap` GLSL + `bake_lut`), built between Slice 2 and Slice 3.
+  Sequencing: I4 Slice 1 → camp#63 → I4 Slice 3. (Resolved 2026-06-20.)
+- [x] **Slicing** → stacked PRs on `feature/issue-90`, Slice 1 first. (Resolved 2026-06-20.)
 
 ## Estimated Scope
 
-**Multiple stacked PRs** on `feature/issue-90` (Slices 1–3). Slice 4 (live transport) = a
-separate follow-on sub-issue of #171, gated on I3.
+**Multiple stacked PRs** on `feature/issue-90` (Slices 1–3), with **camp#63** (GPU colormap
+facility) landed between Slice 2 and Slice 3. Slice 4 (live transport) = a separate follow-on
+sub-issue of #171, gated on I3.

--- a/.agent/work-plans/issue-90/plan.md
+++ b/.agent/work-plans/issue-90/plan.md
@@ -29,15 +29,23 @@ pan/zoom, and band-select + colormap become **shader uniforms** (instant switch,
 
 **Slice 1 — GL plumbing + registered static tile (de-risks #175 acceptance 1).**
 1. Switch `MapView` viewport to `QOpenGLWidget` so layers can issue native GL; verify
-   existing CPU layers (raster/tiles/markers) still paint correctly over it.
+   existing CPU layers still paint registered over it with a **concrete check**: load a KAP
+   chart (`workspace/13283`), OSM/WMTS tiles, and a marker, confirm registration is
+   pixel-unchanged vs the pre-swap build, and capture a **camp#98 memory baseline**
+   (zoom/pan RSS, GDAL-leak #96) so a regression is detectable. This app-wide viewport swap
+   is the highest-risk step.
 2. New `GggsTileLayer : camp::map::Layer` (pure map, `CAMP_MAP_SOURCES`, no ROS). Load a
    tile *directory*: glob `*.tif`, read each tile's **native** band + geotransform via GDAL
    (no warp VRT), upload band as an `R32F` texture; record geographic corner extents.
 3. `paint()` → `beginNativePainting()`: a `QOpenGLShaderProgram` whose **vertex shader
    replicates `web_mercator::geoToMap` exactly** (R=6378137, `asinh(tan φ)`) over a
-   tessellated mesh; build the GL ortho/MVP from the `QPainter` scene→viewport transform so
-   tiles register with vector overlays; fragment shader = grayscale of the sampled value
-   (sidescan), no-data 0 → transparent. `endNativePainting()`.
+   tessellated mesh. Build the GL MVP from the **live `QPainter::worldTransform()`** (scene→
+   viewport), *not* a hand-rolled ortho — the scene transform is `scale(s, −s)`
+   (`map_view.cpp:19`, math-north → screen-down), so deriving from it makes the Y-flip,
+   pan/zoom, and device-pixel-ratio register automatically. Set GL state explicitly inside
+   the native block: **depth-test off, premultiplied-alpha blend**, so the CPU QPainter
+   layers composite correctly over the GL viewport. Fragment shader = grayscale of the
+   sampled value (sidescan), no-data 0 → transparent. `endNativePainting()`.
 4. `boundingRect()` from the union of tile extents (mapped via `web_mercator::geoToMap`).
 
 **Slice 2 — warp correctness + multi-tile.** Tune tessellation so Mercator-y error < 0.5 px
@@ -71,9 +79,9 @@ original camp#90 Tier-2 live consumer).
 | `src/camp2/raster/gggs_tile_layer.{h,cpp}` | New GL layer: dir load, R32F upload, warp+colormap shaders, paint |
 | `src/camp2/raster/gggs_tile.{h,cpp}` | Per-tile: GDAL native read, geotransform extent, GL texture/mesh, `GridIndex` key |
 | `src/camp2/shaders/*.vert/.frag` (or inline) | geoToMap warp vertex + colormap fragment shaders |
-| `CMakeLists.txt` | Add sources to `CAMP_MAP_SOURCES`; GL libs (Qt5::Widgets has `QOpenGLWidget`, QtGui has `QOpenGLShaderProgram`/`QOpenGLFunctions`) |
+| `CMakeLists.txt` | Add sources to `CAMP_MAP_SOURCES`; **add `Qt5::Gui` (and `OpenGL` if used) to the `find_package(Qt5 …)` COMPONENTS and the `camp_map` link list** — `QOpenGLShaderProgram`/`QOpenGLFunctions` are in `Qt5::Gui`, `QOpenGLWidget` in `Qt5::Widgets`; don't rely on transitive Widgets |
 | Layer registration (`background_manager.cpp` and/or an "Open tile store" action) | Expose the layer |
-| `test/test_gggs_tile_layer.cpp` | Extent-from-geotransform + geoToMap-parity (CPU mirror of the shader) + no-data unit tests |
+| `test/test_gggs_tile_layer.cpp` | Extent-from-geotransform + **geoToMap parity** (CPU mirror that calls `web_mercator::geoToMap` *directly* so it can't drift from the shader reference; tolerance < 1e-6 relative over φ ∈ [−85°, 85°], sampling Massabesic ~43°N) + no-data unit tests |
 | `README` / repo docs | Document the layer |
 
 ## Principles Self-Check
@@ -87,10 +95,14 @@ original camp#90 Tier-2 live consumer).
 
 ## ADR Compliance
 
+ADR refs below are **`unh_marine_autonomy` ADR-0002** (the bathy-store / GGGS ADR) — *not*
+camp's local `docs/decisions/0002` (Web-Mercator scene, two-model split), which a bare "0002"
+citation would mis-resolve to from inside the camp worktree.
+
 | ADR | Triggered | How addressed |
 |---|---|---|
-| 0002 §D2 (canonical GGGS-geographic) | Yes | No producer-side pre-warp; tiles stay native-geographic, warped only at display |
-| 0002 §D5 (bathy bands depth/unc/ts) | Yes | Band-select uniform renders depth or uncertainty (Slice 3); ts not rendered (F32 epoch caveat noted) |
+| unh_marine_autonomy 0002 §D2 (canonical GGGS-geographic) | Yes | No producer-side pre-warp; tiles stay native-geographic, warped only at display |
+| unh_marine_autonomy 0002 §D5 (bathy bands depth/unc/ts) | Yes | Band-select uniform renders depth or uncertainty (Slice 3); ts not rendered (F32 epoch caveat noted) |
 
 ## Consequences
 

--- a/.agent/work-plans/issue-90/progress.md
+++ b/.agent/work-plans/issue-90/progress.md
@@ -34,3 +34,25 @@ issue: 90
 - [ ] (suggestion) Make the Y-flip explicit: scene uses `scale(s, -s)` (map_view.cpp:19), so the GL MVP MUST be derived from the live QPainter `worldTransform()` (as the plan says) rather than a hand-rolled ortho; call out depth-test off + premultiplied-alpha blend state for CPU QPainter layers compositing over the GL viewport — `plan.md:39`
 - [ ] (suggestion) Slice 1 verification ("existing CPU layers still render") is qualitative; name the concrete check — load a KAP chart (workspace/13283) + OSM tiles + a marker, confirm registration unchanged, and capture a camp#98 zoom/pan memory baseline — `plan.md:31,99`
 - [ ] (suggestion) geoToMap-parity unit test is the right gate but specify tolerance + sample spread (e.g. < 1e-6 m over φ ∈ [−85°,85°] incl. Massabesic latitude); the CPU mirror must call `web_mercator::geoToMap` directly so it can't silently drift from the shader — `plan.md:76,86`
+
+All 5 suggestions folded into the plan at `4e89b7b` before implementation.
+
+## Implementation
+**Status**: in-progress (Slice 1 code + unit tests complete; runtime registration verification pending)
+**When**: 2026-06-20 01:35 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Branch**: feature/issue-90 at `914ec4a`
+**Slice**: 1 of 4 — GL plumbing + GPU-warp tile layer + registered grayscale sidescan
+
+**Built**:
+- `MapView` viewport → `QOpenGLWidget` (`FullViewportUpdate`) so layers can issue native GL.
+- `GggsTile` (`raster/gggs_tile.{h,cpp}`): GDAL native band-1 read (no warp VRT) + geotransform→geographic extent + NoData/data-range + lazy `R32F` `QOpenGLTexture`.
+- `GggsTileLayer` (`raster/gggs_tile_layer.{h,cpp}`): `map::Layer` + `QOpenGLFunctions`; loads a tile directory, `boundingRect` = union of per-tile Web-Mercator extents via `web_mercator::geoToMap`; `paint()` → `beginNativePainting()` with an inline shader pair (vertex = geoToMap warp over a 16-strip latitude mesh, MVP from live `QPainter::worldTransform()`; fragment = auto-ranged grayscale, NoData 0 → discard; premult-alpha blend, depth-test off). GL teardown via `QPointer<QOpenGLWidget>` makeCurrent.
+- `BackgroundManager`: "Open tile store" directory action → `GggsTileLayer`.
+- CMake: `Qt5::Gui` added to COMPONENTS + `camp_map` link; new sources; `test_gggs_tile` registered.
+- `GggsTileLayerType` item type.
+
+**Verified**: builds clean (camp, only pre-existing warnings); **camp test suite 63 tests, 0 failures** incl. `test_gggs_tile` (extent-from-geotransform, NoData-excluded-from-range, all-NoData-crossed-range, missing-file-invalid, shader-warp==geoToMap parity over φ∈[−85°,85°] incl. Massabesic, rel tol <1e-6).
+
+**Pending (Slice 1 close-out)**: runtime registration check — regenerate sidescan tiles from the #173 bag, open the tile store in CAMP, confirm tiles register vs a KAP chart (`workspace/13283`) + OSM tiles + a marker, and capture a camp#98 zoom/pan memory baseline. Needs a CAMP GUI session.

--- a/.agent/work-plans/issue-90/progress.md
+++ b/.agent/work-plans/issue-90/progress.md
@@ -71,3 +71,27 @@ All 5 suggestions folded into the plan at `4e89b7b` before implementation.
 **Settings persistence** (camp#90, folded in): the #59/#60 port wired view/window persistence only into the camp2 *test harness*, not deployed `MainWindow` → map pos/zoom + window geometry stopped saving. `closeEvent` now saves window geometry/state + `projectView` scale/center to QSettings; ctor restores geometry + (deferred to next event loop) map scale/center.
 
 **Open**: (1) **in-CAMP visual confirm** of tile registration + the settings round-trip (close/reopen); (2) the 544 m Massabesic patch is sub-pixel at default world zoom — zoom in to see it; (3) Slice 2 = visible-region-only render + tessellation/seam tuning; eviction/large-survey memory.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 19:29 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Branch**: feature/issue-90 at `2030f8e`
+**Mode**: pre-push
+**Depth**: Deep (reason: new GL rendering subsystem + lifecycle/persistence, ~1534 lines)
+**Verdict**: changes-requested → must-fix + cheap suggestions addressed; rest deferred to Slice 2
+**Static analysis**: limited (cpplint not installed; clean compile, no warnings) | **Claude Adversarial**: 2 passes (Lens A logic + Lens B systemic) | **Copilot**: off (default)
+**Must-fix**: 1 | **Suggestions**: 8
+
+### Findings
+- [x] (must-fix) Data-range init: all-NoData first tile left `data_min_` stuck at sentinel 1.0 — fixed (separate first_extent/first_range) — `gggs_tile_layer.cpp`
+- [x] (suggestion) `gl_failed_` checked after context → makeCurrent-failure warn-spam every repaint — fixed (gl_failed_ first) — `gggs_tile_layer.cpp`
+- [x] (suggestion) store-tree recursion follows directory symlinks → unbounded loop — fixed (QDir::NoSymLinks) — `gggs_store_layer.cpp`
+- [x] (suggestion) GggsTile retains CPU float copy after GPU upload (~2x RAM/tile) — fixed (free after upload) — `gggs_tile.cpp`
+- [x] (suggestion) `onRemovedByUser` fires on all removeFromMap, not user-only — renamed `onRemovedFromMap` + comment — `layer.{h,cpp}`
+- [x] (suggestion) stale tests: ScenePaint reproduction + "shader"/"row0=south" comments — removed/retitled — `test/*`
+- [ ] (suggestion, DEFERRED Slice 2) synchronous full-store load on GUI thread → startup freeze for large stores — documented in code (async load follow-up) — `background_manager.cpp`
+- [ ] (suggestion, DEFERRED) map-view scale/center restore can be clobbered by a persisted chart's async fit-to-extent — `mainwindow.cpp`
+- [ ] (suggestion, DEFERRED) single-band 8-bit grayscale charts now default to Viridis (user-selectable via context menu) — `raster_layer.cpp`
+- [ ] (suggestion, DEFERRED) persisted store/raster lists grow unbounded; consider an MRU cap — `background_manager.cpp`

--- a/.agent/work-plans/issue-90/progress.md
+++ b/.agent/work-plans/issue-90/progress.md
@@ -56,3 +56,18 @@ All 5 suggestions folded into the plan at `4e89b7b` before implementation.
 **Verified**: builds clean (camp, only pre-existing warnings); **camp test suite 63 tests, 0 failures** incl. `test_gggs_tile` (extent-from-geotransform, NoData-excluded-from-range, all-NoData-crossed-range, missing-file-invalid, shader-warp==geoToMap parity over φ∈[−85°,85°] incl. Massabesic, rel tol <1e-6).
 
 **Pending (Slice 1 close-out)**: runtime registration check — regenerate sidescan tiles from the #173 bag, open the tile store in CAMP, confirm tiles register vs a KAP chart (`workspace/13283`) + OSM tiles + a marker, and capture a camp#98 zoom/pan memory baseline. Needs a CAMP GUI session.
+
+## Implementation — update (offscreen-FBO pivot + settings)
+**Status**: Slice 1 code + headless verification complete; awaiting in-CAMP visual confirm
+**When**: 2026-06-20 13:30 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Branch**: feature/issue-90 at `91cfd6e` (`cb225a1` render pivot, `91cfd6e` settings)
+
+**Render approach revised** (Roland's call, plan §Approach updated): native GL in a QGraphicsView item gets **no current GL context** on this stack — Wayland composites via a software backingstore, not a GL surface; `beginNativePainting` → `QOpenGLFunctions` crashed on a null context (gdb-confirmed). Layer now warps tiles in its **own offscreen GL context** (`QOpenGLContext` + `QOffscreenSurface` + `QOpenGLFramebufferObject`) → `QImage` → `drawImage(boundingRect, img)`, cached by on-screen size. Portable (X11/Wayland/software); **`QOpenGLWidget` viewport reverted** (camp#98 risk moot).
+
+**Verified headlessly** (no window): `test_gggs_render` warps a synthetic tile (asserts geometry + orientation) and, via `GGGS_TEST_STORE`, the **real** `~/data/stores/sidescan_backscatter/draft` store → a coherent **north-up** backscatter mosaic (pixel analysis: QImage row 0 = south → `drawImage` + MapView `scale(s,−s)` flip = north up). **camp tests 66, 0 fail, 1 skip** (env-gated real render).
+
+**Settings persistence** (camp#90, folded in): the #59/#60 port wired view/window persistence only into the camp2 *test harness*, not deployed `MainWindow` → map pos/zoom + window geometry stopped saving. `closeEvent` now saves window geometry/state + `projectView` scale/center to QSettings; ctor restores geometry + (deferred to next event loop) map scale/center.
+
+**Open**: (1) **in-CAMP visual confirm** of tile registration + the settings round-trip (close/reopen); (2) the 544 m Massabesic patch is sub-pixel at default world zoom — zoom in to see it; (3) Slice 2 = visible-region-only render + tessellation/seam tuning; eviction/large-survey memory.

--- a/.agent/work-plans/issue-90/progress.md
+++ b/.agent/work-plans/issue-90/progress.md
@@ -17,3 +17,20 @@ issue: 90
 - [x] GL integration → QOpenGLWidget viewport + beginNativePainting + raw QOpenGLShaderProgram (only Qt-5.15-viable; QRhi is Qt6). Resolved 2026-06-20.
 - [x] Colormap → Slice 3 consumes camp#63's GPU colormap facility (marine_colormap GLSL + bake_lut); sequencing I4 Slice1 → camp#63 → I4 Slice3 (no interim LUT). Resolved 2026-06-20.
 - [x] Slicing → stacked PRs on feature/issue-90, Slice 1 first. Resolved 2026-06-20.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-19 22:01 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+**Plan**: `.agent/work-plans/issue-90/plan.md` at `8ec0a35`
+**PR**: PR-less
+**Branch**: feature/issue-90
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) ADR-0002 §D2/§D5 citations are the *unh_marine_autonomy* bathy-store ADR, not camp's local ADR-0002 (Web-Mercator scene); qualify the repo so a reader doesn't mis-resolve to `docs/decisions/0002` in camp — `plan.md:88-93`
+- [ ] (suggestion) CMake: current `find_package(Qt5 5.15 COMPONENTS ...)` lacks `Gui`/`OpenGL`; `QOpenGLShaderProgram`/`QOpenGLFunctions` live in Qt5::Gui. Add `Gui` (and `OpenGL` if used) to COMPONENTS + `camp_map` link list, not just rely on transitive Widgets — `plan.md:74`
+- [ ] (suggestion) Make the Y-flip explicit: scene uses `scale(s, -s)` (map_view.cpp:19), so the GL MVP MUST be derived from the live QPainter `worldTransform()` (as the plan says) rather than a hand-rolled ortho; call out depth-test off + premultiplied-alpha blend state for CPU QPainter layers compositing over the GL viewport — `plan.md:39`
+- [ ] (suggestion) Slice 1 verification ("existing CPU layers still render") is qualitative; name the concrete check — load a KAP chart (workspace/13283) + OSM tiles + a marker, confirm registration unchanged, and capture a camp#98 zoom/pan memory baseline — `plan.md:31,99`
+- [ ] (suggestion) geoToMap-parity unit test is the right gate but specify tolerance + sample spread (e.g. < 1e-6 m over φ ∈ [−85°,85°] incl. Massabesic latitude); the CPU mirror must call `web_mercator::geoToMap` directly so it can't silently drift from the shader — `plan.md:76,86`

--- a/.agent/work-plans/issue-90/progress.md
+++ b/.agent/work-plans/issue-90/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 90
+---
+
+# Issue #90 — GGGS-tiled raster map layer: GPU display-time warp (bathy + sidescan)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-20 00:55 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-90/plan.md` at `d7e4d6c`
+**Branch**: feature/issue-90 at `d7e4d6c`
+**Phases**: 4 slices (stacked PRs; Slice 1 GL plumbing + registered static tile → Slice 2 warp correctness/multi-tile → Slice 3 bands+colormap+watcher → Slice 4 live transport, deferred to I3)
+
+### Open questions
+- [ ] GL integration approach — recommend QOpenGLWidget viewport + beginNativePainting + raw QOpenGLShaderProgram (only Qt-5.15-viable path; QRhi is Qt6); risk = app-wide viewport swap + camp#98 interaction. Proceed?
+- [ ] Colormap source — minimal 1-D LUT uniform now (reuse ColorMap stops), converge with camp#63 later, vs block on #63?
+- [ ] Slicing — stacked PRs (Slice 1 first) vs one larger PR? Recommend stacked.

--- a/.agent/work-plans/issue-90/progress.md
+++ b/.agent/work-plans/issue-90/progress.md
@@ -14,6 +14,6 @@ issue: 90
 **Phases**: 4 slices (stacked PRs; Slice 1 GL plumbing + registered static tile → Slice 2 warp correctness/multi-tile → Slice 3 bands+colormap+watcher → Slice 4 live transport, deferred to I3)
 
 ### Open questions
-- [ ] GL integration approach — recommend QOpenGLWidget viewport + beginNativePainting + raw QOpenGLShaderProgram (only Qt-5.15-viable path; QRhi is Qt6); risk = app-wide viewport swap + camp#98 interaction. Proceed?
-- [ ] Colormap source — minimal 1-D LUT uniform now (reuse ColorMap stops), converge with camp#63 later, vs block on #63?
-- [ ] Slicing — stacked PRs (Slice 1 first) vs one larger PR? Recommend stacked.
+- [x] GL integration → QOpenGLWidget viewport + beginNativePainting + raw QOpenGLShaderProgram (only Qt-5.15-viable; QRhi is Qt6). Resolved 2026-06-20.
+- [x] Colormap → Slice 3 consumes camp#63's GPU colormap facility (marine_colormap GLSL + bake_lut); sequencing I4 Slice1 → camp#63 → I4 Slice3 (no interim LUT). Resolved 2026-06-20.
+- [x] Slicing → stacked PRs on feature/issue-90, Slice 1 first. Resolved 2026-06-20.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CMAKE_VERSION VERSION_LESS "3.7.0")
     set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()
 
-find_package(Qt5 5.15 COMPONENTS Core Widgets Test Concurrent Positioning Network Svg Xml)
+find_package(Qt5 5.15 COMPONENTS Core Gui Widgets Test Concurrent Positioning Network Svg Xml)
 
 if (Qt5Widgets_FOUND)
     if (Qt5Widgets_VERSION VERSION_LESS 5.15.0)
@@ -251,6 +251,8 @@ set(CAMP_MAP_SOURCES
     src/camp2/map_view/map_view.cpp
     src/camp2/map_view/web_mercator.cpp
     src/camp2/raster/raster_layer.cpp
+    src/camp2/raster/gggs_tile.cpp
+    src/camp2/raster/gggs_tile_layer.cpp
     src/camp2/tools/layer_manager.cpp
     src/camp2/tools/map_tool.cpp
     src/camp2/tools/tools_manager.cpp
@@ -271,6 +273,7 @@ target_include_directories(camp_map PUBLIC
 target_link_libraries(camp_map
     PUBLIC
         Qt5::Core
+        Qt5::Gui
         Qt5::Widgets
         Qt5::Concurrent
         Qt5::Network
@@ -514,6 +517,23 @@ if(BUILD_TESTING)
     camp_map
     Qt5::Widgets
     Qt5::Test
+  )
+
+  # GGGS GPU-warp tile layer (camp#90 / I4): GggsTile extent-from-geotransform +
+  # NoData/range handling, and the shader-warp == web_mercator::geoToMap parity
+  # anchor. Links camp_map (GggsTile + web_mercator) and GDAL (synthetic tiles).
+  ament_add_gtest(test_gggs_tile
+    test/test_gggs_tile.cpp
+  )
+  target_include_directories(test_gggs_tile PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp2
+  )
+  target_link_libraries(test_gggs_tile
+    camp_map
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,6 +535,24 @@ if(BUILD_TESTING)
     Qt5::Positioning
     ${GDAL_LIBRARY}
   )
+
+  # GGGS offscreen-FBO render (camp#90 / I4): warps a synthetic tile in the
+  # layer's own GL context and checks the QImage is non-empty + oriented.
+  # Self-skips when no offscreen GL context is available.
+  ament_add_gtest(test_gggs_render
+    test/test_gggs_render.cpp
+  )
+  target_include_directories(test_gggs_render PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp2
+  )
+  target_link_libraries(test_gggs_render
+    camp_map
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
+  )
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,7 @@ set(CAMP_MAP_SOURCES
     src/camp2/raster/raster_layer.cpp
     src/camp2/raster/gggs_tile.cpp
     src/camp2/raster/gggs_tile_layer.cpp
+    src/camp2/raster/gggs_store_layer.cpp
     src/camp2/tools/layer_manager.cpp
     src/camp2/tools/map_tool.cpp
     src/camp2/tools/tools_manager.cpp

--- a/src/camp/mainwindow.cpp
+++ b/src/camp/mainwindow.cpp
@@ -28,6 +28,10 @@
 #include "map_tree_view/map_tree_view.h"
 #include <QTabWidget>
 
+#include <QCloseEvent>
+#include <QSettings>
+#include <QTimer>
+
 #include <QDebug>
 
 MainWindow::MainWindow(QWidget *parent) :
@@ -136,6 +140,26 @@ MainWindow::MainWindow(QWidget *parent) :
     // signals are wired, so fit-to-extent and the overlay managers refresh for
     // the restored charts. Charts are app state, independent of any mission file.
     project->restorePersistedBackgrounds();
+
+    // [camp#90] Restore window geometry/state and the map view position+zoom from
+    // the previous session (saved in closeEvent). Geometry applies now; the map
+    // view scale/center is deferred to the next event-loop turn so it isn't
+    // overridden by initial layout or the restored charts' fit-to-extent.
+    QSettings settings;
+    restoreGeometry(settings.value("MainWindow/geometry").toByteArray());
+    restoreState(settings.value("MainWindow/state").toByteArray());
+    QTimer::singleShot(0, this, [this]()
+    {
+        QSettings s;
+        const double scale = s.value("MainWindow/mapScale", 0.0).toDouble();
+        if(scale > 0.0 && m_ui->projectView && m_ui->projectView->transform().m11() > 0.0)
+        {
+            const double factor = scale / m_ui->projectView->transform().m11();
+            m_ui->projectView->scale(factor, factor);
+            if(s.contains("MainWindow/mapCenter"))
+                m_ui->projectView->centerOn(s.value("MainWindow/mapCenter").toPointF());
+        }
+    });
 }
 
 MainWindow::~MainWindow()
@@ -147,6 +171,17 @@ MainWindow::~MainWindow()
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
+    // [camp#90] Persist window geometry/state + map view position/zoom so they
+    // restore next session (restored in the constructor).
+    QSettings settings;
+    settings.setValue("MainWindow/geometry", saveGeometry());
+    settings.setValue("MainWindow/state", saveState());
+    if(m_ui->projectView)
+    {
+        settings.setValue("MainWindow/mapScale", m_ui->projectView->transform().m11());
+        settings.setValue("MainWindow/mapCenter",
+            m_ui->projectView->mapToScene(m_ui->projectView->viewport()->rect().center()));
+    }
     emit closing();
     QMainWindow::closeEvent(event);
 }

--- a/src/camp2/background/background_manager.cpp
+++ b/src/camp2/background/background_manager.cpp
@@ -4,6 +4,7 @@
 #include "../map_tiles/map_tiles.h"
 #include "../map_tiles/osm.h"
 #include "../raster/raster_layer.h"
+#include "../raster/gggs_tile_layer.h"
 #include "../tools/tools_manager.h"
 #include <QGraphicsScene>
 #include <QMenu>
@@ -72,6 +73,8 @@ void BackgroundManager::contextMenu(QMenu* menu)
 {
   auto open_raster_action = menu->addAction("Open raster");
   connect(open_raster_action, &QAction::triggered, this, &BackgroundManager::openRaster);
+  auto open_tile_store_action = menu->addAction("Open tile store");
+  connect(open_tile_store_action, &QAction::triggered, this, &BackgroundManager::openTileStore);
 }
 
 void BackgroundManager::openRaster()
@@ -86,6 +89,17 @@ void BackgroundManager::openRaster()
     }
   }
 
+}
+
+void BackgroundManager::openTileStore()
+{
+  QString directory = QFileDialog::getExistingDirectory(nullptr, tr("Open tile store"));
+  if(!directory.isEmpty())
+  {
+    auto layers = topLevelLayers();
+    if(layers)
+      new raster::GggsTileLayer(layers, directory);
+  }
 }
 
 } // namespace background

--- a/src/camp2/background/background_manager.cpp
+++ b/src/camp2/background/background_manager.cpp
@@ -4,12 +4,14 @@
 #include "../map_tiles/map_tiles.h"
 #include "../map_tiles/osm.h"
 #include "../raster/raster_layer.h"
-#include "../raster/gggs_tile_layer.h"
+#include "../raster/gggs_store_layer.h"
 #include "../tools/tools_manager.h"
+#include <QDir>
 #include <QGraphicsScene>
 #include <QMenu>
 #include <QAction>
 #include <QFileDialog>
+#include <QSettings>
 #include "../wmts/capabilities.h"
 
 namespace camp
@@ -60,6 +62,14 @@ void BackgroundManager::createDefaultLayers()
     // new raster::RasterLayer(layers, "/home/roland/data/BSB_ROOT/13283/13283_1.KAP");
 
     // new raster::RasterLayer(layers, "/home/roland/data/BSB_ROOT/13283/13283_2.KAP");
+
+    // [camp#90] Re-create persisted GGGS tile stores so they auto-load each
+    // session (persisted in openTileStore). Skip roots that no longer exist.
+    QSettings settings;
+    const QStringList store_roots = settings.value("GggsStores/roots").toStringList();
+    for(const QString& root : store_roots)
+      if(QDir(root).exists())
+        new raster::GggsStoreLayer(layers, root);
   }
 }
 
@@ -94,11 +104,21 @@ void BackgroundManager::openRaster()
 void BackgroundManager::openTileStore()
 {
   QString directory = QFileDialog::getExistingDirectory(nullptr, tr("Open tile store"));
-  if(!directory.isEmpty())
+  if(directory.isEmpty())
+    return;
+  auto layers = topLevelLayers();
+  if(!layers)
+    return;
+  new raster::GggsStoreLayer(layers, directory);
+
+  // Persist the store root so it auto-loads next session (createDefaultLayers
+  // re-creates it), matching the chart-list persistence.
+  QSettings settings;
+  QStringList roots = settings.value("GggsStores/roots").toStringList();
+  if(!roots.contains(directory))
   {
-    auto layers = topLevelLayers();
-    if(layers)
-      new raster::GggsTileLayer(layers, directory);
+    roots.append(directory);
+    settings.setValue("GggsStores/roots", roots);
   }
 }
 

--- a/src/camp2/background/background_manager.cpp
+++ b/src/camp2/background/background_manager.cpp
@@ -67,6 +67,10 @@ void BackgroundManager::createDefaultLayers()
     // [camp#90] Re-create persisted GGGS tile stores + plain rasters so they
     // auto-load each session (persisted in openTileStore / openRaster). Skip
     // entries that no longer exist on disk.
+    // Slice-2 follow-up: GggsStoreLayer/GggsTile load every tile synchronously
+    // (GDAL RasterIO on the GUI thread), so a large multi-epoch store blocks
+    // startup. Bound this with lazy/visible-region loading like RasterLayer's
+    // async QtConcurrent path before stores get big.
     QSettings settings;
     const QStringList store_roots = settings.value("GggsStores/roots").toStringList();
     for(const QString& root : store_roots)

--- a/src/camp2/background/background_manager.cpp
+++ b/src/camp2/background/background_manager.cpp
@@ -7,6 +7,7 @@
 #include "../raster/gggs_store_layer.h"
 #include "../tools/tools_manager.h"
 #include <QDir>
+#include <QFileInfo>
 #include <QGraphicsScene>
 #include <QMenu>
 #include <QAction>
@@ -63,13 +64,18 @@ void BackgroundManager::createDefaultLayers()
 
     // new raster::RasterLayer(layers, "/home/roland/data/BSB_ROOT/13283/13283_2.KAP");
 
-    // [camp#90] Re-create persisted GGGS tile stores so they auto-load each
-    // session (persisted in openTileStore). Skip roots that no longer exist.
+    // [camp#90] Re-create persisted GGGS tile stores + plain rasters so they
+    // auto-load each session (persisted in openTileStore / openRaster). Skip
+    // entries that no longer exist on disk.
     QSettings settings;
     const QStringList store_roots = settings.value("GggsStores/roots").toStringList();
     for(const QString& root : store_roots)
       if(QDir(root).exists())
         new raster::GggsStoreLayer(layers, root);
+    const QStringList raster_files = settings.value("GggsRasters/files").toStringList();
+    for(const QString& fname : raster_files)
+      if(QFileInfo::exists(fname))
+        new raster::RasterLayer(layers, fname);
   }
 }
 
@@ -90,15 +96,22 @@ void BackgroundManager::contextMenu(QMenu* menu)
 void BackgroundManager::openRaster()
 {
   QString fname = QFileDialog::getOpenFileName(nullptr, tr("Open"));
-  if(!fname.isEmpty())
-  {
-    auto layers = topLevelLayers();
-    if(layers)
-    {
-      raster::RasterLayer* raster = new raster::RasterLayer(layers, fname);
-    }
-  }
+  if(fname.isEmpty())
+    return;
+  auto layers = topLevelLayers();
+  if(!layers)
+    return;
+  new raster::RasterLayer(layers, fname);
 
+  // Persist the raster so it auto-loads next session (createDefaultLayers
+  // re-creates it), matching the tile-store persistence.
+  QSettings settings;
+  QStringList files = settings.value("GggsRasters/files").toStringList();
+  if(!files.contains(fname))
+  {
+    files.append(fname);
+    settings.setValue("GggsRasters/files", files);
+  }
 }
 
 void BackgroundManager::openTileStore()

--- a/src/camp2/background/background_manager.h
+++ b/src/camp2/background/background_manager.h
@@ -40,6 +40,9 @@ public:
 
 private slots:
   void openRaster();
+  /// [camp#90 / I4] Open a directory of GGGS raster tiles (sidescan / bathy
+  /// `<level>_<row>_<col>.tif`) as a GPU-warped GggsTileLayer.
+  void openTileStore();
 };
 
 } // namespace background

--- a/src/camp2/map/item_types.h
+++ b/src/camp2/map/item_types.h
@@ -34,6 +34,7 @@ enum ItemType
   MapTilesType,
   MapToolType,
   RasterLayerType,
+  GggsTileLayerType,
   RosGeometryManagerType,
   RosNamesManagerType,
   RosNodeType,

--- a/src/camp2/map/item_types.h
+++ b/src/camp2/map/item_types.h
@@ -35,6 +35,7 @@ enum ItemType
   MapToolType,
   RasterLayerType,
   GggsTileLayerType,
+  GggsStoreLayerType,
   RosGeometryManagerType,
   RosNamesManagerType,
   RosNodeType,

--- a/src/camp2/map/layer.cpp
+++ b/src/camp2/map/layer.cpp
@@ -53,10 +53,10 @@ void Layer::contextMenu(QMenu* menu)
 
 void Layer::removeFromMap()
 {
-  // [camp#90] User-initiated removal: let a persisted layer drop itself from its
-  // restore list so it stays removed next session (app shutdown does not call
-  // this path, so persisted layers survive a normal quit).
-  onRemovedByUser();
+  // [camp#90] Removal (user "Remove" or programmatic): let a persisted layer
+  // drop itself from its restore list so it stays removed next session (app
+  // shutdown does not call this path, so persisted layers survive a normal quit).
+  onRemovedFromMap();
   // [#59 ADR-0003] Detach through the Map model (fires rowsAboutToBeRemoved so
   // owners can sync their bookkeeping), drop it from the scene so it stops
   // rendering at once, then delete after the current event unwinds.

--- a/src/camp2/map/layer.cpp
+++ b/src/camp2/map/layer.cpp
@@ -53,6 +53,10 @@ void Layer::contextMenu(QMenu* menu)
 
 void Layer::removeFromMap()
 {
+  // [camp#90] User-initiated removal: let a persisted layer drop itself from its
+  // restore list so it stays removed next session (app shutdown does not call
+  // this path, so persisted layers survive a normal quit).
+  onRemovedByUser();
   // [#59 ADR-0003] Detach through the Map model (fires rowsAboutToBeRemoved so
   // owners can sync their bookkeeping), drop it from the scene so it stops
   // rendering at once, then delete after the current event unwinds.

--- a/src/camp2/map/layer.h
+++ b/src/camp2/map/layer.h
@@ -40,12 +40,13 @@ public:
   void removeFromMap();
 
 protected:
-  /// [camp#90] Called by removeFromMap() — i.e. when the *user* removes this
-  /// layer (the "Remove" action), NOT on app shutdown (which destroys layers
-  /// without going through removeFromMap). Subclasses persisted as app state
-  /// (RasterLayer, GggsStoreLayer) override this to drop themselves from their
-  /// QSettings restore list so a removed layer stays removed across sessions.
-  virtual void onRemovedByUser() {}
+  /// [camp#90] Called by removeFromMap() (the "Remove" action and any
+  /// programmatic detach), but NOT on app shutdown — which destroys layers
+  /// without going through removeFromMap, so persisted layers survive a normal
+  /// quit. Subclasses persisted as app state (RasterLayer, GggsStoreLayer)
+  /// override this to drop themselves from their QSettings restore list so a
+  /// removed layer stays removed across sessions.
+  virtual void onRemovedFromMap() {}
 
   /// [#59 ADR-0003] Adds a "Remove" entry (unless setRemovable(false)). Detaches
   /// through the Map model — owners that track specific layers (e.g. the

--- a/src/camp2/map/layer.h
+++ b/src/camp2/map/layer.h
@@ -40,6 +40,13 @@ public:
   void removeFromMap();
 
 protected:
+  /// [camp#90] Called by removeFromMap() — i.e. when the *user* removes this
+  /// layer (the "Remove" action), NOT on app shutdown (which destroys layers
+  /// without going through removeFromMap). Subclasses persisted as app state
+  /// (RasterLayer, GggsStoreLayer) override this to drop themselves from their
+  /// QSettings restore list so a removed layer stays removed across sessions.
+  virtual void onRemovedByUser() {}
+
   /// [#59 ADR-0003] Adds a "Remove" entry (unless setRemovable(false)). Detaches
   /// through the Map model — owners that track specific layers (e.g. the
   /// project's chart/depth bookkeeping) react via the model's

--- a/src/camp2/map_view/map_view.cpp
+++ b/src/camp2/map_view/map_view.cpp
@@ -4,6 +4,7 @@
 #include <QAbstractSlider>
 #include <QScrollBar>
 #include <QGuiApplication>
+#include <QOpenGLWidget>
 #include "../map/map.h"
 #include <QSettings>
 
@@ -15,6 +16,16 @@ const double MapView::max_zoom_scale_;
 
 MapView::MapView(QWidget *parent) : QGraphicsView(parent)
 {
+  // [camp#90 / I4] Use a QOpenGLWidget as the viewport so map layers can issue
+  // native OpenGL inside their paint() (QPainter::beginNativePainting), e.g. the
+  // GPU display-time warp of GGGS raster tiles. The existing CPU layers
+  // (RasterLayer pixmaps, MapTiles, markers) keep working: Qt's GL paint engine
+  // rasterizes their QPainter calls onto the same context, and they remain
+  // pixel-registered because the scene→viewport transform is unchanged. Slice-1
+  // risk to watch: this is an app-wide viewport swap (verify CPU-layer
+  // registration; watch the camp#98 zoom/pan memory path).
+  setViewport(new QOpenGLWidget(this));
+  setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
   connect(horizontalScrollBar(), &QAbstractSlider::valueChanged, this, &MapView::sendViewport);
   connect(verticalScrollBar(), &QAbstractSlider::valueChanged, this , &MapView::sendViewport);
   scale(min_zoom_scale_, -min_zoom_scale_);

--- a/src/camp2/map_view/map_view.cpp
+++ b/src/camp2/map_view/map_view.cpp
@@ -4,7 +4,6 @@
 #include <QAbstractSlider>
 #include <QScrollBar>
 #include <QGuiApplication>
-#include <QOpenGLWidget>
 #include "../map/map.h"
 #include <QSettings>
 
@@ -16,16 +15,6 @@ const double MapView::max_zoom_scale_;
 
 MapView::MapView(QWidget *parent) : QGraphicsView(parent)
 {
-  // [camp#90 / I4] Use a QOpenGLWidget as the viewport so map layers can issue
-  // native OpenGL inside their paint() (QPainter::beginNativePainting), e.g. the
-  // GPU display-time warp of GGGS raster tiles. The existing CPU layers
-  // (RasterLayer pixmaps, MapTiles, markers) keep working: Qt's GL paint engine
-  // rasterizes their QPainter calls onto the same context, and they remain
-  // pixel-registered because the scene→viewport transform is unchanged. Slice-1
-  // risk to watch: this is an app-wide viewport swap (verify CPU-layer
-  // registration; watch the camp#98 zoom/pan memory path).
-  setViewport(new QOpenGLWidget(this));
-  setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
   connect(horizontalScrollBar(), &QAbstractSlider::valueChanged, this, &MapView::sendViewport);
   connect(verticalScrollBar(), &QAbstractSlider::valueChanged, this , &MapView::sendViewport);
   scale(min_zoom_scale_, -min_zoom_scale_);

--- a/src/camp2/raster/gggs_store_layer.cpp
+++ b/src/camp2/raster/gggs_store_layer.cpp
@@ -1,0 +1,62 @@
+#include "gggs_store_layer.h"
+
+#include "gggs_tile_layer.h"
+
+#include <QDir>
+#include <QDirIterator>
+#include <QFileInfo>
+
+namespace camp
+{
+namespace raster
+{
+
+namespace
+{
+
+bool dirHasTifs(const QString& path)
+{
+  return !QDir(path).entryList(QStringList() << "*.tif" << "*.tiff",
+                               QDir::Files).isEmpty();
+}
+
+bool subtreeHasTifs(const QString& path)
+{
+  QDirIterator it(path, QStringList() << "*.tif" << "*.tiff", QDir::Files,
+                  QDirIterator::Subdirectories);
+  return it.hasNext();
+}
+
+}  // namespace
+
+GggsStoreLayer::GggsStoreLayer(map::MapItem* parentItem, const QString& directory):
+  map::Layer(parentItem, QFileInfo(directory).fileName()),
+  directory_(directory)
+{
+  build(directory);
+}
+
+void GggsStoreLayer::build(const QString& directory)
+{
+  QDir dir(directory);
+
+  // Tiles directly in this directory -> a tile-set leaf (handles a root that is
+  // itself a single tile-set).
+  if(dirHasTifs(directory))
+    new GggsTileLayer(this, directory);
+
+  // Each subdirectory: a leaf if it holds tiles directly, a grouping node if it
+  // only has tiles deeper down. Empty / tile-free subtrees are skipped.
+  const QStringList subs = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+  for(const QString& sub : subs)
+  {
+    const QString subpath = dir.filePath(sub);
+    if(dirHasTifs(subpath))
+      new GggsTileLayer(this, subpath);
+    else if(subtreeHasTifs(subpath))
+      new GggsStoreLayer(this, subpath);
+  }
+}
+
+}  // namespace raster
+}  // namespace camp

--- a/src/camp2/raster/gggs_store_layer.cpp
+++ b/src/camp2/raster/gggs_store_layer.cpp
@@ -5,6 +5,7 @@
 #include <QDir>
 #include <QDirIterator>
 #include <QFileInfo>
+#include <QSettings>
 
 namespace camp
 {
@@ -34,6 +35,16 @@ GggsStoreLayer::GggsStoreLayer(map::MapItem* parentItem, const QString& director
   directory_(directory)
 {
   build(directory);
+}
+
+void GggsStoreLayer::onRemovedByUser()
+{
+  // [camp#90] Drop this store root from the BackgroundManager restore list so a
+  // user-removed store stays gone next session.
+  QSettings settings;
+  QStringList roots = settings.value("GggsStores/roots").toStringList();
+  if(roots.removeAll(directory_) > 0)
+    settings.setValue("GggsStores/roots", roots);
 }
 
 void GggsStoreLayer::build(const QString& directory)

--- a/src/camp2/raster/gggs_store_layer.cpp
+++ b/src/camp2/raster/gggs_store_layer.cpp
@@ -37,7 +37,7 @@ GggsStoreLayer::GggsStoreLayer(map::MapItem* parentItem, const QString& director
   build(directory);
 }
 
-void GggsStoreLayer::onRemovedByUser()
+void GggsStoreLayer::onRemovedFromMap()
 {
   // [camp#90] Drop this store root from the BackgroundManager restore list so a
   // user-removed store stays gone next session.
@@ -58,7 +58,9 @@ void GggsStoreLayer::build(const QString& directory)
 
   // Each subdirectory: a leaf if it holds tiles directly, a grouping node if it
   // only has tiles deeper down. Empty / tile-free subtrees are skipped.
-  const QStringList subs = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+  // NoSymLinks guards against a directory-symlink loop recursing unbounded.
+  const QStringList subs = dir.entryList(
+    QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks, QDir::Name);
   for(const QString& sub : subs)
   {
     const QString subpath = dir.filePath(sub);

--- a/src/camp2/raster/gggs_store_layer.h
+++ b/src/camp2/raster/gggs_store_layer.h
@@ -28,7 +28,7 @@ public:
 
 protected:
   /// [camp#90] Drop this store root from the persisted list on user removal.
-  void onRemovedByUser() override;
+  void onRemovedFromMap() override;
 
 private:
   void build(const QString& directory);

--- a/src/camp2/raster/gggs_store_layer.h
+++ b/src/camp2/raster/gggs_store_layer.h
@@ -1,0 +1,38 @@
+#ifndef RASTER_GGGS_STORE_LAYER_H
+#define RASTER_GGGS_STORE_LAYER_H
+
+#include "../map/layer.h"
+
+namespace camp
+{
+namespace raster
+{
+
+/// [camp#90 / I4] Container layer for a GGGS tile *store*. Given a root
+/// directory it recursively builds the layer tree: any directory that directly
+/// contains `*.tif` becomes a renderable GggsTileLayer leaf; directories above
+/// those become grouping GggsStoreLayer nodes (e.g. a store root with
+/// `bathymetry/` and `sidescan_backscatter/<epoch>/` products). The node itself
+/// draws nothing — it only groups children in the Layers tree.
+class GggsStoreLayer: public map::Layer
+{
+  Q_OBJECT
+  Q_INTERFACES(QGraphicsItem)
+public:
+  GggsStoreLayer(map::MapItem* parentItem, const QString& directory);
+
+  enum { Type = map::GggsStoreLayerType };
+  int type() const override { return Type; }
+
+  const QString& directory() const { return directory_; }
+
+private:
+  void build(const QString& directory);
+
+  QString directory_;
+};
+
+}  // namespace raster
+}  // namespace camp
+
+#endif

--- a/src/camp2/raster/gggs_store_layer.h
+++ b/src/camp2/raster/gggs_store_layer.h
@@ -26,6 +26,10 @@ public:
 
   const QString& directory() const { return directory_; }
 
+protected:
+  /// [camp#90] Drop this store root from the persisted list on user removal.
+  void onRemovedByUser() override;
+
 private:
   void build(const QString& directory);
 

--- a/src/camp2/raster/gggs_tile.cpp
+++ b/src/camp2/raster/gggs_tile.cpp
@@ -1,0 +1,108 @@
+#include "gggs_tile.h"
+
+#include <gdal_priv.h>
+
+#include <QOpenGLTexture>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <utility>
+
+namespace camp
+{
+namespace raster
+{
+
+GggsTile::GggsTile(const QString& path):
+  path_(path)
+{
+  if(GDALGetDriverCount() == 0)
+    GDALAllRegister();
+
+  auto dataset = GDALDataset::FromHandle(GDALOpen(path.toUtf8().constData(), GA_ReadOnly));
+  if(!dataset)
+    return;
+
+  if(dataset->GetGeoTransform(geo_transform_) != CE_None || dataset->GetRasterCount() < 1)
+  {
+    GDALClose(dataset);
+    return;
+  }
+
+  const int width = dataset->GetRasterXSize();
+  const int height = dataset->GetRasterYSize();
+  auto band = dataset->GetRasterBand(1);
+
+  // Geographic extent from the geotransform. The tiles are north-up WGS84
+  // (geo[2] == geo[4] == 0, geo[1] > 0, geo[5] < 0): row 0 is the north edge.
+  const double x0 = geo_transform_[0];
+  const double y0 = geo_transform_[3];
+  const double x1 = x0 + width * geo_transform_[1] + height * geo_transform_[2];
+  const double y1 = y0 + width * geo_transform_[4] + height * geo_transform_[5];
+  min_lon_ = std::min(x0, x1);
+  max_lon_ = std::max(x0, x1);
+  min_lat_ = std::min(y0, y1);
+  max_lat_ = std::max(y0, y1);
+
+  int has_nodata = 0;
+  nodata_ = band->GetNoDataValue(&has_nodata);
+  has_nodata_ = has_nodata != 0;
+
+  std::vector<float> values(static_cast<size_t>(width) * height);
+  if(band->RasterIO(GF_Read, 0, 0, width, height, values.data(),
+                    width, height, GDT_Float32, 0, 0) != CE_None)
+  {
+    GDALClose(dataset);
+    return;
+  }
+  GDALClose(dataset);
+
+  // Range over valid samples (for the auto-ranged grayscale ramp).
+  double min_value = std::numeric_limits<double>::max();
+  double max_value = std::numeric_limits<double>::lowest();
+  for(float v : values)
+  {
+    if(!std::isfinite(v) || (has_nodata_ && v == nodata_))
+      continue;
+    min_value = std::min(min_value, double(v));
+    max_value = std::max(max_value, double(v));
+  }
+  data_min_ = min_value;
+  data_max_ = max_value;
+
+  data_ = std::move(values);
+  width_ = width;
+  height_ = height;
+}
+
+GggsTile::~GggsTile()
+{
+  // texture_ (QOpenGLTexture) must be destroyed with its context current; the
+  // layer calls releaseGL() under a current context before dropping the tile.
+  // If it survives to here (e.g. context already gone at shutdown), reset() may
+  // warn and leak the GL object — harmless on teardown.
+}
+
+QOpenGLTexture* GggsTile::texture()
+{
+  if(!texture_ && valid())
+  {
+    texture_ = std::make_unique<QOpenGLTexture>(QOpenGLTexture::Target2D);
+    texture_->setFormat(QOpenGLTexture::R32F);
+    texture_->setSize(width_, height_);
+    texture_->setMipLevels(1);
+    texture_->allocateStorage(QOpenGLTexture::Red, QOpenGLTexture::Float32);
+    texture_->setData(QOpenGLTexture::Red, QOpenGLTexture::Float32, data_.data());
+    texture_->setMinMagFilters(QOpenGLTexture::Linear, QOpenGLTexture::Linear);
+    texture_->setWrapMode(QOpenGLTexture::ClampToEdge);
+  }
+  return texture_.get();
+}
+
+void GggsTile::releaseGL()
+{
+  texture_.reset();
+}
+
+}  // namespace raster
+}  // namespace camp

--- a/src/camp2/raster/gggs_tile.cpp
+++ b/src/camp2/raster/gggs_tile.cpp
@@ -85,7 +85,7 @@ GggsTile::~GggsTile()
 
 QOpenGLTexture* GggsTile::texture()
 {
-  if(!texture_ && valid())
+  if(!texture_ && valid() && !data_.empty())
   {
     texture_ = std::make_unique<QOpenGLTexture>(QOpenGLTexture::Target2D);
     texture_->setFormat(QOpenGLTexture::R32F);
@@ -95,6 +95,10 @@ QOpenGLTexture* GggsTile::texture()
     texture_->setData(QOpenGLTexture::Red, QOpenGLTexture::Float32, data_.data());
     texture_->setMinMagFilters(QOpenGLTexture::Linear, QOpenGLTexture::Linear);
     texture_->setWrapMode(QOpenGLTexture::ClampToEdge);
+    // Free the CPU copy once it's on the GPU — the texture persists for the
+    // tile's lifetime, so we never re-upload (releaseGL = teardown). Halves
+    // resident memory per tile. dataMin/dataMax were captured at load.
+    data_ = std::vector<float>();
   }
   return texture_.get();
 }

--- a/src/camp2/raster/gggs_tile.h
+++ b/src/camp2/raster/gggs_tile.h
@@ -1,0 +1,72 @@
+#ifndef RASTER_GGGS_TILE_H
+#define RASTER_GGGS_TILE_H
+
+#include <QString>
+#include <memory>
+#include <vector>
+
+class QOpenGLTexture;
+
+namespace camp
+{
+namespace raster
+{
+
+/// [camp#90 / I4] One native-geographic GGGS raster tile loaded from a WGS84
+/// GeoTIFF (`<level>_<row>_<col>.tif`). Holds the CPU sample data + geographic
+/// extent (from the GDAL geotransform) and lazily uploads a single-channel
+/// float (R32F) GL texture for the GPU display-time warp. Unlike RasterLayer,
+/// the tile is NOT reprojected on load — it stays in lat/lon and is warped to
+/// Web-Mercator in the shader at display time (unh_marine_autonomy ADR-0002 §D2).
+class GggsTile
+{
+public:
+  /// Open a single-band-or-more north-up WGS84 GeoTIFF and read band 1 as
+  /// Float32. valid() is false if the file can't be opened / has no geotransform.
+  explicit GggsTile(const QString& path);
+  ~GggsTile();
+
+  bool valid() const { return width_ > 0 && height_ > 0; }
+
+  const QString& path() const { return path_; }
+  int width() const { return width_; }
+  int height() const { return height_; }
+
+  /// Geographic extent in degrees, pixel-edge aligned (north-up: row 0 = maxLat).
+  double minLon() const { return min_lon_; }
+  double maxLon() const { return max_lon_; }
+  double minLat() const { return min_lat_; }
+  double maxLat() const { return max_lat_; }
+
+  bool hasNoData() const { return has_nodata_; }
+  double noData() const { return nodata_; }
+
+  /// Min / max over valid (non-NoData, finite) samples. min_ > max_ if the tile
+  /// has no valid samples. Used by the layer to auto-range the grayscale ramp.
+  double dataMin() const { return data_min_; }
+  double dataMax() const { return data_max_; }
+
+  /// Ensure the R32F texture exists in the current GL context and return it.
+  /// Must be called with a current context (i.e. from within paint()).
+  QOpenGLTexture* texture();
+
+  /// Free the GL texture. Must be called with the owning context current.
+  void releaseGL();
+
+private:
+  QString path_;
+  int width_ = 0;
+  int height_ = 0;
+  double geo_transform_[6] = {0.0};
+  double min_lon_ = 0.0, max_lon_ = 0.0, min_lat_ = 0.0, max_lat_ = 0.0;
+  bool has_nodata_ = false;
+  double nodata_ = 0.0;
+  double data_min_ = 1.0, data_max_ = 0.0;   // crossed => no valid samples
+  std::vector<float> data_;                  // row-major, height_ * width_
+  std::unique_ptr<QOpenGLTexture> texture_;
+};
+
+}  // namespace raster
+}  // namespace camp
+
+#endif

--- a/src/camp2/raster/gggs_tile_layer.cpp
+++ b/src/camp2/raster/gggs_tile_layer.cpp
@@ -15,6 +15,7 @@
 #include <QOpenGLShaderProgram>
 #include <QOpenGLTexture>
 #include <QPainter>
+#include <QTransform>
 
 #include <cmath>
 #include <vector>
@@ -77,11 +78,18 @@ GggsTileLayer::GggsTileLayer(map::MapItem* parentItem, const QString& directory)
 {
   loadDirectory(directory);
   if(!tiles_.empty())
-    // Position the item at the extent's corner and paint in small LOCAL
-    // coordinates. QGraphicsView/QPainter lose precision rasterizing at raw
-    // Web-Mercator magnitudes (~1e7), which offsets the image; RasterLayer
-    // avoids this the same way (setPos + local pixel space).
-    setPos(scene_bounds_.topLeft());
+  {
+    // Match the camp2 raster convention (RasterLayer / MapTiles / grids): a
+    // NORTH-UP image anchored at the NW corner with a negative-Y item transform.
+    // The MapView applies its own scale(s, -s); composed with this fromScale(1,
+    // -1) the net Y is positive, so the image draws unmirrored and registers.
+    // (An identity transform + a south-up image relies on the view to mirror the
+    // image via drawImage, which misregisters it — the ~49 m latitude shift.)
+    // Local coordinates stay small (the extent, ~hundreds of m), so QPainter
+    // keeps precision at these large Web-Mercator positions.
+    setTransform(QTransform::fromScale(1.0, -1.0));
+    setPos(QPointF(scene_bounds_.left(), scene_bounds_.bottom()));   // NW corner
+  }
   else
     setStatus("(no tiles)");
 }
@@ -195,18 +203,17 @@ QImage GggsTileLayer::renderImage(const QSize& size)
 
   if(ensureProgram())
   {
-    // Map the layer's Web-Mercator extent to NDC. scene_bounds_ is normalised,
-    // so top() is the smaller mercator-y (south) and bottom() the larger
-    // (north). We want the offscreen QImage's row 0 to be the SOUTH edge, so
-    // that drawImage(boundingRect, image) — boundingRect.top() == south — is
-    // upright once MapView's negative-Y view flip puts north up on screen. So
-    // place south at NDC top (ortho 'top' param = south_y).
+    // Map the layer's Web-Mercator extent to NDC, producing a NORTH-UP image
+    // (row 0 = north): ortho 'top' param = north_y. The item carries a
+    // fromScale(1, -1) transform + NW anchor, so this north-up image draws
+    // upright (see the constructor). scene_bounds_ is normalised: top() is the
+    // smaller mercator-y (south), bottom() the larger (north).
     const double west_x = scene_bounds_.left();
     const double east_x = scene_bounds_.right();
     const double south_y = scene_bounds_.top();
     const double north_y = scene_bounds_.bottom();
     QMatrix4x4 mvp;
-    mvp.ortho(float(west_x), float(east_x), float(north_y), float(south_y),
+    mvp.ortho(float(west_x), float(east_x), float(south_y), float(north_y),
               -1.0f, 1.0f);
 
     program_->bind();

--- a/src/camp2/raster/gggs_tile_layer.cpp
+++ b/src/camp2/raster/gggs_tile_layer.cpp
@@ -28,24 +28,21 @@ namespace raster
 namespace
 {
 
-// Vertex shader: per-vertex geo->Web-Mercator warp. Line-by-line port of
-// web_mercator::geoToMap (x = R*lambda; y = R*asinh(tan phi)); asinh expanded as
-// log(t + sqrt(t^2+1)) to stay valid on GLSL profiles without the asinh builtin.
-// The geoToMap-parity unit test pins the formula so the shader can't drift.
+// Vertex shader: purely linear. The geo->Web-Mercator warp is done on the CPU in
+// double precision (web_mercator::geoToMap) per mesh vertex, with positions made
+// RELATIVE to the extent origin so values stay small. This is deliberate:
+// computing y = R*asinh(tan phi) in the shader used GPU transcendentals (tan/log/
+// sqrt) whose low precision, multiplied by R~6.4e6, produced a ~50 m latitude
+// error (longitude was exact because x = R*lambda needs no transcendental).
 constexpr char kVertexShader[] = R"(
 #version 120
-attribute vec2 a_lonlat;     // degrees
+attribute vec2 a_pos;        // local Web-Mercator metres (from extent origin)
 attribute vec2 a_texcoord;
-uniform mat4 u_mvp;          // scene(Web-Mercator) -> NDC
-uniform float u_radius;      // earth_radius_at_equator
+uniform mat4 u_mvp;          // local metres -> NDC
 varying vec2 v_texcoord;
 void main()
 {
-  float deg2rad = 0.0174532925199432958;
-  float x = a_lonlat.x * deg2rad * u_radius;
-  float t = tan(a_lonlat.y * deg2rad);
-  float y = log(t + sqrt(t * t + 1.0)) * u_radius;   // asinh(t) * R
-  gl_Position = u_mvp * vec4(x, y, 0.0, 1.0);
+  gl_Position = u_mvp * vec4(a_pos, 0.0, 1.0);
   v_texcoord = a_texcoord;
 }
 )";
@@ -203,34 +200,32 @@ QImage GggsTileLayer::renderImage(const QSize& size)
 
   if(ensureProgram())
   {
-    // Map the layer's Web-Mercator extent to NDC, producing a NORTH-UP image
-    // (row 0 = north): ortho 'top' param = north_y. The item carries a
-    // fromScale(1, -1) transform + NW anchor, so this north-up image draws
-    // upright (see the constructor). scene_bounds_ is normalised: top() is the
-    // smaller mercator-y (south), bottom() the larger (north).
-    const double west_x = scene_bounds_.left();
-    const double east_x = scene_bounds_.right();
-    const double south_y = scene_bounds_.top();
-    const double north_y = scene_bounds_.bottom();
+    // Vertices are LOCAL Web-Mercator metres from the extent origin (the SW
+    // corner), so map [0, width] x [0, height] -> NDC. local-y 0 = south,
+    // height = north, so 'top' = height gives a NORTH-UP image (row 0 = north);
+    // the item's fromScale(1,-1) + NW anchor draws it upright.
+    const double origin_x = scene_bounds_.left();    // west
+    const double origin_y = scene_bounds_.top();      // south (smaller mercator-y)
+    const double width_m = scene_bounds_.width();
+    const double height_m = scene_bounds_.height();
     QMatrix4x4 mvp;
-    mvp.ortho(float(west_x), float(east_x), float(south_y), float(north_y),
-              -1.0f, 1.0f);
+    mvp.ortho(0.0f, float(width_m), 0.0f, float(height_m), -1.0f, 1.0f);
 
     program_->bind();
     program_->setUniformValue("u_mvp", mvp);
-    program_->setUniformValue("u_radius",
-                              float(web_mercator::earth_radius_at_equator));
     program_->setUniformValue("u_min", float(data_min_));
     program_->setUniformValue("u_max", float(data_max_));
     program_->setUniformValue("u_tex", 0);
 
-    const int lonlat_loc = program_->attributeLocation("a_lonlat");
+    const int pos_loc = program_->attributeLocation("a_pos");
     const int texcoord_loc = program_->attributeLocation("a_texcoord");
-    program_->enableAttributeArray(lonlat_loc);
+    program_->enableAttributeArray(pos_loc);
     program_->enableAttributeArray(texcoord_loc);
 
-    // Per-tile triangle strip, subdivided in latitude only. Interleaved
-    // [lon, lat, u, v] per vertex.
+    // Per-tile triangle strip, subdivided in latitude only. Each vertex's
+    // Web-Mercator position is computed on the CPU (double precision) via
+    // web_mercator::geoToMap and made relative to the extent origin. Interleaved
+    // [local_x, local_y, u, v] per vertex.
     const int rows = kLatSubdivisions + 1;
     std::vector<float> verts;
     verts.reserve(rows * 2 * 4);
@@ -246,15 +241,19 @@ QImage GggsTileLayer::renderImage(const QSize& size)
         const double frac = double(r) / kLatSubdivisions;
         const double lat = max_lat + (min_lat - max_lat) * frac;   // north -> south
         const float v = float(frac);                               // tex row 0 = north
-        verts.insert(verts.end(), {float(min_lon), float(lat), 0.0f, v});
-        verts.insert(verts.end(), {float(max_lon), float(lat), 1.0f, v});
+        const QPointF l = web_mercator::geoToMap(QGeoCoordinate(lat, min_lon));
+        const QPointF rt = web_mercator::geoToMap(QGeoCoordinate(lat, max_lon));
+        verts.insert(verts.end(),
+                     {float(l.x() - origin_x), float(l.y() - origin_y), 0.0f, v});
+        verts.insert(verts.end(),
+                     {float(rt.x() - origin_x), float(rt.y() - origin_y), 1.0f, v});
       }
 
       QOpenGLTexture* texture = tile->texture();
       if(!texture)
         continue;
       texture->bind(0);
-      program_->setAttributeArray(lonlat_loc, GL_FLOAT, verts.data(), 2,
+      program_->setAttributeArray(pos_loc, GL_FLOAT, verts.data(), 2,
                                   4 * sizeof(float));
       program_->setAttributeArray(texcoord_loc, GL_FLOAT, verts.data() + 2, 2,
                                   4 * sizeof(float));
@@ -262,7 +261,7 @@ QImage GggsTileLayer::renderImage(const QSize& size)
       texture->release(0);
     }
 
-    program_->disableAttributeArray(lonlat_loc);
+    program_->disableAttributeArray(pos_loc);
     program_->disableAttributeArray(texcoord_loc);
     program_->release();
   }

--- a/src/camp2/raster/gggs_tile_layer.cpp
+++ b/src/camp2/raster/gggs_tile_layer.cpp
@@ -76,7 +76,13 @@ GggsTileLayer::GggsTileLayer(map::MapItem* parentItem, const QString& directory)
   directory_(directory)
 {
   loadDirectory(directory);
-  if(tiles_.empty())
+  if(!tiles_.empty())
+    // Position the item at the extent's corner and paint in small LOCAL
+    // coordinates. QGraphicsView/QPainter lose precision rasterizing at raw
+    // Web-Mercator magnitudes (~1e7), which offsets the image; RasterLayer
+    // avoids this the same way (setPos + local pixel space).
+    setPos(scene_bounds_.topLeft());
+  else
     setStatus("(no tiles)");
 }
 
@@ -118,7 +124,10 @@ void GggsTileLayer::loadDirectory(const QString& directory)
 
 QRectF GggsTileLayer::boundingRect() const
 {
-  return scene_bounds_;
+  // Local coordinates: the item is setPos()'d at scene_bounds_.topLeft(), so its
+  // own space spans (0,0)..(width,height) in Web-Mercator metres. paint() and
+  // drawImage() work here (small magnitudes) to keep QPainter precise.
+  return QRectF(QPointF(0.0, 0.0), scene_bounds_.size());
 }
 
 bool GggsTileLayer::ensureGL()

--- a/src/camp2/raster/gggs_tile_layer.cpp
+++ b/src/camp2/raster/gggs_tile_layer.cpp
@@ -3,10 +3,14 @@
 #include "gggs_tile.h"
 #include "../map_view/web_mercator.h"
 
+#include <QAction>
+#include <QColor>
 #include <QDebug>
 #include <QDir>
 #include <QFileInfo>
 #include <QGeoCoordinate>
+#include <QMenu>
+#include <QSettings>
 #include <QMatrix4x4>
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
@@ -47,13 +51,14 @@ void main()
 }
 )";
 
-// Fragment shader: auto-ranged grayscale of the single-band value. NoData (0,
+// Fragment shader: auto-ranged value mapped through a colormap LUT (the shared
+// camp::map::ColorMap baked to a 256x1 RGBA texture on the CPU). NoData (0,
 // reserved by the mosaicker; real returns floored to >= 1) is discarded so empty
-// cells are transparent. Premultiplied-alpha output. Band-select + real colormap
-// are Slice 3 (camp#63).
+// cells are transparent. Premultiplied-alpha output (opaque, so straight == premult).
 constexpr char kFragmentShader[] = R"(
 #version 120
-uniform sampler2D u_tex;
+uniform sampler2D u_tex;     // unit 0: single-band data (R32F)
+uniform sampler2D u_lut;     // unit 1: colormap LUT (256x1 RGBA)
 uniform float u_min;
 uniform float u_max;
 varying vec2 v_texcoord;
@@ -62,8 +67,9 @@ void main()
   float v = texture2D(u_tex, v_texcoord).r;
   if(v <= 0.0)
     discard;
-  float g = clamp((v - u_min) / max(u_max - u_min, 1.0), 0.0, 1.0);
-  gl_FragColor = vec4(g, g, g, 1.0);
+  float t = clamp((v - u_min) / max(u_max - u_min, 1.0), 0.0, 1.0);
+  vec4 c = texture2D(u_lut, vec2(t, 0.5));
+  gl_FragColor = vec4(c.rgb, 1.0);
 }
 )";
 
@@ -173,6 +179,36 @@ bool GggsTileLayer::ensureProgram()
   return true;
 }
 
+QOpenGLTexture* GggsTileLayer::ensureLut()
+{
+  // Bake camp::map::ColorMap into a 256x1 RGBA LUT (re-baked when the ramp
+  // changes). Sampled by the fragment shader as the colour transfer.
+  if(lut_texture_ && !lut_dirty_)
+    return lut_texture_.get();
+  std::vector<uchar> lut(256 * 4);
+  for(int i = 0; i < 256; ++i)
+  {
+    const QColor c = colormap_.colorNormalized(i / 255.0);
+    lut[i * 4 + 0] = uchar(c.red());
+    lut[i * 4 + 1] = uchar(c.green());
+    lut[i * 4 + 2] = uchar(c.blue());
+    lut[i * 4 + 3] = uchar(c.alpha());
+  }
+  if(!lut_texture_)
+  {
+    lut_texture_ = std::make_unique<QOpenGLTexture>(QOpenGLTexture::Target2D);
+    lut_texture_->setFormat(QOpenGLTexture::RGBA8_UNorm);
+    lut_texture_->setSize(256, 1);
+    lut_texture_->setMipLevels(1);
+    lut_texture_->allocateStorage(QOpenGLTexture::RGBA, QOpenGLTexture::UInt8);
+    lut_texture_->setMinMagFilters(QOpenGLTexture::Linear, QOpenGLTexture::Linear);
+    lut_texture_->setWrapMode(QOpenGLTexture::ClampToEdge);
+  }
+  lut_texture_->setData(QOpenGLTexture::RGBA, QOpenGLTexture::UInt8, lut.data());
+  lut_dirty_ = false;
+  return lut_texture_.get();
+}
+
 QImage GggsTileLayer::renderImage(const QSize& size)
 {
   if(tiles_.empty() || data_min_ > data_max_ || size.isEmpty())
@@ -216,6 +252,10 @@ QImage GggsTileLayer::renderImage(const QSize& size)
     program_->setUniformValue("u_min", float(data_min_));
     program_->setUniformValue("u_max", float(data_max_));
     program_->setUniformValue("u_tex", 0);
+    program_->setUniformValue("u_lut", 1);
+    QOpenGLTexture* lut = ensureLut();
+    if(lut)
+      lut->bind(1);
 
     const int pos_loc = program_->attributeLocation("a_pos");
     const int texcoord_loc = program_->attributeLocation("a_texcoord");
@@ -261,6 +301,8 @@ QImage GggsTileLayer::renderImage(const QSize& size)
       texture->release(0);
     }
 
+    if(lut)
+      lut->release(1);
     program_->disableAttributeArray(pos_loc);
     program_->disableAttributeArray(texcoord_loc);
     program_->release();
@@ -307,12 +349,66 @@ void GggsTileLayer::releaseGL()
   {
     fbo_.reset();
     program_.reset();
+    lut_texture_.reset();
     for(auto& tile : tiles_)
       tile->releaseGL();
     gl_context_->doneCurrent();
   }
   delete gl_context_; gl_context_ = nullptr;
   delete gl_surface_; gl_surface_ = nullptr;
+}
+
+void GggsTileLayer::setColormap(map::ColorMap::Type type)
+{
+  if(type == colormap_.type())
+    return;
+  colormap_.setType(type);
+  lut_dirty_ = true;
+  cached_image_ = QImage();   // force a re-render with the new ramp
+  writeSettings();
+  update(boundingRect());
+}
+
+void GggsTileLayer::contextMenu(QMenu* menu)
+{
+  map::Layer::contextMenu(menu);
+  QMenu* colormap_menu = menu->addMenu("Colormap");
+  for(auto type : map::ColorMap::allTypes())
+  {
+    QAction* action = colormap_menu->addAction(map::ColorMap::name(type));
+    action->setCheckable(true);
+    action->setChecked(type == colormap_.type());
+    connect(action, &QAction::triggered, this, [this, type]() { setColormap(type); });
+  }
+}
+
+void GggsTileLayer::readSettings()
+{
+  map::Layer::readSettings();
+  QSettings settings;
+  settings.beginGroup("MapItem");
+  settings.beginGroup(itemID());
+  const map::ColorMap::Type type = map::ColorMap::typeFromName(
+    settings.value("colormap", map::ColorMap::name(colormap_.type())).toString());
+  settings.endGroup();
+  settings.endGroup();
+  if(type != colormap_.type())
+  {
+    colormap_.setType(type);
+    lut_dirty_ = true;
+    cached_image_ = QImage();
+  }
+}
+
+void GggsTileLayer::writeSettings()
+{
+  map::Layer::writeSettings();
+  QSettings settings;
+  settings.beginGroup("MapItem");
+  settings.beginGroup(itemID());
+  settings.setValue("colormap", map::ColorMap::name(colormap_.type()));
+  settings.endGroup();
+  settings.endGroup();
 }
 
 }  // namespace raster

--- a/src/camp2/raster/gggs_tile_layer.cpp
+++ b/src/camp2/raster/gggs_tile_layer.cpp
@@ -3,19 +3,21 @@
 #include "gggs_tile.h"
 #include "../map_view/web_mercator.h"
 
+#include <QDebug>
 #include <QDir>
+#include <QFileInfo>
 #include <QGeoCoordinate>
 #include <QMatrix4x4>
+#include <QOffscreenSurface>
+#include <QOpenGLContext>
+#include <QOpenGLFramebufferObject>
+#include <QOpenGLFunctions>
 #include <QOpenGLShaderProgram>
 #include <QOpenGLTexture>
-#include <QOpenGLWidget>
 #include <QPainter>
-#include <QStyleOptionGraphicsItem>
-#include <QFileInfo>
 
-#include <algorithm>
-#include <array>
 #include <cmath>
+#include <vector>
 
 namespace camp
 {
@@ -25,11 +27,10 @@ namespace raster
 namespace
 {
 
-// Vertex shader: per-vertex geo→Web-Mercator warp. This is a line-by-line port
-// of web_mercator::geoToMap (x = R·λ; y = R·asinh(tan φ)); asinh is expanded as
-// log(t + sqrt(t²+1)) to stay valid on GLSL profiles without the asinh builtin.
-// The geoToMap-parity unit test pins the formula so the shader can't silently
-// drift from the C++ reference.
+// Vertex shader: per-vertex geo->Web-Mercator warp. Line-by-line port of
+// web_mercator::geoToMap (x = R*lambda; y = R*asinh(tan phi)); asinh expanded as
+// log(t + sqrt(t^2+1)) to stay valid on GLSL profiles without the asinh builtin.
+// The geoToMap-parity unit test pins the formula so the shader can't drift.
 constexpr char kVertexShader[] = R"(
 #version 120
 attribute vec2 a_lonlat;     // degrees
@@ -49,9 +50,9 @@ void main()
 )";
 
 // Fragment shader: auto-ranged grayscale of the single-band value. NoData (0,
-// reserved by the mosaicker; real returns are floored to >= 1) is discarded so
-// empty cells are transparent. Premultiplied-alpha output to composite under
-// Qt's GL paint engine. Band-select + real colormap are Slice 3 (camp#63).
+// reserved by the mosaicker; real returns floored to >= 1) is discarded so empty
+// cells are transparent. Premultiplied-alpha output. Band-select + real colormap
+// are Slice 3 (camp#63).
 constexpr char kFragmentShader[] = R"(
 #version 120
 uniform sampler2D u_tex;
@@ -82,24 +83,6 @@ GggsTileLayer::GggsTileLayer(map::MapItem* parentItem, const QString& directory)
 GggsTileLayer::~GggsTileLayer()
 {
   releaseGL();
-}
-
-void GggsTileLayer::releaseGL()
-{
-  // GL objects must be freed with their context current. If the viewport widget
-  // is still alive, make its context current; otherwise the objects fall to
-  // their destructors (a QOpenGLTexture with no current context warns + leaks,
-  // which only happens at app teardown when the context is gone anyway).
-  if(!program_ && tiles_.empty())
-    return;
-  const bool have_ctx = gl_widget_ && gl_widget_->context();
-  if(have_ctx)
-    gl_widget_->makeCurrent();
-  program_.reset();
-  for(auto& tile : tiles_)
-    tile->releaseGL();
-  if(have_ctx)
-    gl_widget_->doneCurrent();
 }
 
 void GggsTileLayer::loadDirectory(const QString& directory)
@@ -138,6 +121,27 @@ QRectF GggsTileLayer::boundingRect() const
   return scene_bounds_;
 }
 
+bool GggsTileLayer::ensureGL()
+{
+  if(gl_context_)
+    return true;
+  if(gl_failed_)
+    return false;
+
+  gl_surface_ = new QOffscreenSurface();
+  gl_surface_->create();
+  gl_context_ = new QOpenGLContext();
+  if(!gl_surface_->isValid() || !gl_context_->create())
+  {
+    qWarning("GggsTileLayer: offscreen GL unavailable; tiles not rendered");
+    gl_failed_ = true;
+    delete gl_context_; gl_context_ = nullptr;
+    delete gl_surface_; gl_surface_ = nullptr;
+    return false;
+  }
+  return true;
+}
+
 bool GggsTileLayer::ensureProgram()
 {
   if(program_)
@@ -147,51 +151,54 @@ bool GggsTileLayer::ensureProgram()
   program_->addShaderFromSourceCode(QOpenGLShader::Fragment, kFragmentShader);
   if(!program_->link())
   {
+    qWarning("GggsTileLayer: shader link failed: %s",
+             program_->log().toUtf8().constData());
     setStatus("(shader error)");
     return false;
   }
   return true;
 }
 
-void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget* widget)
+QImage GggsTileLayer::renderImage(const QSize& size)
 {
-  if(tiles_.empty())
-    return;
-  // Auto-range needs valid samples; a fully-NoData mosaic has nothing to draw.
-  if(data_min_ > data_max_)
-    return;
-
-  painter->beginNativePainting();
-
-  if(!gl_ready_)
+  if(tiles_.empty() || data_min_ > data_max_ || size.isEmpty())
+    return QImage();
+  if(!ensureGL())
+    return QImage();
+  if(!gl_context_->makeCurrent(gl_surface_))
   {
-    initializeOpenGLFunctions();
-    gl_ready_ = true;
+    qWarning("GggsTileLayer: makeCurrent failed; tiles not rendered");
+    gl_failed_ = true;
+    return QImage();
   }
-  if(!gl_widget_)
-    gl_widget_ = qobject_cast<QOpenGLWidget*>(widget);
+
+  QOpenGLFunctions* f = gl_context_->functions();
+  if(!fbo_ || fbo_->size() != size)
+    fbo_ = std::make_unique<QOpenGLFramebufferObject>(size);
+
+  fbo_->bind();
+  f->glViewport(0, 0, size.width(), size.height());
+  f->glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  f->glClear(GL_COLOR_BUFFER_BIT);
+  f->glDisable(GL_DEPTH_TEST);
+  f->glEnable(GL_BLEND);
+  f->glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
   if(ensureProgram())
   {
-    // MVP: scene(Web-Mercator) -> viewport logical px (the live QPainter world
-    // transform, which carries MapView's negative-Y flip + pan/zoom) -> NDC. The
-    // GL viewport covers the full framebuffer, so normalizing by logical size is
-    // device-pixel-ratio independent.
-    const QTransform w = painter->worldTransform();
-    const QMatrix4x4 world(
-      w.m11(), w.m21(), 0.0f, w.dx(),
-      w.m12(), w.m22(), 0.0f, w.dy(),
-      0.0f, 0.0f, 1.0f, 0.0f,
-      0.0f, 0.0f, 0.0f, 1.0f);
-    const double vw = widget ? widget->width() : painter->device()->width();
-    const double vh = widget ? widget->height() : painter->device()->height();
-    QMatrix4x4 ortho;
-    ortho.ortho(0.0f, float(vw), float(vh), 0.0f, -1.0f, 1.0f);
-    const QMatrix4x4 mvp = ortho * world;
-
-    glDisable(GL_DEPTH_TEST);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+    // Map the layer's Web-Mercator extent to NDC. scene_bounds_ is normalised,
+    // so top() is the smaller mercator-y (south) and bottom() the larger
+    // (north). We want the offscreen QImage's row 0 to be the SOUTH edge, so
+    // that drawImage(boundingRect, image) — boundingRect.top() == south — is
+    // upright once MapView's negative-Y view flip puts north up on screen. So
+    // place south at NDC top (ortho 'top' param = south_y).
+    const double west_x = scene_bounds_.left();
+    const double east_x = scene_bounds_.right();
+    const double south_y = scene_bounds_.top();
+    const double north_y = scene_bounds_.bottom();
+    QMatrix4x4 mvp;
+    mvp.ortho(float(west_x), float(east_x), float(north_y), float(south_y),
+              -1.0f, 1.0f);
 
     program_->bind();
     program_->setUniformValue("u_mvp", mvp);
@@ -206,8 +213,8 @@ void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QW
     program_->enableAttributeArray(lonlat_loc);
     program_->enableAttributeArray(texcoord_loc);
 
-    // Per-tile triangle strip, subdivided in latitude only (longitude is the
-    // linear axis of the warp). Interleaved [lon, lat, u, v] per vertex.
+    // Per-tile triangle strip, subdivided in latitude only. Interleaved
+    // [lon, lat, u, v] per vertex.
     const int rows = kLatSubdivisions + 1;
     std::vector<float> verts;
     verts.reserve(rows * 2 * 4);
@@ -223,7 +230,6 @@ void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QW
         const double frac = double(r) / kLatSubdivisions;
         const double lat = max_lat + (min_lat - max_lat) * frac;   // north -> south
         const float v = float(frac);                               // tex row 0 = north
-        // left edge (u = 0), then right edge (u = 1)
         verts.insert(verts.end(), {float(min_lon), float(lat), 0.0f, v});
         verts.insert(verts.end(), {float(max_lon), float(lat), 1.0f, v});
       }
@@ -236,7 +242,7 @@ void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QW
                                   4 * sizeof(float));
       program_->setAttributeArray(texcoord_loc, GL_FLOAT, verts.data() + 2, 2,
                                   4 * sizeof(float));
-      glDrawArrays(GL_TRIANGLE_STRIP, 0, rows * 2);
+      f->glDrawArrays(GL_TRIANGLE_STRIP, 0, rows * 2);
       texture->release(0);
     }
 
@@ -245,7 +251,53 @@ void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QW
     program_->release();
   }
 
-  painter->endNativePainting();
+  fbo_->release();
+  QImage image = fbo_->toImage();   // top-down ARGB32 (premultiplied)
+  gl_context_->doneCurrent();
+  return image;
+}
+
+void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*)
+{
+  if(tiles_.empty() || data_min_ > data_max_)
+    return;
+
+  // Target the offscreen render at the extent's on-screen size, so the image is
+  // crisp at the current zoom. Re-render only when that size changes (zoom);
+  // pan reuses the cached image (drawImage repositions it via the world xform).
+  const QRectF dev = painter->worldTransform().mapRect(boundingRect());
+  const int w = std::min(kMaxImageEdge,
+                         std::max(1, int(std::ceil(std::abs(dev.width())))));
+  const int h = std::min(kMaxImageEdge,
+                         std::max(1, int(std::ceil(std::abs(dev.height())))));
+  const QSize size(w, h);
+
+  if(cached_image_.isNull() || cached_size_ != size)
+  {
+    cached_image_ = renderImage(size);
+    cached_size_ = size;
+  }
+  if(cached_image_.isNull())
+    return;
+
+  painter->save();
+  painter->setRenderHint(QPainter::SmoothPixmapTransform);
+  painter->drawImage(boundingRect(), cached_image_);
+  painter->restore();
+}
+
+void GggsTileLayer::releaseGL()
+{
+  if(gl_context_ && gl_surface_ && gl_context_->makeCurrent(gl_surface_))
+  {
+    fbo_.reset();
+    program_.reset();
+    for(auto& tile : tiles_)
+      tile->releaseGL();
+    gl_context_->doneCurrent();
+  }
+  delete gl_context_; gl_context_ = nullptr;
+  delete gl_surface_; gl_surface_ = nullptr;
 }
 
 }  // namespace raster

--- a/src/camp2/raster/gggs_tile_layer.cpp
+++ b/src/camp2/raster/gggs_tile_layer.cpp
@@ -1,0 +1,252 @@
+#include "gggs_tile_layer.h"
+
+#include "gggs_tile.h"
+#include "../map_view/web_mercator.h"
+
+#include <QDir>
+#include <QGeoCoordinate>
+#include <QMatrix4x4>
+#include <QOpenGLShaderProgram>
+#include <QOpenGLTexture>
+#include <QOpenGLWidget>
+#include <QPainter>
+#include <QStyleOptionGraphicsItem>
+#include <QFileInfo>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace camp
+{
+namespace raster
+{
+
+namespace
+{
+
+// Vertex shader: per-vertex geo→Web-Mercator warp. This is a line-by-line port
+// of web_mercator::geoToMap (x = R·λ; y = R·asinh(tan φ)); asinh is expanded as
+// log(t + sqrt(t²+1)) to stay valid on GLSL profiles without the asinh builtin.
+// The geoToMap-parity unit test pins the formula so the shader can't silently
+// drift from the C++ reference.
+constexpr char kVertexShader[] = R"(
+#version 120
+attribute vec2 a_lonlat;     // degrees
+attribute vec2 a_texcoord;
+uniform mat4 u_mvp;          // scene(Web-Mercator) -> NDC
+uniform float u_radius;      // earth_radius_at_equator
+varying vec2 v_texcoord;
+void main()
+{
+  float deg2rad = 0.0174532925199432958;
+  float x = a_lonlat.x * deg2rad * u_radius;
+  float t = tan(a_lonlat.y * deg2rad);
+  float y = log(t + sqrt(t * t + 1.0)) * u_radius;   // asinh(t) * R
+  gl_Position = u_mvp * vec4(x, y, 0.0, 1.0);
+  v_texcoord = a_texcoord;
+}
+)";
+
+// Fragment shader: auto-ranged grayscale of the single-band value. NoData (0,
+// reserved by the mosaicker; real returns are floored to >= 1) is discarded so
+// empty cells are transparent. Premultiplied-alpha output to composite under
+// Qt's GL paint engine. Band-select + real colormap are Slice 3 (camp#63).
+constexpr char kFragmentShader[] = R"(
+#version 120
+uniform sampler2D u_tex;
+uniform float u_min;
+uniform float u_max;
+varying vec2 v_texcoord;
+void main()
+{
+  float v = texture2D(u_tex, v_texcoord).r;
+  if(v <= 0.0)
+    discard;
+  float g = clamp((v - u_min) / max(u_max - u_min, 1.0), 0.0, 1.0);
+  gl_FragColor = vec4(g, g, g, 1.0);
+}
+)";
+
+}  // namespace
+
+GggsTileLayer::GggsTileLayer(map::MapItem* parentItem, const QString& directory):
+  map::Layer(parentItem, QFileInfo(directory).fileName()),
+  directory_(directory)
+{
+  loadDirectory(directory);
+  if(tiles_.empty())
+    setStatus("(no tiles)");
+}
+
+GggsTileLayer::~GggsTileLayer()
+{
+  releaseGL();
+}
+
+void GggsTileLayer::releaseGL()
+{
+  // GL objects must be freed with their context current. If the viewport widget
+  // is still alive, make its context current; otherwise the objects fall to
+  // their destructors (a QOpenGLTexture with no current context warns + leaks,
+  // which only happens at app teardown when the context is gone anyway).
+  if(!program_ && tiles_.empty())
+    return;
+  const bool have_ctx = gl_widget_ && gl_widget_->context();
+  if(have_ctx)
+    gl_widget_->makeCurrent();
+  program_.reset();
+  for(auto& tile : tiles_)
+    tile->releaseGL();
+  if(have_ctx)
+    gl_widget_->doneCurrent();
+}
+
+void GggsTileLayer::loadDirectory(const QString& directory)
+{
+  QDir dir(directory);
+  const QStringList files = dir.entryList(QStringList() << "*.tif" << "*.tiff",
+                                          QDir::Files, QDir::Name);
+  bool first = true;
+  for(const QString& name : files)
+  {
+    auto tile = std::make_unique<GggsTile>(dir.filePath(name));
+    if(!tile->valid())
+      continue;
+
+    // Tile extent in Web-Mercator scene units. geoToMap is monotonic in both
+    // lon and lat, so the two opposite geographic corners give the scene rect.
+    const QPointF lo = web_mercator::geoToMap(
+      QGeoCoordinate(tile->minLat(), tile->minLon()));
+    const QPointF hi = web_mercator::geoToMap(
+      QGeoCoordinate(tile->maxLat(), tile->maxLon()));
+    const QRectF tile_rect = QRectF(lo, hi).normalized();
+    scene_bounds_ = first ? tile_rect : scene_bounds_.united(tile_rect);
+
+    if(tile->dataMin() <= tile->dataMax())   // tile has valid samples
+    {
+      if(first || tile->dataMin() < data_min_) data_min_ = tile->dataMin();
+      if(first || tile->dataMax() > data_max_) data_max_ = tile->dataMax();
+    }
+    first = false;
+    tiles_.push_back(std::move(tile));
+  }
+}
+
+QRectF GggsTileLayer::boundingRect() const
+{
+  return scene_bounds_;
+}
+
+bool GggsTileLayer::ensureProgram()
+{
+  if(program_)
+    return program_->isLinked();
+  program_ = std::make_unique<QOpenGLShaderProgram>();
+  program_->addShaderFromSourceCode(QOpenGLShader::Vertex, kVertexShader);
+  program_->addShaderFromSourceCode(QOpenGLShader::Fragment, kFragmentShader);
+  if(!program_->link())
+  {
+    setStatus("(shader error)");
+    return false;
+  }
+  return true;
+}
+
+void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget* widget)
+{
+  if(tiles_.empty())
+    return;
+  // Auto-range needs valid samples; a fully-NoData mosaic has nothing to draw.
+  if(data_min_ > data_max_)
+    return;
+
+  painter->beginNativePainting();
+
+  if(!gl_ready_)
+  {
+    initializeOpenGLFunctions();
+    gl_ready_ = true;
+  }
+  if(!gl_widget_)
+    gl_widget_ = qobject_cast<QOpenGLWidget*>(widget);
+
+  if(ensureProgram())
+  {
+    // MVP: scene(Web-Mercator) -> viewport logical px (the live QPainter world
+    // transform, which carries MapView's negative-Y flip + pan/zoom) -> NDC. The
+    // GL viewport covers the full framebuffer, so normalizing by logical size is
+    // device-pixel-ratio independent.
+    const QTransform w = painter->worldTransform();
+    const QMatrix4x4 world(
+      w.m11(), w.m21(), 0.0f, w.dx(),
+      w.m12(), w.m22(), 0.0f, w.dy(),
+      0.0f, 0.0f, 1.0f, 0.0f,
+      0.0f, 0.0f, 0.0f, 1.0f);
+    const double vw = widget ? widget->width() : painter->device()->width();
+    const double vh = widget ? widget->height() : painter->device()->height();
+    QMatrix4x4 ortho;
+    ortho.ortho(0.0f, float(vw), float(vh), 0.0f, -1.0f, 1.0f);
+    const QMatrix4x4 mvp = ortho * world;
+
+    glDisable(GL_DEPTH_TEST);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+
+    program_->bind();
+    program_->setUniformValue("u_mvp", mvp);
+    program_->setUniformValue("u_radius",
+                              float(web_mercator::earth_radius_at_equator));
+    program_->setUniformValue("u_min", float(data_min_));
+    program_->setUniformValue("u_max", float(data_max_));
+    program_->setUniformValue("u_tex", 0);
+
+    const int lonlat_loc = program_->attributeLocation("a_lonlat");
+    const int texcoord_loc = program_->attributeLocation("a_texcoord");
+    program_->enableAttributeArray(lonlat_loc);
+    program_->enableAttributeArray(texcoord_loc);
+
+    // Per-tile triangle strip, subdivided in latitude only (longitude is the
+    // linear axis of the warp). Interleaved [lon, lat, u, v] per vertex.
+    const int rows = kLatSubdivisions + 1;
+    std::vector<float> verts;
+    verts.reserve(rows * 2 * 4);
+    for(auto& tile : tiles_)
+    {
+      verts.clear();
+      const double min_lon = tile->minLon();
+      const double max_lon = tile->maxLon();
+      const double min_lat = tile->minLat();
+      const double max_lat = tile->maxLat();
+      for(int r = 0; r < rows; ++r)
+      {
+        const double frac = double(r) / kLatSubdivisions;
+        const double lat = max_lat + (min_lat - max_lat) * frac;   // north -> south
+        const float v = float(frac);                               // tex row 0 = north
+        // left edge (u = 0), then right edge (u = 1)
+        verts.insert(verts.end(), {float(min_lon), float(lat), 0.0f, v});
+        verts.insert(verts.end(), {float(max_lon), float(lat), 1.0f, v});
+      }
+
+      QOpenGLTexture* texture = tile->texture();
+      if(!texture)
+        continue;
+      texture->bind(0);
+      program_->setAttributeArray(lonlat_loc, GL_FLOAT, verts.data(), 2,
+                                  4 * sizeof(float));
+      program_->setAttributeArray(texcoord_loc, GL_FLOAT, verts.data() + 2, 2,
+                                  4 * sizeof(float));
+      glDrawArrays(GL_TRIANGLE_STRIP, 0, rows * 2);
+      texture->release(0);
+    }
+
+    program_->disableAttributeArray(lonlat_loc);
+    program_->disableAttributeArray(texcoord_loc);
+    program_->release();
+  }
+
+  painter->endNativePainting();
+}
+
+}  // namespace raster
+}  // namespace camp

--- a/src/camp2/raster/gggs_tile_layer.cpp
+++ b/src/camp2/raster/gggs_tile_layer.cpp
@@ -107,7 +107,8 @@ void GggsTileLayer::loadDirectory(const QString& directory)
   QDir dir(directory);
   const QStringList files = dir.entryList(QStringList() << "*.tif" << "*.tiff",
                                           QDir::Files, QDir::Name);
-  bool first = true;
+  bool first_extent = true;   // first geometrically-valid tile (scene_bounds_)
+  bool first_range = true;    // first tile WITH valid samples (data range)
   for(const QString& name : files)
   {
     auto tile = std::make_unique<GggsTile>(dir.filePath(name));
@@ -121,14 +122,18 @@ void GggsTileLayer::loadDirectory(const QString& directory)
     const QPointF hi = web_mercator::geoToMap(
       QGeoCoordinate(tile->maxLat(), tile->maxLon()));
     const QRectF tile_rect = QRectF(lo, hi).normalized();
-    scene_bounds_ = first ? tile_rect : scene_bounds_.united(tile_rect);
+    scene_bounds_ = first_extent ? tile_rect : scene_bounds_.united(tile_rect);
+    first_extent = false;
 
-    if(tile->dataMin() <= tile->dataMax())   // tile has valid samples
+    // Data range tracks the first tile that actually HAS samples — separately
+    // from the extent, or an all-NoData first tile would leave data_min_ stuck
+    // at the sentinel (its default 1.0 is never < a floored-to->=1 sample).
+    if(tile->dataMin() <= tile->dataMax())
     {
-      if(first || tile->dataMin() < data_min_) data_min_ = tile->dataMin();
-      if(first || tile->dataMax() > data_max_) data_max_ = tile->dataMax();
+      if(first_range || tile->dataMin() < data_min_) data_min_ = tile->dataMin();
+      if(first_range || tile->dataMax() > data_max_) data_max_ = tile->dataMax();
+      first_range = false;
     }
-    first = false;
     tiles_.push_back(std::move(tile));
   }
 }
@@ -143,10 +148,13 @@ QRectF GggsTileLayer::boundingRect() const
 
 bool GggsTileLayer::ensureGL()
 {
-  if(gl_context_)
-    return true;
+  // gl_failed_ first: once GL is declared broken (creation OR a mid-session
+  // makeCurrent failure), stay failed and don't retry — otherwise every repaint
+  // re-enters renderImage (cached_image_ never populates) and re-warns.
   if(gl_failed_)
     return false;
+  if(gl_context_)
+    return true;
 
   gl_surface_ = new QOffscreenSurface();
   gl_surface_->create();

--- a/src/camp2/raster/gggs_tile_layer.h
+++ b/src/camp2/raster/gggs_tile_layer.h
@@ -1,0 +1,78 @@
+#ifndef RASTER_GGGS_TILE_LAYER_H
+#define RASTER_GGGS_TILE_LAYER_H
+
+#include "../map/layer.h"
+
+#include <QOpenGLFunctions>
+#include <QPointer>
+#include <memory>
+#include <vector>
+
+class QOpenGLShaderProgram;
+class QOpenGLWidget;
+
+namespace camp
+{
+namespace raster
+{
+
+class GggsTile;
+
+/// [camp#90 / I4] Map layer that renders a directory of GGGS raster tiles
+/// (native-geographic WGS84 GeoTIFFs from marine_sidescan_mosaic #173 / the
+/// bathymetry store) by warping each tile into the Web-Mercator scene on the
+/// GPU at display time. Slice 1: single-band grayscale (auto-ranged), fixed
+/// tessellation; band-select + colormap are Slice 3 (camp#63 GPU facility).
+///
+/// The layer lives at the scene origin with an identity item transform, so its
+/// local coordinates ARE Web-Mercator scene coordinates; each tile vertex is
+/// supplied in lon/lat and the vertex shader applies web_mercator::geoToMap
+/// (the only nonlinearity is the 1-D latitude warp), then the MVP built from the
+/// live QPainter transform maps scene → NDC so tiles register with vector
+/// overlays and the existing CPU raster/tile layers.
+class GggsTileLayer: public map::Layer, protected QOpenGLFunctions
+{
+  Q_OBJECT
+  Q_INTERFACES(QGraphicsItem)
+public:
+  GggsTileLayer(map::MapItem* parentItem, const QString& directory);
+  ~GggsTileLayer();
+
+  enum { Type = map::GggsTileLayerType };
+  int type() const override { return Type; }
+
+  QRectF boundingRect() const override;
+  void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
+
+  /// Directory of `<level>_<row>_<col>.tif` tiles this layer renders.
+  const QString& directory() const { return directory_; }
+
+  /// True once at least one valid tile loaded.
+  bool valid() const { return !tiles_.empty(); }
+
+private:
+  void loadDirectory(const QString& directory);
+  bool ensureProgram();
+  void releaseGL();
+
+  // Latitude tessellation per tile. The geo→Web-Mercator warp is separable:
+  // longitude is linear (no subdivision needed), latitude is the lone
+  // nonlinearity. 16 strips is sub-pixel over a tile at these zooms (Slice 2
+  // tunes/justifies this against a < 0.5 px error budget).
+  static constexpr int kLatSubdivisions = 16;
+
+  QString directory_;
+  std::vector<std::unique_ptr<GggsTile>> tiles_;
+  QRectF scene_bounds_;        // union of tile extents in Web-Mercator scene units
+  double data_min_ = 1.0;      // auto-range over all tiles (crossed => no data)
+  double data_max_ = 0.0;
+
+  std::unique_ptr<QOpenGLShaderProgram> program_;
+  QPointer<QOpenGLWidget> gl_widget_;   // for making the context current on teardown
+  bool gl_ready_ = false;
+};
+
+}  // namespace raster
+}  // namespace camp
+
+#endif

--- a/src/camp2/raster/gggs_tile_layer.h
+++ b/src/camp2/raster/gggs_tile_layer.h
@@ -3,13 +3,15 @@
 
 #include "../map/layer.h"
 
-#include <QOpenGLFunctions>
-#include <QPointer>
+#include <QImage>
+#include <QSize>
 #include <memory>
 #include <vector>
 
+class QOpenGLContext;
+class QOffscreenSurface;
+class QOpenGLFramebufferObject;
 class QOpenGLShaderProgram;
-class QOpenGLWidget;
 
 namespace camp
 {
@@ -21,16 +23,21 @@ class GggsTile;
 /// [camp#90 / I4] Map layer that renders a directory of GGGS raster tiles
 /// (native-geographic WGS84 GeoTIFFs from marine_sidescan_mosaic #173 / the
 /// bathymetry store) by warping each tile into the Web-Mercator scene on the
-/// GPU at display time. Slice 1: single-band grayscale (auto-ranged), fixed
-/// tessellation; band-select + colormap are Slice 3 (camp#63 GPU facility).
+/// GPU — but to an **offscreen framebuffer the layer owns**, then presenting the
+/// result with QPainter::drawImage(). This is portable across X11 / Wayland /
+/// software GL, independent of whether QGraphicsView paints its viewport through
+/// a GL context (it generally does not — native painting in an item gives no
+/// current context under a Wayland software backingstore).
 ///
-/// The layer lives at the scene origin with an identity item transform, so its
-/// local coordinates ARE Web-Mercator scene coordinates; each tile vertex is
-/// supplied in lon/lat and the vertex shader applies web_mercator::geoToMap
-/// (the only nonlinearity is the 1-D latitude warp), then the MVP built from the
-/// live QPainter transform maps scene → NDC so tiles register with vector
-/// overlays and the existing CPU raster/tile layers.
-class GggsTileLayer: public map::Layer, protected QOpenGLFunctions
+/// The vertex shader applies web_mercator::geoToMap (the only nonlinearity is
+/// the 1-D latitude warp), so the offscreen image is a Web-Mercator raster of
+/// the layer's extent; drawing it into boundingRect() (also Web-Mercator) keeps
+/// it registered with the vector overlays and CPU raster/tile layers.
+///
+/// Slice 1: single-band auto-ranged grayscale (sidescan); fixed tessellation;
+/// whole-extent render cached by on-screen size. Band-select + colormap are
+/// Slice 3 (camp#63 GPU facility); visible-region-only render is Slice 2.
+class GggsTileLayer: public map::Layer
 {
   Q_OBJECT
   Q_INTERFACES(QGraphicsItem)
@@ -50,16 +57,24 @@ public:
   /// True once at least one valid tile loaded.
   bool valid() const { return !tiles_.empty(); }
 
+  /// Warp the tiles into an offscreen image of @p size spanning the layer's
+  /// Web-Mercator extent (boundingRect). Returns a null image if there is no
+  /// data or GL is unavailable. Exposed so a headless test can render + inspect
+  /// without a window.
+  QImage renderImage(const QSize& size);
+
 private:
   void loadDirectory(const QString& directory);
+  bool ensureGL();
   bool ensureProgram();
   void releaseGL();
 
-  // Latitude tessellation per tile. The geo→Web-Mercator warp is separable:
-  // longitude is linear (no subdivision needed), latitude is the lone
-  // nonlinearity. 16 strips is sub-pixel over a tile at these zooms (Slice 2
-  // tunes/justifies this against a < 0.5 px error budget).
+  // Latitude tessellation per tile. The geo->Web-Mercator warp is separable:
+  // longitude is linear, latitude is the lone nonlinearity. 16 strips is
+  // sub-pixel over a tile at these zooms (Slice 2 tunes this to a < 0.5 px
+  // budget and renders only the visible region for large surveys).
   static constexpr int kLatSubdivisions = 16;
+  static constexpr int kMaxImageEdge = 4096;   // clamp the offscreen target
 
   QString directory_;
   std::vector<std::unique_ptr<GggsTile>> tiles_;
@@ -67,9 +82,16 @@ private:
   double data_min_ = 1.0;      // auto-range over all tiles (crossed => no data)
   double data_max_ = 0.0;
 
+  // The layer's own offscreen GL context — created lazily, used only for the
+  // FBO render; never touches the GUI's context.
+  QOpenGLContext* gl_context_ = nullptr;
+  QOffscreenSurface* gl_surface_ = nullptr;
+  std::unique_ptr<QOpenGLFramebufferObject> fbo_;
   std::unique_ptr<QOpenGLShaderProgram> program_;
-  QPointer<QOpenGLWidget> gl_widget_;   // for making the context current on teardown
-  bool gl_ready_ = false;
+  bool gl_failed_ = false;
+
+  QImage cached_image_;        // last render, reused on pan (re-rendered on zoom)
+  QSize cached_size_;
 };
 
 }  // namespace raster

--- a/src/camp2/raster/gggs_tile_layer.h
+++ b/src/camp2/raster/gggs_tile_layer.h
@@ -57,6 +57,10 @@ public:
   /// True once at least one valid tile loaded.
   bool valid() const { return !tiles_.empty(); }
 
+  /// The layer's Web-Mercator extent (union of tile extents). The item is
+  /// setPos()'d at its top-left; exposed for tests.
+  QRectF sceneBounds() const { return scene_bounds_; }
+
   /// Warp the tiles into an offscreen image of @p size spanning the layer's
   /// Web-Mercator extent (boundingRect). Returns a null image if there is no
   /// data or GL is unavailable. Exposed so a headless test can render + inspect

--- a/src/camp2/raster/gggs_tile_layer.h
+++ b/src/camp2/raster/gggs_tile_layer.h
@@ -2,6 +2,7 @@
 #define RASTER_GGGS_TILE_LAYER_H
 
 #include "../map/layer.h"
+#include "../map/color_map.h"
 
 #include <QImage>
 #include <QSize>
@@ -12,6 +13,7 @@ class QOpenGLContext;
 class QOffscreenSurface;
 class QOpenGLFramebufferObject;
 class QOpenGLShaderProgram;
+class QOpenGLTexture;
 
 namespace camp
 {
@@ -67,10 +69,20 @@ public:
   /// without a window.
   QImage renderImage(const QSize& size);
 
+  /// [camp#90] Select the colour ramp (the shared camp::map::ColorMap, baked to
+  /// a GPU LUT). Persists and re-renders.
+  void setColormap(map::ColorMap::Type type);
+
+protected:
+  void contextMenu(QMenu* menu) override;
+  void readSettings() override;
+  void writeSettings() override;
+
 private:
   void loadDirectory(const QString& directory);
   bool ensureGL();
   bool ensureProgram();
+  QOpenGLTexture* ensureLut();
   void releaseGL();
 
   // Latitude tessellation per tile. The geo->Web-Mercator warp is separable:
@@ -92,7 +104,12 @@ private:
   QOffscreenSurface* gl_surface_ = nullptr;
   std::unique_ptr<QOpenGLFramebufferObject> fbo_;
   std::unique_ptr<QOpenGLShaderProgram> program_;
+  std::unique_ptr<QOpenGLTexture> lut_texture_;   // colormap LUT (256x1 RGBA)
   bool gl_failed_ = false;
+
+  // Default grayscale preserves the original look; selectable via context menu.
+  map::ColorMap colormap_{map::ColorMap::Grayscale};
+  bool lut_dirty_ = true;      // re-bake the LUT on next render after a change
 
   QImage cached_image_;        // last render, reused on pan (re-rendered on zoom)
   QSize cached_size_;

--- a/src/camp2/raster/raster_layer.cpp
+++ b/src/camp2/raster/raster_layer.cpp
@@ -159,12 +159,15 @@ RasterLayer::LoadResult RasterLayer::loadAndReprojectFile(const QString& filenam
 
   auto first_band = reprojected_dataset->GetRasterBand(1);
   if(reprojected_dataset->GetRasterCount() == 1 &&
-     first_band->GetRasterDataType() == GDT_Float32)
+     first_band->GetColorTable() == nullptr)
   {
     result.is_scalar = true;
-    // [camp#63/#59 PR3c] Single-band scalar field (e.g. a depth raster): shade
-    // through the ColorMap over the data range instead of the UInt32 RGB path
-    // (which renders Float32 values as near-black). NoData / NaN -> transparent.
+    // [camp#63/#59 PR3c / camp#90] Single-band scalar field (depth raster, GGGS
+    // backscatter/bathy tiles, etc.): shade through the ColorMap over the data
+    // range — read as Float32 so any numeric dtype (Float32/UInt16/...) works —
+    // instead of the UInt32 RGB path (which renders non-8-bit values as near-
+    // black AND opaque, ignoring NoData). NoData / NaN -> transparent. Paletted
+    // single-band rasters still use the colour-table path below.
     image.fill(Qt::transparent);
     int has_nodata = 0;
     const double nodata = first_band->GetNoDataValue(&has_nodata);

--- a/src/camp2/raster/raster_layer.cpp
+++ b/src/camp2/raster/raster_layer.cpp
@@ -339,6 +339,16 @@ void RasterLayer::readSettings()
   }
 }
 
+void RasterLayer::onRemovedByUser()
+{
+  // [camp#90] Drop this file from the BackgroundManager restore list so a
+  // user-removed raster stays gone next session.
+  QSettings settings;
+  QStringList files = settings.value("GggsRasters/files").toStringList();
+  if(files.removeAll(filename_) > 0)
+    settings.setValue("GggsRasters/files", files);
+}
+
 void RasterLayer::writeSettings()
 {
   map::Layer::writeSettings();

--- a/src/camp2/raster/raster_layer.cpp
+++ b/src/camp2/raster/raster_layer.cpp
@@ -339,7 +339,7 @@ void RasterLayer::readSettings()
   }
 }
 
-void RasterLayer::onRemovedByUser()
+void RasterLayer::onRemovedFromMap()
 {
   // [camp#90] Drop this file from the BackgroundManager restore list so a
   // user-removed raster stays gone next session.

--- a/src/camp2/raster/raster_layer.h
+++ b/src/camp2/raster/raster_layer.h
@@ -47,7 +47,7 @@ protected:
   void readSettings() override;
   void writeSettings() override;
   /// [camp#90] Drop this file from the persisted raster list on user removal.
-  void onRemovedByUser() override;
+  void onRemovedFromMap() override;
 
 private:
   // Store lower resolutions in an image pyramid

--- a/src/camp2/raster/raster_layer.h
+++ b/src/camp2/raster/raster_layer.h
@@ -46,6 +46,8 @@ protected:
   void contextMenu(QMenu* menu) override;
   void readSettings() override;
   void writeSettings() override;
+  /// [camp#90] Drop this file from the persisted raster list on user removal.
+  void onRemovedByUser() override;
 
 private:
   // Store lower resolutions in an image pyramid

--- a/test/test_gggs_render.cpp
+++ b/test/test_gggs_render.cpp
@@ -16,11 +16,9 @@
 #include <gdal_priv.h>
 
 #include <QApplication>
-#include <QGraphicsScene>
 #include <QImage>
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
-#include <QPainter>
 #include <QTemporaryDir>
 
 #include "map/map.h"
@@ -103,60 +101,6 @@ TEST(GggsRenderTest, OffscreenWarpProducesOrientedImage)
   EXPECT_GT(bright, 0);
 
   img.save("/tmp/gggs_render.png");
-}
-
-// Reproduce the live paint path (QGraphicsScene::render -> GggsTileLayer::paint
-// -> drawImage at setPos) and compare to a direct renderImage(), to localize the
-// reported ~constant latitude offset between CAMP and QGIS. Both are row0=south,
-// same extent, so a non-zero bright-centroid delta means the paint/placement
-// path shifts the image.
-TEST(GggsRenderTest, ScenePaintMatchesDirectRender)
-{
-  if(!offscreenGLAvailable())
-    GTEST_SKIP() << "no offscreen GL context available";
-
-  QTemporaryDir dir;
-  ASSERT_TRUE(dir.isValid());
-  const int w = 100, h = 100;
-  const double geo[6] = {-71.40, 0.0001, 0.0, 43.00, 0.0, -0.0001};
-  std::vector<uint16_t> samples(w * h, 8000);
-  for(int r = 0; r < h; ++r)
-    for(int c = 0; c < w; ++c)
-      if(r < 10 || c < 10)
-        samples[r * w + c] = 60000;
-  ASSERT_FALSE(writeTile(dir, w, h, geo, samples).isEmpty());
-
-  camp::map::Map map;
-  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
-  ASSERT_TRUE(layer->valid());
-  const QRectF sb = layer->sceneBounds();
-  const QSize size(200, 200);
-
-  const QImage direct = layer->renderImage(size);   // row 0 = south
-  ASSERT_FALSE(direct.isNull());
-
-  QImage scene(size, QImage::Format_ARGB32_Premultiplied);
-  scene.fill(Qt::transparent);
-  {
-    QPainter p(&scene);
-    map.scene()->render(&p, QRectF(QPointF(0, 0), QSizeF(size)), sb, Qt::IgnoreAspectRatio);
-  }
-  direct.save("/tmp/gggs_direct.png");
-  scene.save("/tmp/gggs_scene.png");
-
-  auto centroidY = [](const QImage& im)
-  {
-    double sy = 0; long n = 0;
-    for(int y = 0; y < im.height(); ++y)
-      for(int x = 0; x < im.width(); ++x)
-        if(im.pixelColor(x, y).red() > 200) { sy += y; ++n; }
-    return n ? sy / n : -1.0;
-  };
-  const double cd = centroidY(direct);
-  const double cs = centroidY(scene);
-  qInfo("ScenePaint: bright centroidY direct=%.1f scene=%.1f delta=%.1f px", cd, cs, cs - cd);
-  EXPECT_GE(cd, 0.0);
-  EXPECT_GE(cs, 0.0);
 }
 
 // Optional real-data smoke render: set GGGS_TEST_STORE to a tile directory to

--- a/test/test_gggs_render.cpp
+++ b/test/test_gggs_render.cpp
@@ -16,9 +16,11 @@
 #include <gdal_priv.h>
 
 #include <QApplication>
+#include <QGraphicsScene>
 #include <QImage>
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
+#include <QPainter>
 #include <QTemporaryDir>
 
 #include "map/map.h"
@@ -101,6 +103,60 @@ TEST(GggsRenderTest, OffscreenWarpProducesOrientedImage)
   EXPECT_GT(bright, 0);
 
   img.save("/tmp/gggs_render.png");
+}
+
+// Reproduce the live paint path (QGraphicsScene::render -> GggsTileLayer::paint
+// -> drawImage at setPos) and compare to a direct renderImage(), to localize the
+// reported ~constant latitude offset between CAMP and QGIS. Both are row0=south,
+// same extent, so a non-zero bright-centroid delta means the paint/placement
+// path shifts the image.
+TEST(GggsRenderTest, ScenePaintMatchesDirectRender)
+{
+  if(!offscreenGLAvailable())
+    GTEST_SKIP() << "no offscreen GL context available";
+
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const int w = 100, h = 100;
+  const double geo[6] = {-71.40, 0.0001, 0.0, 43.00, 0.0, -0.0001};
+  std::vector<uint16_t> samples(w * h, 8000);
+  for(int r = 0; r < h; ++r)
+    for(int c = 0; c < w; ++c)
+      if(r < 10 || c < 10)
+        samples[r * w + c] = 60000;
+  ASSERT_FALSE(writeTile(dir, w, h, geo, samples).isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  const QRectF sb = layer->sceneBounds();
+  const QSize size(200, 200);
+
+  const QImage direct = layer->renderImage(size);   // row 0 = south
+  ASSERT_FALSE(direct.isNull());
+
+  QImage scene(size, QImage::Format_ARGB32_Premultiplied);
+  scene.fill(Qt::transparent);
+  {
+    QPainter p(&scene);
+    map.scene()->render(&p, QRectF(QPointF(0, 0), QSizeF(size)), sb, Qt::IgnoreAspectRatio);
+  }
+  direct.save("/tmp/gggs_direct.png");
+  scene.save("/tmp/gggs_scene.png");
+
+  auto centroidY = [](const QImage& im)
+  {
+    double sy = 0; long n = 0;
+    for(int y = 0; y < im.height(); ++y)
+      for(int x = 0; x < im.width(); ++x)
+        if(im.pixelColor(x, y).red() > 200) { sy += y; ++n; }
+    return n ? sy / n : -1.0;
+  };
+  const double cd = centroidY(direct);
+  const double cs = centroidY(scene);
+  qInfo("ScenePaint: bright centroidY direct=%.1f scene=%.1f delta=%.1f px", cd, cs, cs - cd);
+  EXPECT_GE(cd, 0.0);
+  EXPECT_GE(cs, 0.0);
 }
 
 // Optional real-data smoke render: set GGGS_TEST_STORE to a tile directory to

--- a/test/test_gggs_render.cpp
+++ b/test/test_gggs_render.cpp
@@ -1,0 +1,131 @@
+// [camp#90 / I4] Headless offscreen render test for the GGGS tile layer. The
+// layer warps tiles to Web-Mercator in its own offscreen GL context and returns
+// a QImage (the portable path that does not depend on the QGraphicsView viewport
+// being GL). This renders a synthetic tile with a bright "L" along its NORTH and
+// WEST edges so the output orientation is unambiguous, asserts the render is
+// non-empty, and writes /tmp/gggs_render.png for visual inspection.
+//
+// Skipped automatically if no offscreen GL context can be created (e.g. a CI
+// box with no GL at all).
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <vector>
+
+#include <gdal_priv.h>
+
+#include <QApplication>
+#include <QImage>
+#include <QOffscreenSurface>
+#include <QOpenGLContext>
+#include <QTemporaryDir>
+
+#include "map/map.h"
+#include "map/layer_list.h"
+#include "raster/gggs_tile_layer.h"
+
+namespace
+{
+
+QString writeTile(const QTemporaryDir& dir, int w, int h, const double geo[6],
+                  const std::vector<uint16_t>& samples)
+{
+  if(GDALGetDriverCount() == 0)
+    GDALAllRegister();
+  const QString path = dir.filePath("13_0_0.tif");
+  GDALDriver* driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+  GDALDataset* ds = driver->Create(path.toUtf8().constData(), w, h, 1, GDT_UInt16, nullptr);
+  ds->SetGeoTransform(const_cast<double*>(geo));
+  GDALRasterBand* band = ds->GetRasterBand(1);
+  band->SetNoDataValue(0);
+  const CPLErr err = band->RasterIO(GF_Write, 0, 0, w, h,
+                                    const_cast<uint16_t*>(samples.data()),
+                                    w, h, GDT_UInt16, 0, 0);
+  GDALClose(ds);
+  return err == CE_None ? path : QString();
+}
+
+bool offscreenGLAvailable()
+{
+  QOffscreenSurface surface;
+  surface.create();
+  QOpenGLContext ctx;
+  return surface.isValid() && ctx.create();
+}
+
+}  // namespace
+
+TEST(GggsRenderTest, OffscreenWarpProducesOrientedImage)
+{
+  if(!offscreenGLAvailable())
+    GTEST_SKIP() << "no offscreen GL context available";
+
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+
+  // North-up tile over a small patch; row 0 = north edge.
+  const int w = 100, h = 100;
+  const double geo[6] = {-71.40, 0.0001, 0.0, 43.00, 0.0, -0.0001};
+  std::vector<uint16_t> samples(w * h, 8000);
+  for(int r = 0; r < h; ++r)
+    for(int c = 0; c < w; ++c)
+      if(r < 10 || c < 10)                 // north band (low row) + west band (low col)
+        samples[r * w + c] = 60000;
+  const QString path = writeTile(dir, w, h, geo, samples);
+  ASSERT_FALSE(path.isEmpty());
+
+  camp::map::Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  auto* layer = new camp::raster::GggsTileLayer(layers, dir.path());
+  ASSERT_TRUE(layer->valid());
+
+  const QImage img = layer->renderImage(QSize(200, 200));
+  ASSERT_FALSE(img.isNull());
+  EXPECT_EQ(img.width(), 200);
+  EXPECT_EQ(img.height(), 200);
+
+  // Some pixels are opaque (the warped tile), some transparent (outside it).
+  int opaque = 0, bright = 0;
+  for(int y = 0; y < img.height(); ++y)
+    for(int x = 0; x < img.width(); ++x)
+    {
+      const QColor px = img.pixelColor(x, y);
+      if(px.alpha() > 0)
+        ++opaque;
+      if(px.red() > 200)
+        ++bright;
+    }
+  EXPECT_GT(opaque, 0);
+  EXPECT_GT(bright, 0);
+
+  img.save("/tmp/gggs_render.png");
+}
+
+// Optional real-data smoke render: set GGGS_TEST_STORE to a tile directory to
+// warp it headlessly to /tmp/gggs_real.png (QA / preview; skipped otherwise).
+TEST(GggsRenderTest, RealStoreRendersWhenProvided)
+{
+  const QByteArray store = qgetenv("GGGS_TEST_STORE");
+  if(store.isEmpty())
+    GTEST_SKIP() << "set GGGS_TEST_STORE to a tile directory to run";
+  if(!offscreenGLAvailable())
+    GTEST_SKIP() << "no offscreen GL context available";
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(),
+                                                QString::fromLocal8Bit(store));
+  ASSERT_TRUE(layer->valid());
+  const QImage img = layer->renderImage(QSize(900, 900));
+  ASSERT_FALSE(img.isNull());
+  img.save("/tmp/gggs_real.png");
+}
+
+int main(int argc, char** argv)
+{
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QApplication app(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_gggs_tile.cpp
+++ b/test/test_gggs_tile.cpp
@@ -1,0 +1,148 @@
+// [camp#90 / I4] Tests for the GGGS GPU-warp tile layer's non-GL logic:
+//  - GggsTile geographic-extent recovery from the GDAL geotransform,
+//  - NoData / data-range handling (the mosaicker reserves 0 for NoData and
+//    floors real returns to >= 1), and
+//  - geoToMap parity: the vertex shader warps lon/lat -> Web-Mercator with
+//    x = R*lambda, y = R*asinh(tan phi), expanded as log(t + sqrt(t^2+1)) to
+//    avoid the asinh builtin. This pins that formula against the C++ reference
+//    web_mercator::geoToMap so the shader can't silently drift. (Full offscreen
+//    GPU/CPU render parity is the rqt#48-style harness deferred to camp#63.)
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include <gdal_priv.h>
+
+#include <QGeoCoordinate>
+#include <QPointF>
+#include <QTemporaryDir>
+
+#include "raster/gggs_tile.h"
+#include "map_view/web_mercator.h"
+
+using camp::raster::GggsTile;
+
+namespace
+{
+
+// Write a single-band UInt16 north-up WGS84-ish GeoTIFF with the given
+// geotransform, NoData = 0, and row-major samples. Returns the file path.
+QString writeTile(const QTemporaryDir& dir, const QString& name,
+                  int width, int height, const double geo[6],
+                  const std::vector<uint16_t>& samples)
+{
+  if(GDALGetDriverCount() == 0)
+    GDALAllRegister();
+  const QString path = dir.filePath(name);
+  GDALDriver* driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+  GDALDataset* ds = driver->Create(path.toUtf8().constData(), width, height, 1,
+                                   GDT_UInt16, nullptr);
+  ds->SetGeoTransform(const_cast<double*>(geo));
+  GDALRasterBand* band = ds->GetRasterBand(1);
+  band->SetNoDataValue(0);
+  const CPLErr err = band->RasterIO(GF_Write, 0, 0, width, height,
+                                    const_cast<uint16_t*>(samples.data()),
+                                    width, height, GDT_UInt16, 0, 0);
+  GDALClose(ds);
+  if(err != CE_None)
+    return QString();
+  return path;
+}
+
+}  // namespace
+
+// Extent corners come straight from the geotransform: north-up tile, row 0 is
+// the north edge (maxLat).
+TEST(GggsTileTest, ExtentFromGeotransform)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const int w = 4, h = 4;
+  const double dlon = 0.001, dlat = 0.001;
+  const double min_lon = -71.4, max_lat = 43.0;
+  const double geo[6] = {min_lon, dlon, 0.0, max_lat, 0.0, -dlat};
+  std::vector<uint16_t> samples(w * h, 100);
+  const QString path = writeTile(dir, "13_10_20.tif", w, h, geo, samples);
+
+  GggsTile tile(path);
+  ASSERT_TRUE(tile.valid());
+  EXPECT_EQ(tile.width(), w);
+  EXPECT_EQ(tile.height(), h);
+  EXPECT_NEAR(tile.minLon(), min_lon, 1e-12);
+  EXPECT_NEAR(tile.maxLon(), min_lon + w * dlon, 1e-12);
+  EXPECT_NEAR(tile.maxLat(), max_lat, 1e-12);
+  EXPECT_NEAR(tile.minLat(), max_lat - h * dlat, 1e-12);
+}
+
+// NoData (0) is excluded from the data range; real samples set min/max.
+TEST(GggsTileTest, NoDataExcludedFromRange)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const int w = 2, h = 2;
+  const double geo[6] = {-71.4, 0.001, 0.0, 43.0, 0.0, -0.001};
+  // one NoData (0), the rest spanning [5, 50000]
+  std::vector<uint16_t> samples = {0, 5, 12345, 50000};
+  const QString path = writeTile(dir, "13_0_0.tif", w, h, geo, samples);
+
+  GggsTile tile(path);
+  ASSERT_TRUE(tile.valid());
+  EXPECT_TRUE(tile.hasNoData());
+  EXPECT_DOUBLE_EQ(tile.noData(), 0.0);
+  EXPECT_DOUBLE_EQ(tile.dataMin(), 5.0);
+  EXPECT_DOUBLE_EQ(tile.dataMax(), 50000.0);
+}
+
+// An all-NoData tile has a crossed range (min > max) so the layer can skip it.
+TEST(GggsTileTest, AllNoDataHasCrossedRange)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const int w = 2, h = 2;
+  const double geo[6] = {-71.4, 0.001, 0.0, 43.0, 0.0, -0.001};
+  std::vector<uint16_t> samples(w * h, 0);
+  const QString path = writeTile(dir, "13_1_1.tif", w, h, geo, samples);
+
+  GggsTile tile(path);
+  ASSERT_TRUE(tile.valid());           // dimensions known
+  EXPECT_GT(tile.dataMin(), tile.dataMax());   // no valid samples
+}
+
+// A missing file degrades to invalid (no crash), like RasterLayer.
+TEST(GggsTileTest, MissingFileInvalid)
+{
+  GggsTile tile("/nonexistent/path/13_0_0.tif");
+  EXPECT_FALSE(tile.valid());
+}
+
+// The shader's warp formula must equal web_mercator::geoToMap exactly. x is the
+// linear longitude map; y is asinh(tan phi)*R expanded without the builtin.
+TEST(GggsTileTest, ShaderWarpMatchesGeoToMap)
+{
+  const double R = web_mercator::earth_radius_at_equator;
+  const double deg2rad = M_PI / 180.0;
+  for(double lat : {-85.0, -43.0, -10.0, 0.0, 10.0, 42.99, 43.0, 85.0})
+  {
+    for(double lon : {-180.0, -71.39, 0.0, 71.39, 179.0})
+    {
+      // shader formula (see gggs_tile_layer.cpp kVertexShader)
+      const double x = lon * deg2rad * R;
+      const double t = std::tan(lat * deg2rad);
+      const double y = std::log(t + std::sqrt(t * t + 1.0)) * R;
+
+      const QPointF ref = web_mercator::geoToMap(QGeoCoordinate(lat, lon));
+      // relative tolerance over the (large, ~1e7 m) Web-Mercator magnitudes
+      const double scale = std::max(1.0, std::abs(ref.x()) + std::abs(ref.y()));
+      EXPECT_NEAR(x, ref.x(), 1e-6 * scale) << "lon=" << lon;
+      EXPECT_NEAR(y, ref.y(), 1e-6 * scale) << "lat=" << lat;
+    }
+  }
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_gggs_tile.cpp
+++ b/test/test_gggs_tile.cpp
@@ -117,9 +117,11 @@ TEST(GggsTileTest, MissingFileInvalid)
   EXPECT_FALSE(tile.valid());
 }
 
-// The shader's warp formula must equal web_mercator::geoToMap exactly. x is the
-// linear longitude map; y is asinh(tan phi)*R expanded without the builtin.
-TEST(GggsTileTest, ShaderWarpMatchesGeoToMap)
+// The layer warps each mesh vertex via web_mercator::geoToMap on the CPU (in
+// double precision — the warp is intentionally NOT done in the GPU shader, whose
+// transcendentals x R caused a ~50 m latitude error). This pins geoToMap against
+// the analytic EPSG:3857 formula: x = R*lambda (linear); y = R*asinh(tan phi).
+TEST(GggsTileTest, GeoToMapMatchesWebMercator)
 {
   const double R = web_mercator::earth_radius_at_equator;
   const double deg2rad = M_PI / 180.0;


### PR DESCRIPTION
## Summary

I4 / camp#90: a new **GGGS-tiled raster map layer** that renders on-disk WGS84 GeoTIFF tile stores (sidescan backscatter from `marine_sidescan_mosaic` #173, bathymetry) on CAMP's Web-Mercator map, plus related raster/persistence improvements. Part of rolker/unh_marine_autonomy#175 and #171.

## What's in it

- **`GggsTileLayer`** — warps native-geographic tiles to Web-Mercator and presents them on the map. Renders into an **offscreen GL framebuffer the layer owns** (`QOpenGLContext` + `QOffscreenSurface` + FBO), then `drawImage()` — portable across X11 / Wayland / software GL (native painting in a QGraphicsView item gets no GL context under a Wayland software backingstore). The warp (`web_mercator::geoToMap`) runs **per mesh vertex on the CPU in double precision**, relative to the extent origin; the shader is purely linear. (Doing the warp in the GPU shader caused a ~50 m latitude error — GPU transcendentals × R≈6.4e6.)
- **`GggsStoreLayer`** — open a store *root* and recursively build the Layers tree (`stores → sidescan_backscatter → draft`); tile-bearing dirs become tile-set leaves.
- **Colormap** — grayscale/viridis/turbo via a GPU LUT (shared `camp::map::ColorMap`), context-menu selectable + persisted. (The rviz/rqt-matching `marine_colormap` upgrade stays the camp#63 / Slice-3 follow-up.)
- **Persistence** — opened stores and "Open raster" charts auto-load each session; removing one (Layers-tab "Remove") de-persists it. Window geometry + map view position/zoom persist too.
- **`RasterLayer`** — single-band non-paletted rasters now render through the scalar ColorMap path, so NoData is transparent (was opaque) and the band is colormapped.

## Verification

Headless render tests + a GDAL EPSG:3857 cross-check: the rendered mosaic aligns with GDAL's own warp to **0 px** (was 100 px / ~49 m before the CPU-warp fix). In-CAMP confirmed: registers with OSM + a GDAL raster of the same tiles; colormap, transparency, and persistence all working. **66 camp tests pass.** A Deep `review-code` (two adversarial lenses) ran pre-merge — must-fix + cheap suggestions addressed; the work plan / `progress.md` carry the timeline.

## Deferred (Slice 2 follow-ups, documented)

Async/lazy store load (current load is synchronous on the GUI thread — fine at present size, would freeze startup for a large multi-epoch store); visible-region-only render + tessellation/seam tuning; map-view-restore vs. fit-to-extent timing; persisted-list MRU cap.

Closes #90

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
