### PR TITLE
GGGS store layer: lazy/async tile load + default-off + persisted visibility (#102)

### DIFF
--- a/.agent/work-plans/issue-102/plan.md
+++ b/.agent/work-plans/issue-102/plan.md
@@ -1,0 +1,146 @@
+# Plan: GGGS store layer — lazy/async tile load + default-off tile-sets + persisted visibility
+
+## Issue
+
+https://github.com/rolker/camp/issues/102
+
+## Context
+
+The GGGS store layer (camp#90, merged on `jazzy`) loads **every** tile
+synchronously in the `GggsTile` constructor: a full-band GDAL `RasterIO` on the
+GUI thread (`gggs_tile.cpp:51-57`). For the small Massabesic store that's fine,
+but a store over *all* existing data would freeze the UI at startup, and every
+tile-set loads whether the operator wants it or not. The fix generalizes the
+pattern `RasterLayer` already uses per camp ADR-0003 §3: cheap extent/metadata
+in the constructor, the pixel read deferred to a `QtConcurrent` worker with an
+abort/join dtor contract.
+
+Five cohesive changes toward one goal — open a large store without blocking, and
+read pixels only for layers the operator turns on. Visible-region LOD render,
+producer pyramids, and live ROS transport stay out of scope (separate issues).
+
+## Approach
+
+1. **Split `GggsTile` into extent-read (ctor) + deferred pixel-read.** The ctor
+   opens the dataset, reads the geotransform → extent, dimensions, and NoData
+   only (no `RasterIO`); `valid()` becomes true on dimensions/geotransform alone.
+   A new `loadPixels()` does the band `RasterIO` and computes `data_min_/data_max_`.
+   `texture()` keeps its current-context upload but is only reachable once pixels
+   are present. The colormap auto-range (`data_min_/data_max_`) therefore becomes
+   **incremental**: it is unknown until a tile's pixels load, so the layer's
+   `data_min_/data_max_` accumulate as tiles complete (not at `loadDirectory`
+   time). Keep `texture()` and `releaseGL()` on the render thread only — never
+   call them off-thread (OQ1).
+
+2. **Async pixel load on `GggsTileLayer`, mirroring `RasterLayer`.** Add a
+   `QFutureWatcher<...>` + `abort_flag_`/`abort_flag_mutex_` to the layer (not the
+   tile — one watcher per layer drives that layer's tile reads). A `loadTiles()`
+   slot launches `QtConcurrent::run` over the layer's not-yet-loaded tiles, each
+   honoring the abort flag between tiles; an `tilesReady()` slot folds the new
+   ranges into `data_min_/data_max_`, invalidates `cached_image_`, and calls
+   `update()`. Worker does **GDAL `RasterIO` only**; `texture()` upload stays on
+   the paint path (OQ1). Port the dtor contract **verbatim** from `RasterLayer`
+   (`raster_layer.cpp:38-44`, `103-123`): set `abort_flag_` under mutex +
+   `waitForFinished()` in the dtor and before re-launching, so a layer destroyed
+   mid-load can't outlive `this` (OQ4).
+
+3. **Trigger load only when the layer is visible/drawn.** `loadDirectory` keeps
+   building the cheap-extent tile list (so `boundingRect()`/`sceneBounds()` are
+   valid immediately) but launches **no** pixel reads. The first `paint()` (which
+   QGraphicsView calls only for visible items) lazily kicks `loadTiles()` if not
+   already loaded/loading; an in-flight tile is skipped in `renderImage` (its
+   `texture()` returns null) and the layer repaints on `tilesReady()` (OQ2). This
+   piggybacks on Qt's existing "don't paint hidden items" rather than adding a
+   visibility-change observer MapItem doesn't have.
+
+4. **Default tile-set leaves OFF, persisted.** Override `readSettings()` on
+   `GggsTileLayer` to read `visible` with a **`false`** fallback (the auto-range
+   `data_min_/data_max_` and the colormap already round-trip via the existing
+   override). A ctor `setVisible(false)` would be clobbered: `MapItem::itemConstructed()`
+   runs `readSettings()` via `QTimer::singleShot(0,…)` after the ctor
+   (`map_item.cpp:26,180-183`), and `Layer::readSettings` defaults `visible` to
+   `true` (`layer.cpp:101-102`). So the off-default must live in the leaf's
+   `readSettings` fallback, **not** a ctor call and **not** a base-class change
+   (which would wrongly default charts/AIS off) (OQ3). `GggsStoreLayer` grouping
+   nodes are **not** forced off — only the renderable `GggsTileLayer` leaves.
+   Note: `Map::setData` toggles `setVisible` but does **not** call
+   `writeSettings` (`map.cpp:110-112`); visibility persists at app-quit
+   (`MapItem::applicationQuitting` → `writeSettings`), as today — the leaf
+   override only changes the *default*, the persistence path is unchanged.
+
+5. **`QFileSystemWatcher` on the store for new tiles/epochs.** `GggsStoreLayer`
+   watches its directory subtree; on a change it (a) discovers newly-landed
+   tile-set dirs and adds `GggsTileLayer`/`GggsStoreLayer` children (default-off
+   per change 4), and (b) for an existing tile-set, signals the leaf to re-scan
+   and re-read changed tiles. A half-written tile that fires mid-write degrades
+   to `valid()==false` (or a crossed range) and is simply skipped — producer-side
+   atomic-write safety is the separate uma#189; the consumer only tolerates it
+   (OQ5). Watch granularity: add one watch per discovered directory (Qt watches
+   are non-recursive); reload semantics are **incremental add**, not a full
+   rebuild, so already-loaded tiles and operator on/off choices are preserved.
+
+6. **Update stale docs.** Fix the `gggs_tile.h:15-20` class comment (ctor no
+   longer reads CPU samples) and the `background_manager.cpp:70-73` TODO (the
+   lazy/async path now exists). Record the GL-upload-vs-async-GDAL split + the
+   default-off-for-tile-sets decision as a PR/issue note (small enough that a
+   note suffices; not a new ADR — it generalizes ADR-0003 §3, and §4 persists
+   app-state visibility, which default-off respects).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/camp2/raster/gggs_tile.h` | Add `loadPixels()`; `pixelsLoaded()`; ctor reads extent/metadata only; fix class doc comment |
+| `src/camp2/raster/gggs_tile.cpp` | Move band `RasterIO` + range computation from ctor into `loadPixels()`; ctor stops at geotransform/dimensions/NoData |
+| `src/camp2/raster/gggs_tile_layer.h` | Add `QFutureWatcher` + abort flag/mutex, `loadTiles()`/`tilesReady()` slots, `loaded_/loading_` state, `readSettings()` already present (extend), dtor contract |
+| `src/camp2/raster/gggs_tile_layer.cpp` | `loadDirectory` extent-only; async `loadTiles` worker (RasterIO only, abort-aware); incremental `data_min_/data_max_`; lazy kick from `paint`; skip in-flight tiles in `renderImage`; `readSettings` `visible` false fallback; verbatim abort/join dtor |
+| `src/camp2/raster/gggs_store_layer.h` | Add `QFileSystemWatcher` member + `onDirectoryChanged()` slot; `Q_OBJECT` already present |
+| `src/camp2/raster/gggs_store_layer.cpp` | Install watches per directory in `build`; on change, discover new children (default-off) + signal existing leaves to re-scan; incremental, not rebuild |
+| `src/camp2/background/background_manager.cpp` | Update the stale Slice-2 TODO comment (`:70-73`) now that lazy/async lands |
+| `test/test_gggs_tile.cpp` | Add: ctor yields valid extent/`boundingRect` *before* `loadPixels()`; `data_min_/data_max_` only valid after `loadPixels()` |
+| `test/test_gggs_render.cpp` (or new `test_gggs_visibility.cpp`) | Add: default-off visibility persistence round-trip on a tile-set leaf; in-flight tile skip/repaint behavior if feasible headless |
+| `CMakeLists.txt` | Wire any new test target; existing gggs tests already link Qt5::Concurrent |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Robustness / do-it-completely | Port the abort/join dtor *verbatim* (no "good enough" partial join); tolerate half-written tiles by degrading the tile, not crashing; tests cover the risky concurrency + visibility-default logic |
+| Verify against source, not assumptions | Plan pins exact precedents: `RasterLayer` ctor/dtor/`loadFile`/`imageReady`, `MapItem::itemConstructed` → `readSettings` ordering, `Map::setData` not calling `writeSettings` |
+| Tests are the only gate (camp has no CI/pre-commit) | New gtests for (a) extent-before-pixels and (b) default-off persistence round-trip — the two highest-risk behaviors |
+| Atomic commits | Sequence: (1) tile split + test, (2) layer async + dtor, (3) lazy-on-visible, (4) default-off + test, (5) watcher, (6) doc/TODO cleanup |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| camp ADR-0003 §3 (sync extent / async pixels) | Yes | Directly generalizes the `RasterLayer` extent-in-ctor + async-pixel-on-worker contract to `GggsTile`/`GggsTileLayer`; same abort/join dtor |
+| camp ADR-0003 §4 (backgrounds persist as app/Map state: visibility/order/opacity/colormap) | Yes | Default-off is a *default* change only; visibility still persists via the existing app-state path. PR note records that default-off-for-tile-sets is an intentional refinement of §4's app-state visibility, not a departure from its persistence mechanism |
+| camp ADR-0002 (Web-Mercator scene, layer model) | No (unchanged) | Tile geometry/warp untouched; only load timing + visibility default change |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `GggsTile` ctor no longer reads pixels | `gggs_tile.h` class doc comment; any caller assuming `dataMin/Max` valid post-ctor (the layer — now incremental) | Yes |
+| Lazy/async path now exists | `background_manager.cpp:70-73` Slice-2 TODO | Yes |
+| Default tile-sets OFF | Operator UX (must turn layers on); persistence is via existing QSettings path | Yes (documented in PR note) |
+| New `QFileSystemWatcher` | Watch-count limits over a deep store (per-dir, non-recursive) — noted as a bounded, incremental-add design | Yes |
+
+## Open Questions
+
+- **OQ-A (watcher scale):** per-directory watches over a deep multi-epoch store
+  could hit the OS inotify watch limit on a very large store. Plan caps risk with
+  incremental-add semantics, but is a watch-count ceiling (e.g. watch only the
+  store root + active epoch dirs) wanted now, or deferred until stores get big?
+- **OQ-B (in-flight render test):** a headless gtest for "skip in-flight tile,
+  repaint on completion" may need GL/event-loop scaffolding the existing
+  `test_gggs_render` harness doesn't have. If it's not cleanly headless-testable,
+  is asserting the *non-GL* state machine (loading/loaded flags + range folding)
+  sufficient, with the render path covered manually?
+
+## Estimated Scope
+
+Single PR, ~6 atomic commits (tile split, layer async+dtor, lazy-on-visible,
+default-off+test, watcher, doc cleanup). Self-contained within `src/camp2/raster/`
+plus one TODO-comment touch in `background_manager.cpp` and test additions.

--- a/.agent/work-plans/issue-102/plan.md
+++ b/.agent/work-plans/issue-102/plan.md
@@ -92,14 +92,15 @@ producer pyramids, and live ROS transport stay out of scope (separate issues).
 |------|--------|
 | `src/camp2/raster/gggs_tile.h` | Add `loadPixels()`; `pixelsLoaded()`; ctor reads extent/metadata only; fix class doc comment |
 | `src/camp2/raster/gggs_tile.cpp` | Move band `RasterIO` + range computation from ctor into `loadPixels()`; ctor stops at geotransform/dimensions/NoData |
-| `src/camp2/raster/gggs_tile_layer.h` | Add `QFutureWatcher` + abort flag/mutex, `loadTiles()`/`tilesReady()` slots, `loaded_/loading_` state, `readSettings()` already present (extend), dtor contract |
-| `src/camp2/raster/gggs_tile_layer.cpp` | `loadDirectory` extent-only; async `loadTiles` worker (RasterIO only, abort-aware); incremental `data_min_/data_max_`; lazy kick from `paint`; skip in-flight tiles in `renderImage`; `readSettings` `visible` false fallback; verbatim abort/join dtor |
-| `src/camp2/raster/gggs_store_layer.h` | Add `QFileSystemWatcher` member + `onDirectoryChanged()` slot; `Q_OBJECT` already present |
-| `src/camp2/raster/gggs_store_layer.cpp` | Install watches per directory in `build`; on change, discover new children (default-off) + signal existing leaves to re-scan; incremental, not rebuild |
-| `src/camp2/background/background_manager.cpp` | Update the stale Slice-2 TODO comment (`:70-73`) now that lazy/async lands |
-| `test/test_gggs_tile.cpp` | Add: ctor yields valid extent/`boundingRect` *before* `loadPixels()`; `data_min_/data_max_` only valid after `loadPixels()` |
-| `test/test_gggs_render.cpp` (or new `test_gggs_visibility.cpp`) | Add: default-off visibility persistence round-trip on a tile-set leaf; in-flight tile skip/repaint behavior if feasible headless |
-| `CMakeLists.txt` | Wire any new test target; existing gggs tests already link Qt5::Concurrent |
+| `src/camp2/raster/gggs_tile_layer.h` | Add `QFutureWatcher<void>` + `abort_flag_`/mutex, `loadTiles()`/`tilesReady()` slots + `loadTilesWorker()`, `load_started_` state, `readSettings()` extend (false `visible` fallback), verbatim abort/join dtor. Also added `waitForLoad()` (test seam) and `rescan()` (watcher hook) — see Deviations |
+| `src/camp2/raster/gggs_tile_layer.cpp` | `loadDirectory` extent-only (range fold removed — now incremental); async `loadTiles`/`loadTilesWorker` (RasterIO only, abort between tiles); `tilesReady` incremental `data_min_/data_max_` fold + `pixelsLoaded()` gate; lazy kick from `paint`; skip not-`pixelsLoaded()` tiles in `renderImage`; `readSettings` `visible` false fallback; verbatim abort/join dtor + re-launch guard in `loadTiles`; `rescan()` for new tiles |
+| `src/camp2/raster/gggs_store_layer.h` | Add `QFileSystemWatcher*` + `onDirectoryChanged()` slot + `scan()`; `tileset_children_`/`group_children_` sets to make re-scan incremental |
+| `src/camp2/raster/gggs_store_layer.cpp` | `build`→`scan`; install one watch per visited directory; on change, discover new children (default-off) + call `rescan()` on the changed existing leaf; incremental, not rebuild; watch-count cap deferred (review #4) |
+| `src/camp2/background/background_manager.cpp` | Update the stale Slice-2 TODO comment now that lazy/async lands |
+| `test/test_gggs_tile.cpp` | Add `ExtentKnownBeforePixelsLoad` (ctor valid extent + crossed range *before* `loadPixels()`; range populated after); update `NoDataExcludedFromRange`/`AllNoDataHasCrossedRange` to call `loadPixels()` first |
+| `test/test_gggs_visibility.cpp` (new) | Default-off + persisted-visibility round-trip on a tile-set leaf (non-GL state machine per review #3; render path covered by existing `test_gggs_render`, now driven via `waitForLoad()`) |
+| `test/test_gggs_render.cpp` | Drive + await the async load (`waitForLoad()`) before `renderImage` (pixels are no longer synchronous) |
+| `CMakeLists.txt` | Wire `test_gggs_visibility`; gggs tests already link `camp_map` (Qt5::Concurrent is PUBLIC on it) |
 
 ## Principles Self-Check
 
@@ -144,3 +145,28 @@ producer pyramids, and live ROS transport stay out of scope (separate issues).
 Single PR, ~6 atomic commits (tile split, layer async+dtor, lazy-on-visible,
 default-off+test, watcher, doc cleanup). Self-contained within `src/camp2/raster/`
 plus one TODO-comment touch in `background_manager.cpp` and test additions.
+
+## Deviations (recorded during implementation)
+
+- **`GggsTileLayer::waitForLoad()` added** (not in the original Files-to-Change).
+  The existing `test_gggs_render` calls `renderImage()` directly, outside the
+  QGraphicsView paint loop that normally kicks + awaits the load via signals. A
+  small public test seam (`load if not started → waitForFinished → tilesReady`)
+  keeps that test valid without GL/event-loop scaffolding (review #3 intent).
+- **`GggsTileLayer::rescan()` added.** The plan said "signal the leaf to re-scan
+  and re-read changed tiles"; this is the concrete API the store's
+  `onDirectoryChanged` calls — it aborts/joins any in-flight load, appends
+  extent-only entries for newly-landed tiles (a half-written tile degrades to
+  `valid()==false` and is skipped), and re-kicks the load if already loaded.
+- **`QFutureWatcher<void>`** (not `<LoadResult>`): the worker mutates each shared
+  `GggsTile` in place (`loadPixels()`), so there is no per-future result struct
+  to marshal — the watcher only signals completion; `tilesReady()` reads the
+  tiles. This still ports RasterLayer's abort/join + re-launch contract verbatim.
+- **New test file `test_gggs_visibility.cpp`** (vs. extending `test_gggs_render`)
+  — the visibility round-trip needs only `QApplication` + `QSettings`, no GL, so
+  a dedicated file is cleaner. Uses a tiny subclass to reach the protected
+  `readSettings()`/`writeSettings()` without the deferred `itemConstructed()` timer.
+- **Watcher inotify watch-count cap DEFERRED** (review #4 / OQ-A): per-directory
+  non-recursive watches with incremental-add semantics, sized for the
+  Massabesic-scale store; a root+active-epoch ceiling is premature. Noted in a
+  code comment in `gggs_store_layer.h` and the PR.

--- a/.agent/work-plans/issue-102/progress.md
+++ b/.agent/work-plans/issue-102/progress.md
@@ -53,3 +53,20 @@ that to GggsTile.
 - [ ] Record the GL-upload-vs-async-GDAL split decision (ADR addendum or PR/issue note)
       and note whether default-off-for-tile-sets departs from ADR-0003 §4's implied
       default-on visibility.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-20 21:20 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-102/plan.md` at `5369945`
+**Branch**: feature/issue-102 at `5369945`
+**Phases**: single PR (~6 atomic commits)
+
+### Open questions
+- [ ] OQ-A — `QFileSystemWatcher` scale: per-dir non-recursive watches over a deep
+      multi-epoch store could hit OS inotify limits; cap watch count now (root +
+      active epochs) or defer until stores get big?
+- [ ] OQ-B — Headless gtest for "skip in-flight tile, repaint on completion" may
+      need GL/event-loop scaffolding the current harness lacks; is asserting the
+      non-GL load state machine + range folding sufficient instead?

--- a/.agent/work-plans/issue-102/progress.md
+++ b/.agent/work-plans/issue-102/progress.md
@@ -70,3 +70,42 @@ that to GggsTile.
 - [ ] OQ-B — Headless gtest for "skip in-flight tile, repaint on completion" may
       need GL/event-loop scaffolding the current harness lacks; is asserting the
       non-GL load state machine + range folding sufficient instead?
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-20 21:44 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+**Plan**: `.agent/work-plans/issue-102/plan.md` at `5369945`
+**PR**: PR-less
+**Branch**: feature/issue-102
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) Per-layer single-`QFutureWatcher` over a multi-tile `QtConcurrent::run`
+      is a faithful structural port of `RasterLayer` (one watcher / one future /
+      abort-between-units / dtor join + re-launch guard), but the unit of abort shifts
+      from scanline (RasterLayer) to whole-tile. Spell out in the layer worker that the
+      abort check is between tiles AND that a `tilesReady()` fold + a `paint()` lazy-kick
+      cannot launch a second `loadTiles()` while one is in flight — port `loadFile`'s
+      `isRunning() → abort+join` re-launch guard verbatim, not just the dtor join. The
+      plan states this (Approach 2) but the Files-to-Change row for `gggs_tile_layer.cpp`
+      omits the re-launch guard from its checklist — add it. — `plan.md:42-45,96`
+- [ ] (suggestion) The worker mutates each shared `GggsTile`'s pixel buffer
+      (`loadPixels()`) off-thread while `tilesReady()` reads `dataMin/Max` and
+      `texture()` runs on the paint thread. The dtor/re-launch join is the only barrier
+      — confirm in implementation that no tile touched by an in-flight worker is read on
+      the paint path before `tilesReady()` fires (the "in-flight tile → `texture()`
+      returns null → skip in `renderImage`" path, Approach 3, must gate on a per-tile
+      `pixelsLoaded()` flag set only after the worker completes and the fold runs, never
+      mid-write). — `plan.md:50-53`
+- [ ] (suggestion) OQ-B is the right call: the non-GL load state machine
+      (loading/loaded flags + incremental range fold) is headless-testable and is the
+      highest-risk logic; the GL skip/repaint path is already covered by the existing
+      self-skipping `test_gggs_render` harness. Recommend asserting the state machine in
+      a gtest and documenting the render path as manually verified — don't block on
+      GL/event-loop scaffolding. — `plan.md:101,136-140`
+- [ ] (suggestion) OQ-A (watcher inotify scale): defer the watch-count ceiling. The
+      incremental-add, per-discovered-dir design is sound for the Massabesic-scale store
+      this lands against; a root+active-epoch cap is premature until stores grow. Note
+      the deferral in the PR so it isn't lost. — `plan.md:132-135`

--- a/.agent/work-plans/issue-102/progress.md
+++ b/.agent/work-plans/issue-102/progress.md
@@ -178,3 +178,26 @@ contract without GL/event-loop scaffolding:
   thread spins on `pixelsLoaded()` exactly as the paint gate does; asserts the released
   range is fully visible/consistent the moment the acquire flag reads true (a
   non-atomic/no-barrier flag could let the observer see a torn/stale range).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 23:22 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Branch**: feature/issue-102 at `fbb2bb4`
+**Mode**: pre-push
+**Depth**: Deep (re-review of the round-1 race fix)
+**Round**: 2
+**Verdict**: approved
+**Ship**: recommended
+**Claude Adversarial**: 1 focused concurrency re-review (traced the atomic release/acquire publication end-to-end)
+**Must-fix**: 0 | **Suggestions**: 2 (nits)
+
+### Findings
+- [x] (round-1 must-fix) Worker-vs-paint data race — CLOSED: `pixels_loaded_` is `std::atomic<bool>`, release-store after the `data_`/range writes, acquire-load gating every paint-path read of pixel state (`renderImage`→`texture()`, `tilesReady`→dataMin/Max); no bypass exists (grep-confirmed). First-load path + auto-range + default-off unchanged.
+- [x] (round-1 must-fix) Misleading "set only on GUI thread" comments — corrected to the real acquire/release invariant.
+- [x] (round-1 suggestions) "(no data)" status on all-crossed fold + whole-tile abort-granularity comments — applied.
+- [ ] (nit) `PixelsLoadedFalseUntilLoadCompletes` is single-threaded — pins the API contract but would pass on a plain bool; comment overstates what it guards.
+- [ ] (nit) `PixelsPublishedToObserverThread` is a probabilistic cross-thread test — real teeth only under TSan; document that.
+
+Tests: 72, 0 failures, 1 skipped (GL self-skip). Production fix is correct + complete; safe to push.

--- a/.agent/work-plans/issue-102/progress.md
+++ b/.agent/work-plans/issue-102/progress.md
@@ -109,3 +109,25 @@ that to GggsTile.
       incremental-add, per-discovered-dir design is sound for the Massabesic-scale store
       this lands against; a root+active-epoch cap is premature until stores grow. Note
       the deferral in the PR so it isn't lost. — `plan.md:132-135`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 23:06 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Branch**: feature/issue-102 at `267e7ea`
+**Mode**: pre-push
+**Depth**: Deep (reason: async/threading refactor, ~804 lines)
+**Round**: 1
+**Verdict**: changes-requested
+**Ship**: continue (must-fix data race in the target rescan/streaming path)
+**Static analysis**: limited (cpplint not installed; clean compile) | **Claude Adversarial**: 2 passes (Lens A logic + Lens B concurrency) — both cross-confirmed the race | **Copilot**: off
+**Must-fix**: 2 | **Suggestions**: 2
+
+### Findings
+- [ ] (must-fix) Worker-vs-paint **data race** on `GggsTile::pixels_loaded_` + `data_`: `loadPixels()` writes them on the QtConcurrent worker (gggs_tile.cpp:101-102) with no barrier; the GUI paint reads `pixelsLoaded()`/`texture()`/`data_` (gggs_tile_layer.cpp:431,452). Safe on first load only via the incidental crossed-range gate (line 493); **races on the `rescan()` re-kick** (range already valid → gate open) = the live-streaming case. Fix: make `pixels_loaded_` `std::atomic<bool>` with release(after data_ move)/acquire(paint read), OR make `tilesReady()` (post-join, GUI) the sole writer of a layer-side paintable set. — `gggs_tile.cpp:101-102` / `gggs_tile_layer.cpp:431,452,493`
+- [ ] (must-fix) Comments assert a barrier that doesn't exist ("flag set ONLY in tilesReady() on the GUI thread after the worker finished") — it's set on the worker in `loadPixels()`. Correct the comments AND make the invariant real (pairs with #1). — `gggs_tile_layer.h:131-134`, `gggs_tile_layer.cpp:238-241,428-430`
+- [ ] (suggestion) All-failed / all-NoData enabled tile-set → silent blank (range stays crossed, status cleared); show "(no data)"/error so the operator gets a signal. — `gggs_tile_layer.cpp:269`
+- [ ] (suggestion) `rescan()`/`loadTiles()` `waitForFinished()` blocks the GUI thread for a full large-tile `RasterIO` (whole-tile abort granularity vs RasterLayer's scanline); fine at current scale, note/finer-abort for large tiles. — `gggs_tile_layer.cpp:162,223`
+
+Lifecycle/teardown confirmed solid by both lenses (dtor abort+join, tiles_-mutation guarding, QFileSystemWatcher parented/serial, single finished connect).

--- a/.agent/work-plans/issue-102/progress.md
+++ b/.agent/work-plans/issue-102/progress.md
@@ -1,0 +1,55 @@
+---
+issue: 102
+---
+
+# Issue #102 — GGGS store layer: lazy/async tile load + default-off tile-sets + persisted visibility
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-20 21:20 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Issue**: #102
+**Comment**: https://github.com/rolker/camp/issues/102#issuecomment-4760503965
+**Scope verdict**: well-scoped
+
+Follow-up to merged camp#90; part of unh_marine_autonomy#171/#175. Five cohesive
+changes (split GggsTile extent/pixel; default-off tile-sets; async load-on-visible
+mirroring RasterLayer's QtConcurrent path; persisted per-layer visibility;
+QFileSystemWatcher) toward one goal — open a large store without freezing the GUI
+thread. LOD/visible-region render, producer pyramids, and live ROS transport are
+explicitly out of scope (separate issues). Right repo (rolker/camp, GitHub-origin,
+default branch `jazzy`). Strong in-repo precedent: RasterLayer already does
+sync-extent (ctor) + async-pixel (worker) per camp ADR-0003 §3; this generalizes
+that to GggsTile.
+
+### Actions
+- [ ] Add gtests (camp has no CI/pre-commit — the suite is the only gate): (a) tile
+      extent/boundingRect valid before pixels load; (b) default-off visibility
+      persistence round-trip.
+- [ ] OQ1 — Keep GDAL `RasterIO` on the QtConcurrent worker; keep the `QOpenGLTexture`
+      upload (`gggs_tile.cpp:86-104`) on the render/paint path only (current-context
+      requirement). Never call `texture()`/`allocateStorage` off the render thread.
+- [ ] OQ2 — Define the "pixels not ready yet" path for the offscreen-FBO render
+      (`GggsTileLayer::renderImage`): skip/partial-render an in-flight tile and
+      repaint on completion (today `data_` is present at `texture()` time; with
+      deferral it may be empty).
+- [ ] OQ3 — Flip visibility default to off via a `readSettings()` override with a
+      `false` fallback in the GGGS tile-set leaf layer — NOT a ctor `setVisible(false)`
+      (overwritten: `MapItem::itemConstructed()` calls `readSettings()` via
+      `QTimer::singleShot(0,...)` after the ctor; `Layer::readSettings` defaults
+      `visible` to `true`, `layer.cpp:101-102`), and NOT a base-class change (would
+      wrongly default charts/AIS off). Confirm it affects tile-set leaves, not
+      grouping `GggsStoreLayer` nodes.
+- [ ] OQ4 — Port RasterLayer's abort/join dtor contract verbatim (set `abort_flag_`
+      under mutex + `waitForFinished()`) so a layer destroyed mid-load can't outlive
+      `this`.
+- [ ] OQ5 — Decide `QFileSystemWatcher` granularity (recursive/per-dir watch limits
+      over a deep multi-epoch store) and reload semantics (incremental add vs rebuild;
+      tolerate a half-written tile firing mid-write — atomic-write producer half is a
+      separate issue).
+- [ ] Update the stale TODO at `background_manager.cpp:70-73` and the `gggs_tile.h:15-20`
+      doc comment (ctor no longer reads CPU sample data) when the lazy path lands.
+- [ ] Record the GL-upload-vs-async-GDAL split decision (ADR addendum or PR/issue note)
+      and note whether default-off-for-tile-sets departs from ADR-0003 §4's implied
+      default-on visibility.

--- a/.agent/work-plans/issue-102/progress.md
+++ b/.agent/work-plans/issue-102/progress.md
@@ -131,3 +131,50 @@ that to GggsTile.
 - [ ] (suggestion) `rescan()`/`loadTiles()` `waitForFinished()` blocks the GUI thread for a full large-tile `RasterIO` (whole-tile abort granularity vs RasterLayer's scanline); fine at current scale, note/finer-abort for large tiles. — `gggs_tile_layer.cpp:162,223`
 
 Lifecycle/teardown confirmed solid by both lenses (dtor abort+join, tiles_-mutation guarding, QFileSystemWatcher parented/serial, single finished connect).
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-20 23:45 -0400
+**By**: Claude Code Agent (Claude Opus 4.8)
+
+**Branch**: feature/issue-102
+**Addresses**: the latest Local Review (Pre-Push) round 1 (2 must-fix + 2 suggestions)
+**Build**: `./ui_ws/build.sh camp` — clean (only pre-existing Qt `setData` deprecation warnings)
+**Test**: `./ui_ws/test.sh camp` — 72 tests, 0 failures, 1 skipped (GL render self-skip, no offscreen GL)
+
+### Findings addressed
+- [x] (must-fix #1) **Worker-vs-paint data race** on `GggsTile::pixels_loaded_`/`data_`.
+      Made `pixels_loaded_` a `std::atomic<bool>` (added `<atomic>` to `gggs_tile.h`).
+      `loadPixels()` now stores `true` with `memory_order_release` AFTER the `data_`
+      move (and the load-guard read uses acquire); `pixelsLoaded()` loads with
+      `memory_order_acquire`. This establishes happens-before (worker `data_`/range
+      write → release store → acquire load → paint `data_`/`texture()` read), closing
+      the race on both first load and the `rescan()` re-kick (where the crossed-range
+      gate is already open). Confirmed the only paint-path reads of tile pixel state
+      (`renderImage` `pixelsLoaded()`→`texture()`) go through the acquire check;
+      `tilesReady()` reads `dataMin/Max` post-join (already safe). — `gggs_tile.h`,
+      `gggs_tile.cpp`
+- [x] (must-fix #2) Corrected the three comments that wrongly claimed the flag is set
+      "ONLY in tilesReady() on the GUI thread" — it is set on the worker. They now
+      describe the real atomic release/acquire publication invariant. —
+      `gggs_tile_layer.h` (~131-138), `gggs_tile_layer.cpp` `loadTilesWorker` (~239-248),
+      `renderImage` skip-gate (~431-437)
+- [x] (suggestion #3) `tilesReady()` now calls `setStatus("(no data)")` when the
+      folded range is still crossed (every loaded tile all-NoData/failed) instead of
+      clearing the status, so an enabled-but-empty tile-set signals the operator. —
+      `gggs_tile_layer.cpp` `tilesReady`
+- [x] (suggestion #4) Added a comment at both `waitForFinished()` joins
+      (`rescan()` + `loadTiles()`) noting the abort granularity is whole-tile (a large
+      in-flight `RasterIO` blocks the GUI thread until that tile finishes), acceptable
+      at current scale, finer sub-tile abort is a follow-up. — `gggs_tile_layer.cpp`
+
+### Tests
+Added two non-GL regression tests to `test/test_gggs_tile.cpp` pinning the race's
+contract without GL/event-loop scaffolding:
+- `PixelsLoadedFalseUntilLoadCompletes` — `pixelsLoaded()` stays false (and the range
+  stays the crossed sentinel) until `loadPixels()` completes; after, flag true AND
+  range consistent.
+- `PixelsPublishedToObserverThread` — a worker thread `loadPixels()` while an observer
+  thread spins on `pixelsLoaded()` exactly as the paint gate does; asserts the released
+  range is fully visible/consistent the moment the acquire flag reads true (a
+  non-atomic/no-barrier flag could let the observer see a torn/stale range).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -554,6 +554,23 @@ if(BUILD_TESTING)
     Qt5::Positioning
     ${GDAL_LIBRARY}
   )
+
+  # [camp#102] GGGS tile-set default-off visibility + persistence round-trip
+  # (non-GL state machine — the highest-risk logic of the lazy/async change).
+  ament_add_gtest(test_gggs_visibility
+    test/test_gggs_visibility.cpp
+  )
+  target_include_directories(test_gggs_visibility PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp2
+  )
+  target_link_libraries(test_gggs_visibility
+    camp_map
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
+  )
 endif()
 
 

--- a/src/camp2/background/background_manager.cpp
+++ b/src/camp2/background/background_manager.cpp
@@ -67,10 +67,13 @@ void BackgroundManager::createDefaultLayers()
     // [camp#90] Re-create persisted GGGS tile stores + plain rasters so they
     // auto-load each session (persisted in openTileStore / openRaster). Skip
     // entries that no longer exist on disk.
-    // Slice-2 follow-up: GggsStoreLayer/GggsTile load every tile synchronously
-    // (GDAL RasterIO on the GUI thread), so a large multi-epoch store blocks
-    // startup. Bound this with lazy/visible-region loading like RasterLayer's
-    // async QtConcurrent path before stores get big.
+    // [camp#102] GggsTile now reads only extent/metadata in its ctor; the band
+    // pixels load lazily off a QtConcurrent worker, kicked from the first paint()
+    // of a *visible* tile-set (tile-sets default OFF). So opening a large
+    // multi-epoch store no longer blocks startup — only layers the operator turns
+    // on read pixels. A QFileSystemWatcher on each store picks up tiles/epochs
+    // that land after open. Visible-region LOD render is still future work
+    // (separate issue).
     QSettings settings;
     const QStringList store_roots = settings.value("GggsStores/roots").toStringList();
     for(const QString& root : store_roots)

--- a/src/camp2/raster/gggs_store_layer.cpp
+++ b/src/camp2/raster/gggs_store_layer.cpp
@@ -5,6 +5,7 @@
 #include <QDir>
 #include <QDirIterator>
 #include <QFileInfo>
+#include <QFileSystemWatcher>
 #include <QSettings>
 
 namespace camp
@@ -34,6 +35,12 @@ GggsStoreLayer::GggsStoreLayer(map::MapItem* parentItem, const QString& director
   map::Layer(parentItem, QFileInfo(directory).fileName()),
   directory_(directory)
 {
+  // [camp#102] Watch the store subtree so tiles/epochs that land after open show
+  // up without a restart. Created before build() so scan() can register a watch
+  // per visited directory.
+  watcher_ = new QFileSystemWatcher(this);
+  connect(watcher_, &QFileSystemWatcher::directoryChanged, this,
+          &GggsStoreLayer::onDirectoryChanged);
   build(directory);
 }
 
@@ -49,12 +56,24 @@ void GggsStoreLayer::onRemovedFromMap()
 
 void GggsStoreLayer::build(const QString& directory)
 {
+  scan(directory);
+}
+
+void GggsStoreLayer::scan(const QString& directory)
+{
   QDir dir(directory);
 
+  // [camp#102] Watch this directory for added/removed entries (non-recursive).
+  if(watcher_ && !watcher_->directories().contains(directory) && dir.exists())
+    watcher_->addPath(directory);
+
   // Tiles directly in this directory -> a tile-set leaf (handles a root that is
-  // itself a single tile-set).
-  if(dirHasTifs(directory))
-    new GggsTileLayer(this, directory);
+  // itself a single tile-set). Skip if already added (incremental re-scan).
+  if(dirHasTifs(directory) && !tileset_children_.contains(directory))
+  {
+    new GggsTileLayer(this, directory);   // default-off via its readSettings()
+    tileset_children_.insert(directory);
+  }
 
   // Each subdirectory: a leaf if it holds tiles directly, a grouping node if it
   // only has tiles deeper down. Empty / tile-free subtrees are skipped.
@@ -65,10 +84,45 @@ void GggsStoreLayer::build(const QString& directory)
   {
     const QString subpath = dir.filePath(sub);
     if(dirHasTifs(subpath))
-      new GggsTileLayer(this, subpath);
+    {
+      if(!tileset_children_.contains(subpath))
+      {
+        new GggsTileLayer(this, subpath);   // default-off
+        tileset_children_.insert(subpath);
+      }
+    }
     else if(subtreeHasTifs(subpath))
-      new GggsStoreLayer(this, subpath);
+    {
+      if(!group_children_.contains(subpath))
+      {
+        new GggsStoreLayer(this, subpath);   // grouping node (NOT forced off)
+        group_children_.insert(subpath);
+      }
+    }
   }
+}
+
+void GggsStoreLayer::onDirectoryChanged(const QString& path)
+{
+  // [camp#102] Incremental: discover newly-landed tile-sets/epochs (added
+  // default-off in scan()) and, for a changed tile-set leaf, ask it to re-scan
+  // for new tiles. Never rebuilds — existing children and operator on/off choices
+  // are preserved.
+  //
+  // Re-scan from `path` to pick up new direct-tile leaves / grouping subtrees.
+  scan(path);
+
+  // If `path` is itself a known tile-set leaf, the change may be a tile landing
+  // inside it — tell that leaf to re-scan its directory. Match the child by its
+  // directory().
+  if(tileset_children_.contains(path))
+    for(map::MapItem* child : childMapItems())
+      if(auto* leaf = dynamic_cast<GggsTileLayer*>(child))
+        if(leaf->directory() == path)
+        {
+          leaf->rescan();
+          break;
+        }
 }
 
 }  // namespace raster

--- a/src/camp2/raster/gggs_store_layer.h
+++ b/src/camp2/raster/gggs_store_layer.h
@@ -3,10 +3,17 @@
 
 #include "../map/layer.h"
 
+#include <QSet>
+#include <QString>
+
+class QFileSystemWatcher;
+
 namespace camp
 {
 namespace raster
 {
+
+class GggsTileLayer;
 
 /// [camp#90 / I4] Container layer for a GGGS tile *store*. Given a root
 /// directory it recursively builds the layer tree: any directory that directly
@@ -30,10 +37,30 @@ protected:
   /// [camp#90] Drop this store root from the persisted list on user removal.
   void onRemovedFromMap() override;
 
+private slots:
+  /// [camp#102] A watched directory changed: incrementally add newly-landed
+  /// tile-sets/epochs (default-off) and re-scan a changed tile-set leaf. Never
+  /// rebuilds — already-loaded tiles and operator on/off choices are preserved.
+  void onDirectoryChanged(const QString& path);
+
 private:
   void build(const QString& directory);
+  /// [camp#102] Scan @p directory for direct-tile leaves / grouping subtrees,
+  /// creating any child not already known. Registers a watch on each visited
+  /// directory. Idempotent — existing children are left untouched.
+  void scan(const QString& directory);
 
   QString directory_;
+
+  // [camp#102] Watch the store subtree so tiles/epochs that land after open show
+  // up without a restart. Qt watches are non-recursive, so we add one watch per
+  // discovered directory (incremental add — see onDirectoryChanged). The inotify
+  // watch-count ceiling over a very deep multi-epoch store is DEFERRED (camp#102
+  // review finding #4): the Massabesic-scale store this lands against is small;
+  // a root+active-epoch cap is premature until stores grow.
+  QFileSystemWatcher* watcher_ = nullptr;
+  QSet<QString> tileset_children_;   // leaf tile-set dirs already added
+  QSet<QString> group_children_;     // grouping subtree dirs already added
 };
 
 }  // namespace raster

--- a/src/camp2/raster/gggs_tile.cpp
+++ b/src/camp2/raster/gggs_tile.cpp
@@ -62,7 +62,7 @@ bool GggsTile::loadPixels()
 {
   if(!valid())
     return false;
-  if(pixels_loaded_)
+  if(pixels_loaded_.load(std::memory_order_acquire))
     return true;
 
   // [camp#102] Pure GDAL read — safe off the GUI thread (no GL touched here).
@@ -99,7 +99,11 @@ bool GggsTile::loadPixels()
   data_max_ = max_value;
 
   data_ = std::move(values);
-  pixels_loaded_ = true;
+  // [camp#102] RELEASE store AFTER all of data_/data_min_/data_max_ are written.
+  // Pairs with the ACQUIRE load in pixelsLoaded() so the paint thread, once it
+  // sees this flag true, is guaranteed to observe the completed buffer/range —
+  // closing the worker-vs-paint race on both first load and the rescan() re-kick.
+  pixels_loaded_.store(true, std::memory_order_release);
   return true;
 }
 

--- a/src/camp2/raster/gggs_tile.cpp
+++ b/src/camp2/raster/gggs_tile.cpp
@@ -48,12 +48,40 @@ GggsTile::GggsTile(const QString& path):
   nodata_ = band->GetNoDataValue(&has_nodata);
   has_nodata_ = has_nodata != 0;
 
-  std::vector<float> values(static_cast<size_t>(width) * height);
-  if(band->RasterIO(GF_Read, 0, 0, width, height, values.data(),
-                    width, height, GDT_Float32, 0, 0) != CE_None)
+  GDALClose(dataset);
+
+  // [camp#102] Extent/metadata only — NO band RasterIO here. The pixel read is
+  // deferred to loadPixels() so a large store opens without blocking the GUI
+  // thread (the layer drives loadPixels() off a QtConcurrent worker). dataMin/
+  // dataMax stay at the crossed sentinel until loadPixels() runs.
+  width_ = width;
+  height_ = height;
+}
+
+bool GggsTile::loadPixels()
+{
+  if(!valid())
+    return false;
+  if(pixels_loaded_)
+    return true;
+
+  // [camp#102] Pure GDAL read — safe off the GUI thread (no GL touched here).
+  auto dataset = GDALDataset::FromHandle(GDALOpen(path_.toUtf8().constData(), GA_ReadOnly));
+  if(!dataset)
+    return false;
+  if(dataset->GetRasterCount() < 1)
   {
     GDALClose(dataset);
-    return;
+    return false;
+  }
+  auto band = dataset->GetRasterBand(1);
+
+  std::vector<float> values(static_cast<size_t>(width_) * height_);
+  if(band->RasterIO(GF_Read, 0, 0, width_, height_, values.data(),
+                    width_, height_, GDT_Float32, 0, 0) != CE_None)
+  {
+    GDALClose(dataset);
+    return false;
   }
   GDALClose(dataset);
 
@@ -71,8 +99,8 @@ GggsTile::GggsTile(const QString& path):
   data_max_ = max_value;
 
   data_ = std::move(values);
-  width_ = width;
-  height_ = height;
+  pixels_loaded_ = true;
+  return true;
 }
 
 GggsTile::~GggsTile()

--- a/src/camp2/raster/gggs_tile.h
+++ b/src/camp2/raster/gggs_tile.h
@@ -12,21 +12,34 @@ namespace camp
 namespace raster
 {
 
-/// [camp#90 / I4] One native-geographic GGGS raster tile loaded from a WGS84
-/// GeoTIFF (`<level>_<row>_<col>.tif`). Holds the CPU sample data + geographic
-/// extent (from the GDAL geotransform) and lazily uploads a single-channel
-/// float (R32F) GL texture for the GPU display-time warp. Unlike RasterLayer,
-/// the tile is NOT reprojected on load — it stays in lat/lon and is warped to
-/// Web-Mercator in the shader at display time (unh_marine_autonomy ADR-0002 §D2).
+/// [camp#90 / I4 / camp#102] One native-geographic GGGS raster tile loaded from a
+/// WGS84 GeoTIFF (`<level>_<row>_<col>.tif`). The constructor reads only the
+/// geographic extent + dimensions + NoData from the GDAL geotransform/metadata
+/// (no `RasterIO`) so `valid()` becomes true cheaply on the GUI thread; the band
+/// pixels are read later by `loadPixels()` (typically off-thread, per camp#102 /
+/// ADR-0003 §3) and then lazily uploaded as a single-channel float (R32F) GL
+/// texture for the GPU display-time warp. Unlike RasterLayer, the tile is NOT
+/// reprojected on load — it stays in lat/lon and is warped to Web-Mercator in the
+/// shader at display time (unh_marine_autonomy ADR-0002 §D2).
 class GggsTile
 {
 public:
-  /// Open a single-band-or-more north-up WGS84 GeoTIFF and read band 1 as
-  /// Float32. valid() is false if the file can't be opened / has no geotransform.
+  /// Open a north-up WGS84 GeoTIFF and read its geotransform → extent, dimensions
+  /// and NoData ONLY (no pixel `RasterIO` — that is deferred to `loadPixels()`).
+  /// valid() is false if the file can't be opened / has no geotransform.
   explicit GggsTile(const QString& path);
   ~GggsTile();
 
   bool valid() const { return width_ > 0 && height_ > 0; }
+
+  /// Read band 1 as Float32 and compute the data range. Safe to call off the GUI
+  /// thread (pure GDAL `RasterIO`, no GL). No-op if the tile is invalid or pixels
+  /// are already loaded. Returns true if pixels are present after the call.
+  bool loadPixels();
+
+  /// True once `loadPixels()` has read the band into CPU memory (or freed it into
+  /// the GL texture). dataMin/dataMax and texture() are only meaningful once true.
+  bool pixelsLoaded() const { return pixels_loaded_; }
 
   const QString& path() const { return path_; }
   int width() const { return width_; }
@@ -61,6 +74,7 @@ private:
   double min_lon_ = 0.0, max_lon_ = 0.0, min_lat_ = 0.0, max_lat_ = 0.0;
   bool has_nodata_ = false;
   double nodata_ = 0.0;
+  bool pixels_loaded_ = false;               // set once loadPixels() has run
   double data_min_ = 1.0, data_max_ = 0.0;   // crossed => no valid samples
   std::vector<float> data_;                  // row-major, height_ * width_
   std::unique_ptr<QOpenGLTexture> texture_;

--- a/src/camp2/raster/gggs_tile.h
+++ b/src/camp2/raster/gggs_tile.h
@@ -2,6 +2,7 @@
 #define RASTER_GGGS_TILE_H
 
 #include <QString>
+#include <atomic>
 #include <memory>
 #include <vector>
 
@@ -39,7 +40,17 @@ public:
 
   /// True once `loadPixels()` has read the band into CPU memory (or freed it into
   /// the GL texture). dataMin/dataMax and texture() are only meaningful once true.
-  bool pixelsLoaded() const { return pixels_loaded_; }
+  ///
+  /// [camp#102] `pixels_loaded_` is `std::atomic<bool>` and this is an ACQUIRE
+  /// load. It pairs with the RELEASE store in `loadPixels()` (issued AFTER the
+  /// `data_` move) to establish happens-before: when the paint thread observes
+  /// `pixelsLoaded() == true` it is guaranteed to see the worker's completed
+  /// `data_`/range writes. No other path may read `data_`/`texture()` without
+  /// first passing this acquire check (see `texture()`, gated below).
+  bool pixelsLoaded() const
+  {
+    return pixels_loaded_.load(std::memory_order_acquire);
+  }
 
   const QString& path() const { return path_; }
   int width() const { return width_; }
@@ -74,7 +85,12 @@ private:
   double min_lon_ = 0.0, max_lon_ = 0.0, min_lat_ = 0.0, max_lat_ = 0.0;
   bool has_nodata_ = false;
   double nodata_ = 0.0;
-  bool pixels_loaded_ = false;               // set once loadPixels() has run
+  // [camp#102] Cross-thread publication flag: stored with release in loadPixels()
+  // (worker thread) AFTER data_/range are written, loaded with acquire in
+  // pixelsLoaded() (paint thread) before data_/texture() are read. Atomic so the
+  // rescan() re-kick (range already valid → paint's crossed-range gate is open)
+  // can't race the worker's mid-write.
+  std::atomic<bool> pixels_loaded_{false};   // set once loadPixels() has run
   double data_min_ = 1.0, data_max_ = 0.0;   // crossed => no valid samples
   std::vector<float> data_;                  // row-major, height_ * width_
   std::unique_ptr<QOpenGLTexture> texture_;

--- a/src/camp2/raster/gggs_tile_layer.cpp
+++ b/src/camp2/raster/gggs_tile_layer.cpp
@@ -156,6 +156,11 @@ bool GggsTileLayer::rescan()
   // already loaded so the new tiles' pixels stream in too.
   if(future_watcher_.isRunning())
   {
+    // [camp#102] Abort granularity is WHOLE-TILE (the worker checks abort_flag_
+    // only between tiles, not mid-RasterIO like RasterLayer's per-scanline check).
+    // A large in-flight tile's RasterIO therefore blocks this GUI-thread join
+    // until that one tile finishes. Acceptable at the Massabesic store scale this
+    // lands against; finer (sub-tile) abort is a follow-up if tiles grow large.
     abort_flag_mutex_.lock();
     abort_flag_ = true;
     abort_flag_mutex_.unlock();
@@ -215,6 +220,11 @@ void GggsTileLayer::loadTiles()
   // tiles_, and — if the layer is destroyed first — outlive `this`. A paint()
   // lazy-kick + a tilesReady() fold therefore cannot launch a second concurrent
   // load.
+  //
+  // [camp#102] Abort granularity is WHOLE-TILE: the worker honors abort_flag_ only
+  // between tiles, so a large in-flight tile's RasterIO blocks this GUI-thread join
+  // until that tile finishes (vs RasterLayer's per-scanline abort). Acceptable at
+  // current store scale; finer sub-tile abort is a follow-up if tiles grow large.
   if(future_watcher_.isRunning())
   {
     abort_flag_mutex_.lock();
@@ -235,10 +245,12 @@ void GggsTileLayer::loadTilesWorker()
   // [camp#102] Off-thread: GDAL RasterIO only — NEVER touch GL here (texture()/
   // allocateStorage stay on the paint path). The abort check is between tiles
   // (whole-tile granularity, vs RasterLayer's scanline granularity). loadPixels()
-  // writes each tile's data_/range; the pixelsLoaded() flag those reads set is
-  // only OBSERVED by the paint path after tilesReady() runs on the GUI thread
-  // (the watcher's finished->tilesReady join is the barrier), so the paint path
-  // never reads a tile mid-write.
+  // writes each tile's data_/range and then publishes it with a RELEASE store to
+  // the tile's atomic pixelsLoaded() flag. The paint path reads that flag with an
+  // ACQUIRE load before touching data_/texture(), so the release/acquire pair —
+  // not the tilesReady() join — is what guarantees the paint thread never reads a
+  // tile mid-write. (tilesReady() still runs post-join to fold the range +
+  // repaint, but a paint() that races an in-flight worker is already safe.)
   for(auto& tile : tiles_)
   {
     {
@@ -266,7 +278,14 @@ void GggsTileLayer::tilesReady()
     first_range = false;
   }
   cached_image_ = QImage();   // re-render now that pixels (and the range) exist
-  setStatus("");
+  // [camp#102] If the range is still crossed after the fold, every loaded tile was
+  // all-NoData (or failed to read): there is nothing to draw and clearing the
+  // status would leave a silently-blank enabled layer. Signal "(no data)" so the
+  // operator can tell an empty tile-set from one that simply hasn't loaded yet.
+  if(data_min_ > data_max_)
+    setStatus("(no data)");
+  else
+    setStatus("");
   update(boundingRect());
 }
 
@@ -425,9 +444,12 @@ QImage GggsTileLayer::renderImage(const QSize& size)
     for(auto& tile : tiles_)
     {
       // [camp#102] Skip a tile whose pixels haven't loaded yet (in-flight or not
-      // yet kicked). pixelsLoaded() is only set by tilesReady() after the worker
-      // joins, so reading it here on the paint path never races the worker's
-      // mid-write. The layer repaints on tilesReady() once the load completes.
+      // yet kicked). pixelsLoaded() is an ACQUIRE load that pairs with the worker's
+      // RELEASE store in loadPixels() (issued after the data_ move), so once it
+      // reads true the subsequent data_/texture() reads are guaranteed to see the
+      // worker's completed writes — no race even while a worker is mid-flight on
+      // another tile. The layer also repaints on tilesReady() once the load
+      // completes (to fold the range).
       if(!tile->pixelsLoaded())
         continue;
 

--- a/src/camp2/raster/gggs_tile_layer.cpp
+++ b/src/camp2/raster/gggs_tile_layer.cpp
@@ -10,6 +10,7 @@
 #include <QFileInfo>
 #include <QGeoCoordinate>
 #include <QMenu>
+#include <QSet>
 #include <QSettings>
 #include <QMatrix4x4>
 #include <QOffscreenSurface>
@@ -20,6 +21,7 @@
 #include <QOpenGLTexture>
 #include <QPainter>
 #include <QTransform>
+#include <QtConcurrent>
 
 #include <cmath>
 #include <vector>
@@ -79,6 +81,10 @@ GggsTileLayer::GggsTileLayer(map::MapItem* parentItem, const QString& directory)
   map::Layer(parentItem, QFileInfo(directory).fileName()),
   directory_(directory)
 {
+  // [camp#102] tilesReady() folds completed tiles' ranges + repaints on the GUI
+  // thread when the async pixel load finishes.
+  connect(&future_watcher_, &QFutureWatcher<void>::finished, this,
+          &GggsTileLayer::tilesReady);
   loadDirectory(directory);
   if(!tiles_.empty())
   {
@@ -99,6 +105,14 @@ GggsTileLayer::GggsTileLayer(map::MapItem* parentItem, const QString& directory)
 
 GggsTileLayer::~GggsTileLayer()
 {
+  // [camp#102] Abort + join any in-flight pixel load BEFORE tearing down GL or
+  // dropping the tiles the worker is reading — verbatim from RasterLayer's dtor
+  // contract (raster_layer.cpp:38-44), so a layer destroyed mid-load can't
+  // outlive `this` (the worker captures `this` and mutates tiles_).
+  abort_flag_mutex_.lock();
+  abort_flag_ = true;
+  abort_flag_mutex_.unlock();
+  future_watcher_.waitForFinished();
   releaseGL();
 }
 
@@ -108,9 +122,13 @@ void GggsTileLayer::loadDirectory(const QString& directory)
   const QStringList files = dir.entryList(QStringList() << "*.tif" << "*.tiff",
                                           QDir::Files, QDir::Name);
   bool first_extent = true;   // first geometrically-valid tile (scene_bounds_)
-  bool first_range = true;    // first tile WITH valid samples (data range)
   for(const QString& name : files)
   {
+    // [camp#102] Extent/metadata only — the GggsTile ctor no longer reads pixels.
+    // boundingRect()/sceneBounds() are valid immediately (fit-to-extent works at
+    // load time); the band reads (and therefore the data range) are deferred to
+    // the async loadTiles() worker, so data_min_/data_max_ accumulate
+    // incrementally in tilesReady() rather than here.
     auto tile = std::make_unique<GggsTile>(dir.filePath(name));
     if(!tile->valid())
       continue;
@@ -125,17 +143,144 @@ void GggsTileLayer::loadDirectory(const QString& directory)
     scene_bounds_ = first_extent ? tile_rect : scene_bounds_.united(tile_rect);
     first_extent = false;
 
-    // Data range tracks the first tile that actually HAS samples — separately
-    // from the extent, or an all-NoData first tile would leave data_min_ stuck
-    // at the sentinel (its default 1.0 is never < a floored-to->=1 sample).
-    if(tile->dataMin() <= tile->dataMax())
-    {
-      if(first_range || tile->dataMin() < data_min_) data_min_ = tile->dataMin();
-      if(first_range || tile->dataMax() > data_max_) data_max_ = tile->dataMax();
-      first_range = false;
-    }
     tiles_.push_back(std::move(tile));
   }
+}
+
+bool GggsTileLayer::rescan()
+{
+  // [camp#102] Incremental add of newly-landed tiles (QFileSystemWatcher fired).
+  // Abort + join any in-flight load first so we don't mutate tiles_ under the
+  // worker (it captures `this` and iterates tiles_). Then append extent-only
+  // entries for any path not already held; re-kick the load if the layer was
+  // already loaded so the new tiles' pixels stream in too.
+  if(future_watcher_.isRunning())
+  {
+    abort_flag_mutex_.lock();
+    abort_flag_ = true;
+    abort_flag_mutex_.unlock();
+    future_watcher_.waitForFinished();
+  }
+
+  QSet<QString> known;
+  for(const auto& tile : tiles_)
+    known.insert(tile->path());
+
+  QDir dir(directory_);
+  const QStringList files = dir.entryList(QStringList() << "*.tif" << "*.tiff",
+                                          QDir::Files, QDir::Name);
+  bool added = false;
+  for(const QString& name : files)
+  {
+    const QString path = dir.filePath(name);
+    if(known.contains(path))
+      continue;
+    // A half-written tile degrades to valid()==false here and is skipped — the
+    // next watcher fire (or a manual rescan) re-tries it once the producer's
+    // write completes. Producer-side atomic-write safety is uma#189.
+    auto tile = std::make_unique<GggsTile>(path);
+    if(!tile->valid())
+      continue;
+    const bool first_extent = tiles_.empty() && scene_bounds_.isNull();
+    const QPointF lo = web_mercator::geoToMap(
+      QGeoCoordinate(tile->minLat(), tile->minLon()));
+    const QPointF hi = web_mercator::geoToMap(
+      QGeoCoordinate(tile->maxLat(), tile->maxLon()));
+    const QRectF tile_rect = QRectF(lo, hi).normalized();
+    prepareGeometryChange();
+    scene_bounds_ = first_extent ? tile_rect : scene_bounds_.united(tile_rect);
+    if(first_extent)
+    {
+      setTransform(QTransform::fromScale(1.0, -1.0));
+      setPos(QPointF(scene_bounds_.left(), scene_bounds_.bottom()));
+    }
+    tiles_.push_back(std::move(tile));
+    added = true;
+  }
+
+  if(added && load_started_)
+  {
+    cached_image_ = QImage();   // force a re-render once the new pixels arrive
+    loadTiles();                // stream the new tiles' pixels in
+  }
+  return added;
+}
+
+void GggsTileLayer::loadTiles()
+{
+  // [camp#102] Abort + join any in-flight load before launching a new one, then
+  // re-arm — verbatim from RasterLayer::loadFile's re-launch guard
+  // (raster_layer.cpp:103-123). setFuture() only tracks the latest future, so a
+  // replaced job would otherwise keep running untracked, race the new job on
+  // tiles_, and — if the layer is destroyed first — outlive `this`. A paint()
+  // lazy-kick + a tilesReady() fold therefore cannot launch a second concurrent
+  // load.
+  if(future_watcher_.isRunning())
+  {
+    abort_flag_mutex_.lock();
+    abort_flag_ = true;
+    abort_flag_mutex_.unlock();
+    future_watcher_.waitForFinished();
+  }
+  abort_flag_mutex_.lock();
+  abort_flag_ = false;   // re-arm for the new job
+  abort_flag_mutex_.unlock();
+
+  setStatus("(loading...)");
+  future_watcher_.setFuture(QtConcurrent::run(this, &GggsTileLayer::loadTilesWorker));
+}
+
+void GggsTileLayer::loadTilesWorker()
+{
+  // [camp#102] Off-thread: GDAL RasterIO only — NEVER touch GL here (texture()/
+  // allocateStorage stay on the paint path). The abort check is between tiles
+  // (whole-tile granularity, vs RasterLayer's scanline granularity). loadPixels()
+  // writes each tile's data_/range; the pixelsLoaded() flag those reads set is
+  // only OBSERVED by the paint path after tilesReady() runs on the GUI thread
+  // (the watcher's finished->tilesReady join is the barrier), so the paint path
+  // never reads a tile mid-write.
+  for(auto& tile : tiles_)
+  {
+    {
+      QMutexLocker lock(&abort_flag_mutex_);
+      if(abort_flag_)
+        return;
+    }
+    if(!tile->pixelsLoaded())
+      tile->loadPixels();
+  }
+}
+
+void GggsTileLayer::tilesReady()
+{
+  // [camp#102] GUI thread, after the worker's join. Fold each loaded tile's range
+  // into the layer auto-range incrementally (the range is unknown until a tile's
+  // pixels load — an all-NoData tile reports a crossed range and is skipped).
+  bool first_range = (data_min_ > data_max_);
+  for(auto& tile : tiles_)
+  {
+    if(!tile->pixelsLoaded() || tile->dataMin() > tile->dataMax())
+      continue;
+    if(first_range || tile->dataMin() < data_min_) data_min_ = tile->dataMin();
+    if(first_range || tile->dataMax() > data_max_) data_max_ = tile->dataMax();
+    first_range = false;
+  }
+  cached_image_ = QImage();   // re-render now that pixels (and the range) exist
+  setStatus("");
+  update(boundingRect());
+}
+
+void GggsTileLayer::waitForLoad()
+{
+  // [camp#102] Test/headless seam: kick the load if it hasn't started, then join
+  // and run the ready-fold so renderImage() sees loaded pixels + a valid range.
+  if(!load_started_)
+  {
+    load_started_ = true;
+    loadTiles();
+  }
+  future_watcher_.waitForFinished();
+  tilesReady();
 }
 
 QRectF GggsTileLayer::boundingRect() const
@@ -279,6 +424,13 @@ QImage GggsTileLayer::renderImage(const QSize& size)
     verts.reserve(rows * 2 * 4);
     for(auto& tile : tiles_)
     {
+      // [camp#102] Skip a tile whose pixels haven't loaded yet (in-flight or not
+      // yet kicked). pixelsLoaded() is only set by tilesReady() after the worker
+      // joins, so reading it here on the paint path never races the worker's
+      // mid-write. The layer repaints on tilesReady() once the load completes.
+      if(!tile->pixelsLoaded())
+        continue;
+
       verts.clear();
       const double min_lon = tile->minLon();
       const double max_lon = tile->maxLon();
@@ -324,7 +476,21 @@ QImage GggsTileLayer::renderImage(const QSize& size)
 
 void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*)
 {
-  if(tiles_.empty() || data_min_ > data_max_)
+  if(tiles_.empty())
+    return;
+
+  // [camp#102] Lazily kick the async pixel load on the first paint — QGraphicsView
+  // only paints visible items, so this defers band reads to layers the operator
+  // turns on (default-off tile-sets never load). Kick exactly once; tilesReady()
+  // folds the range + repaints when the worker finishes. Until then the range is
+  // still crossed and there is nothing to draw, so fall through and return.
+  if(!load_started_)
+  {
+    load_started_ = true;
+    loadTiles();
+  }
+
+  if(data_min_ > data_max_)   // no tile's pixels/range folded yet
     return;
 
   // Target the offscreen render at the extent's on-screen size, so the image is
@@ -396,6 +562,14 @@ void GggsTileLayer::readSettings()
   QSettings settings;
   settings.beginGroup("MapItem");
   settings.beginGroup(itemID());
+  // [camp#102] Default GGGS tile-set leaves OFF: re-read `visible` with a FALSE
+  // fallback (Layer::readSettings just applied it with a TRUE default). This has
+  // to live in the leaf override, not a ctor setVisible(false) — MapItem::
+  // itemConstructed() runs readSettings() via QTimer::singleShot(0,...) AFTER the
+  // ctor, which would clobber a ctor call (map_item.cpp:26,180-183). A persisted
+  // `visible` value still wins (the operator's on/off choice round-trips); only
+  // the first-run default flips. Grouping GggsStoreLayer nodes are NOT affected.
+  setVisible(settings.value("visible", false).toBool());
   const map::ColorMap::Type type = map::ColorMap::typeFromName(
     settings.value("colormap", map::ColorMap::name(colormap_.type())).toString());
   settings.endGroup();

--- a/src/camp2/raster/gggs_tile_layer.h
+++ b/src/camp2/raster/gggs_tile_layer.h
@@ -4,7 +4,9 @@
 #include "../map/layer.h"
 #include "../map/color_map.h"
 
+#include <QFutureWatcher>
 #include <QImage>
+#include <QMutex>
 #include <QSize>
 #include <memory>
 #include <vector>
@@ -73,13 +75,36 @@ public:
   /// a GPU LUT). Persists and re-renders.
   void setColormap(map::ColorMap::Type type);
 
+  /// [camp#102] Block until this layer's async pixel load (if any) has completed.
+  /// Exposed for headless tests that call renderImage() directly without the
+  /// QGraphicsView paint loop that normally kicks + awaits the load via signals.
+  void waitForLoad();
+
+  /// [camp#102] Re-scan the tile directory for newly-landed `*.tif` files (e.g.
+  /// the GggsStoreLayer's QFileSystemWatcher fired). Adds extent-only entries for
+  /// any tile not already held and re-kicks the async pixel load if the layer is
+  /// already loaded. A half-written tile that fails to open degrades to
+  /// valid()==false and is skipped — never crashes. Returns true if any tile was
+  /// added.
+  bool rescan();
+
 protected:
   void contextMenu(QMenu* menu) override;
   void readSettings() override;
   void writeSettings() override;
 
+private slots:
+  /// [camp#102] Launch the async pixel read over not-yet-loaded tiles.
+  void loadTiles();
+  /// [camp#102] Fold completed tiles' ranges into data_min_/data_max_, mark them
+  /// pixelsLoaded(), invalidate the cache, and repaint.
+  void tilesReady();
+
 private:
   void loadDirectory(const QString& directory);
+  /// [camp#102] Worker body (runs off-thread): loadPixels() each not-yet-loaded
+  /// tile, honoring abort_flag_ between tiles. GDAL only — never touches GL.
+  void loadTilesWorker();
   bool ensureGL();
   bool ensureProgram();
   QOpenGLTexture* ensureLut();
@@ -97,6 +122,20 @@ private:
   QRectF scene_bounds_;        // union of tile extents in Web-Mercator scene units
   double data_min_ = 1.0;      // auto-range over all tiles (crossed => no data)
   double data_max_ = 0.0;
+
+  // [camp#102] Async pixel load mirroring RasterLayer (ADR-0003 §3): the cheap
+  // extent list is built in loadDirectory(); the band reads are deferred to a
+  // single QtConcurrent worker driven by this watcher and kicked lazily from the
+  // first paint(). The abort flag + waitForFinished() dtor/re-launch join is
+  // ported verbatim from RasterLayer so a layer destroyed mid-load can't outlive
+  // `this`. The worker mutates each GggsTile's pixel buffer off-thread; the paint
+  // path only ever reads a tile whose pixelsLoaded() flag is set, and that flag
+  // is set ONLY in tilesReady() (GUI thread) after the worker has finished — so
+  // no tile is read mid-write.
+  QFutureWatcher<void> future_watcher_;
+  bool abort_flag_ = false;
+  QMutex abort_flag_mutex_;
+  bool load_started_ = false;  // first paint() kicks the load exactly once
 
   // The layer's own offscreen GL context — created lazily, used only for the
   // FBO render; never touches the GUI's context.

--- a/src/camp2/raster/gggs_tile_layer.h
+++ b/src/camp2/raster/gggs_tile_layer.h
@@ -128,10 +128,13 @@ private:
   // single QtConcurrent worker driven by this watcher and kicked lazily from the
   // first paint(). The abort flag + waitForFinished() dtor/re-launch join is
   // ported verbatim from RasterLayer so a layer destroyed mid-load can't outlive
-  // `this`. The worker mutates each GggsTile's pixel buffer off-thread; the paint
-  // path only ever reads a tile whose pixelsLoaded() flag is set, and that flag
-  // is set ONLY in tilesReady() (GUI thread) after the worker has finished — so
-  // no tile is read mid-write.
+  // `this`. The worker mutates each GggsTile's pixel buffer off-thread and then
+  // publishes it by storing the tile's atomic pixelsLoaded() flag with RELEASE
+  // ordering (gggs_tile.cpp). The paint path only ever reads a tile's data_/
+  // texture() after an ACQUIRE load of that flag returns true (gggs_tile_layer.cpp
+  // renderImage). That release/acquire pair establishes happens-before, so the
+  // paint thread never observes a half-written buffer — even on the rescan()
+  // re-kick, where the layer's crossed-range gate is already open.
   QFutureWatcher<void> future_watcher_;
   bool abort_flag_ = false;
   QMutex abort_flag_mutex_;

--- a/test/test_gggs_render.cpp
+++ b/test/test_gggs_render.cpp
@@ -80,6 +80,9 @@ TEST(GggsRenderTest, OffscreenWarpProducesOrientedImage)
   ASSERT_NE(layers, nullptr);
   auto* layer = new camp::raster::GggsTileLayer(layers, dir.path());
   ASSERT_TRUE(layer->valid());
+  // [camp#102] Pixel loads are async + lazily kicked from paint(); this headless
+  // test calls renderImage() directly, so drive + await the load explicitly.
+  layer->waitForLoad();
 
   const QImage img = layer->renderImage(QSize(200, 200));
   ASSERT_FALSE(img.isNull());
@@ -117,6 +120,7 @@ TEST(GggsRenderTest, RealStoreRendersWhenProvided)
   auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(),
                                                 QString::fromLocal8Bit(store));
   ASSERT_TRUE(layer->valid());
+  layer->waitForLoad();
   const QImage img = layer->renderImage(QSize(900, 900));
   ASSERT_FALSE(img.isNull());
   img.save("/tmp/gggs_real.png");

--- a/test/test_gggs_tile.cpp
+++ b/test/test_gggs_tile.cpp
@@ -10,7 +10,9 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <cmath>
+#include <thread>
 #include <vector>
 
 #include <gdal_priv.h>
@@ -144,6 +146,81 @@ TEST(GggsTileTest, AllNoDataHasCrossedRange)
   ASSERT_TRUE(tile.valid());           // dimensions known
   ASSERT_TRUE(tile.loadPixels());      // pixels read (all NoData)
   EXPECT_GT(tile.dataMin(), tile.dataMax());   // no valid samples
+}
+
+// [camp#102] Publication-contract regression: pixelsLoaded() must stay false
+// until loadPixels() has fully populated the buffer + range. The layer's paint
+// path gates every data_/texture() read on this flag (an acquire load that pairs
+// with the worker's release store), so this flag flipping early — or the range
+// being observable before the flag — would reopen the worker-vs-paint race the
+// rescan() re-kick exposes. Pins the contract without GL/event-loop scaffolding.
+TEST(GggsTileTest, PixelsLoadedFalseUntilLoadCompletes)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const int w = 2, h = 2;
+  const double geo[6] = {-71.4, 0.001, 0.0, 43.0, 0.0, -0.001};
+  std::vector<uint16_t> samples = {0, 5, 12345, 50000};
+  const QString path = writeTile(dir, "13_3_3.tif", w, h, geo, samples);
+
+  GggsTile tile(path);
+  ASSERT_TRUE(tile.valid());
+  // Before any load: flag false and the range is still the crossed sentinel.
+  EXPECT_FALSE(tile.pixelsLoaded());
+  EXPECT_GT(tile.dataMin(), tile.dataMax());
+
+  ASSERT_TRUE(tile.loadPixels());
+  // After load: flag true AND the range is consistent (the flag must not become
+  // observable before the range it advertises).
+  EXPECT_TRUE(tile.pixelsLoaded());
+  EXPECT_LE(tile.dataMin(), tile.dataMax());
+}
+
+// [camp#102] Cross-thread publication: a worker thread loads the pixels while a
+// second thread spins on pixelsLoaded() exactly as the paint path does. The
+// moment the spinner observes the (acquire) flag true, the released data_ range
+// MUST already be visible and consistent — that is the happens-before the
+// release/acquire pair provides. A plain (non-atomic, no-barrier) flag could let
+// the spinner see true with a torn/stale range; this guards that regression.
+TEST(GggsTileTest, PixelsPublishedToObserverThread)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const int w = 4, h = 4;
+  const double geo[6] = {-71.4, 0.001, 0.0, 43.0, 0.0, -0.001};
+  std::vector<uint16_t> samples(w * h);
+  for(int i = 0; i < w * h; ++i)
+    samples[i] = uint16_t(i + 1);   // 1..16, no NoData → range [1, 16]
+  const QString path = writeTile(dir, "13_4_4.tif", w, h, geo, samples);
+
+  GggsTile tile(path);
+  ASSERT_TRUE(tile.valid());
+
+  std::atomic<bool> go{false};
+  std::atomic<bool> saw_inconsistent{false};
+
+  // Observer mirrors renderImage()'s gate: only read the range once the flag
+  // (acquire) reads true, then assert it is the fully-populated value.
+  std::thread observer([&]() {
+    while(!go.load(std::memory_order_acquire)) { /* spin to start */ }
+    while(!tile.pixelsLoaded()) { /* spin until published */ }
+    if(tile.dataMin() != 1.0 || tile.dataMax() != 16.0)
+      saw_inconsistent.store(true, std::memory_order_relaxed);
+  });
+
+  std::thread worker([&]() {
+    while(!go.load(std::memory_order_acquire)) { /* spin to start */ }
+    tile.loadPixels();
+  });
+
+  go.store(true, std::memory_order_release);
+  worker.join();
+  observer.join();
+
+  EXPECT_FALSE(saw_inconsistent.load(std::memory_order_relaxed));
+  EXPECT_TRUE(tile.pixelsLoaded());
+  EXPECT_DOUBLE_EQ(tile.dataMin(), 1.0);
+  EXPECT_DOUBLE_EQ(tile.dataMax(), 16.0);
 }
 
 // A missing file degrades to invalid (no crash), like RasterLayer.

--- a/test/test_gggs_tile.cpp
+++ b/test/test_gggs_tile.cpp
@@ -76,7 +76,41 @@ TEST(GggsTileTest, ExtentFromGeotransform)
   EXPECT_NEAR(tile.minLat(), max_lat - h * dlat, 1e-12);
 }
 
-// NoData (0) is excluded from the data range; real samples set min/max.
+// [camp#102] The constructor reads extent/dimensions ONLY — valid() and the
+// geographic extent are known before any pixel read. The data range stays at the
+// crossed sentinel until loadPixels() runs, which then populates it.
+TEST(GggsTileTest, ExtentKnownBeforePixelsLoad)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const int w = 2, h = 2;
+  const double geo[6] = {-71.4, 0.001, 0.0, 43.0, 0.0, -0.001};
+  std::vector<uint16_t> samples = {0, 5, 12345, 50000};
+  const QString path = writeTile(dir, "13_2_2.tif", w, h, geo, samples);
+
+  GggsTile tile(path);
+  // Extent + dimensions are valid synchronously, before any RasterIO.
+  ASSERT_TRUE(tile.valid());
+  EXPECT_FALSE(tile.pixelsLoaded());
+  EXPECT_EQ(tile.width(), w);
+  EXPECT_EQ(tile.height(), h);
+  EXPECT_NEAR(tile.maxLat(), 43.0, 1e-12);
+  // The range is crossed (unknown) until pixels load.
+  EXPECT_GT(tile.dataMin(), tile.dataMax());
+
+  // loadPixels() reads the band and populates the range.
+  EXPECT_TRUE(tile.loadPixels());
+  EXPECT_TRUE(tile.pixelsLoaded());
+  EXPECT_DOUBLE_EQ(tile.dataMin(), 5.0);
+  EXPECT_DOUBLE_EQ(tile.dataMax(), 50000.0);
+
+  // Idempotent: a second call is a no-op and stays loaded.
+  EXPECT_TRUE(tile.loadPixels());
+  EXPECT_TRUE(tile.pixelsLoaded());
+}
+
+// NoData (0) is excluded from the data range; real samples set min/max
+// (post loadPixels()).
 TEST(GggsTileTest, NoDataExcludedFromRange)
 {
   QTemporaryDir dir;
@@ -91,6 +125,7 @@ TEST(GggsTileTest, NoDataExcludedFromRange)
   ASSERT_TRUE(tile.valid());
   EXPECT_TRUE(tile.hasNoData());
   EXPECT_DOUBLE_EQ(tile.noData(), 0.0);
+  ASSERT_TRUE(tile.loadPixels());
   EXPECT_DOUBLE_EQ(tile.dataMin(), 5.0);
   EXPECT_DOUBLE_EQ(tile.dataMax(), 50000.0);
 }
@@ -107,6 +142,7 @@ TEST(GggsTileTest, AllNoDataHasCrossedRange)
 
   GggsTile tile(path);
   ASSERT_TRUE(tile.valid());           // dimensions known
+  ASSERT_TRUE(tile.loadPixels());      // pixels read (all NoData)
   EXPECT_GT(tile.dataMin(), tile.dataMax());   // no valid samples
 }
 

--- a/test/test_gggs_visibility.cpp
+++ b/test/test_gggs_visibility.cpp
@@ -1,0 +1,92 @@
+// [camp#102] Tests for the GGGS tile-set leaf's default-off visibility and its
+// persistence round-trip (the highest-risk non-GL behavior of the lazy/async
+// change). A GGGS tile-set leaf must default to NOT visible (so opening a large
+// store doesn't paint — and therefore doesn't load pixels for — every tile-set),
+// but a persisted on/off choice must still round-trip via QSettings.
+//
+// The GggsTileLayer's readSettings()/writeSettings() are protected and normally
+// driven by MapItem::itemConstructed() on a deferred timer. A tiny test subclass
+// exposes them so we can assert the round-trip synchronously, without an event
+// loop. No GL / GDAL is needed (the layer holds no tiles here).
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QSettings>
+#include <QTemporaryDir>
+
+#include "map/map.h"
+#include "map/layer_list.h"
+#include "raster/gggs_tile_layer.h"
+
+namespace
+{
+
+// Exposes the protected settings hooks so the round-trip is testable without the
+// deferred itemConstructed() timer.
+class TestableGggsTileLayer: public camp::raster::GggsTileLayer
+{
+public:
+  using camp::raster::GggsTileLayer::GggsTileLayer;
+  using camp::raster::GggsTileLayer::readSettings;
+  using camp::raster::GggsTileLayer::writeSettings;
+};
+
+}  // namespace
+
+// Default (no persisted value): a GGGS tile-set leaf comes up NOT visible.
+TEST(GggsVisibilityTest, DefaultsOff)
+{
+  QSettings().clear();
+  camp::map::Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+
+  // An empty directory -> a valid layer object (no tiles) with a stable itemID.
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  auto* layer = new TestableGggsTileLayer(layers, dir.path());
+  layer->readSettings();   // would run via itemConstructed()'s deferred timer
+
+  EXPECT_FALSE(layer->isVisible());
+}
+
+// A persisted visibility choice round-trips: turning a leaf ON and writing
+// settings, then re-reading, restores visible == true (the default-off only
+// changes the first-run default, not the persistence path).
+TEST(GggsVisibilityTest, PersistedVisibilityRoundTrips)
+{
+  QSettings().clear();
+  camp::map::Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+
+  // First layer: operator turns it ON and the choice is persisted.
+  {
+    auto* layer = new TestableGggsTileLayer(layers, dir.path());
+    layer->readSettings();
+    EXPECT_FALSE(layer->isVisible());   // default off
+    layer->setVisible(true);
+    layer->writeSettings();             // persist the ON choice
+  }
+
+  // A fresh layer with the SAME directory (same itemID) reads the persisted ON.
+  {
+    auto* layer = new TestableGggsTileLayer(layers, dir.path());
+    layer->readSettings();
+    EXPECT_TRUE(layer->isVisible());    // persisted choice wins over the default
+  }
+}
+
+int main(int argc, char** argv)
+{
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QApplication app(argc, argv);
+  QCoreApplication::setOrganizationName("camp_test");
+  QCoreApplication::setApplicationName("test_gggs_visibility");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

camp#102 — make the GGGS store layer (camp#90) load lazily/async so opening a **large** store doesn't freeze the GUI thread. Generalizes `RasterLayer`'s sync-extent-ctor + async-pixel-load pattern (camp ADR-0003 §3) to the GGGS tile path. Part of rolker/unh_marine_autonomy#175 and #171.

## What's in it

- **`GggsTile` split** — the ctor reads only geotransform/extent/dimensions/NoData (no `RasterIO`); a new `loadPixels()` does the band read + data range off-thread. `valid()` is true on dimensions alone.
- **Async pixel load** — `GggsTileLayer` runs a `QtConcurrent`/`QFutureWatcher` worker (GDAL `RasterIO` off the GUI thread); `tilesReady()` folds the range incrementally + uploads GL textures on the paint path. `RasterLayer`'s abort-flag-under-mutex + `waitForFinished()` dtor + `isRunning()→abort+join` re-launch guard are ported verbatim.
- **Lazy load-on-visible + default-off tile-sets** — leaves default OFF (a `readSettings()` override with a `false` fallback — a ctor `setVisible(false)` is clobbered by the post-ctor `readSettings`); the async load is kicked from the first `paint()` (Qt only paints visible items). Per-layer visibility persists.
- **`QFileSystemWatcher`** — discovers newly-landed tile-sets/epochs (default-off) and re-scans changed leaves; a half-written tile degrades to `valid()==false` and is skipped (atomic-write safety is the separate uma#189).

## Concurrency

The worker↔paint publication of tile pixel state uses a `std::atomic<bool> pixels_loaded_` with **release** (after the `data_` write) / **acquire** (every paint-path read) ordering, so a repaint can never observe a half-published tile — including on the `rescan()`/live-streaming re-kick. A round-1 self-review caught the original plain-bool race; round 2 traced the fix closed.

## Verification

**72 tests, 0 failures** (1 GL self-skip). Deep `review-code` (two adversarial lenses, concurrency-weighted) → must-fix race fixed → re-review **approved**. Timeline + findings in `progress.md`.

## Deferred (documented follow-ups)

Watcher inotify watch-count cap (fine at current scale); finer-than-whole-tile abort granularity; visible-region render + pyramid LOD (camp#103); producer pyramids + atomic tile writes (uma#188/#189); live ROS transport (I3).

Closes #102

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
