### PR TITLE
docs: update GggsStoreLayer store-root example to split modality dirs

### DIFF
--- a/src/camp2/raster/gggs_store_layer.h
+++ b/src/camp2/raster/gggs_store_layer.h
@@ -19,8 +19,9 @@ class GggsTileLayer;
 /// directory it recursively builds the layer tree: any directory that directly
 /// contains `*.tif` becomes a renderable GggsTileLayer leaf; directories above
 /// those become grouping GggsStoreLayer nodes (e.g. a store root with
-/// `bathymetry/` and `sidescan_backscatter/<epoch>/` products). The node itself
-/// draws nothing — it only groups children in the Layers tree.
+/// `bathymetry/`, `sidescan/` and `backscatter/` modality dirs, each holding
+/// `draft/`/`processed/` maturity subdirs). The node itself draws nothing — it
+/// only groups children in the Layers tree.
 class GggsStoreLayer: public map::Layer
 {
   Q_OBJECT


### PR DESCRIPTION
Closes #106.

Comment-only. Updates the `GggsStoreLayer` doc example from the old fused `sidescan_backscatter/<epoch>/` to the current split convention: `bathymetry/`, `sidescan/`, `backscatter/` modality dirs each with `draft/`/`processed/` maturity subdirs (ADR-0006 sidescan / ADR-0007 MBES; matches the on-disk store rename). No behavior change.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
