### PR TITLE
Running-task view: adopt marine_nav_tasks::TaskList, ordering + staleness, retire Heartbeat text

### DIFF
--- a/.agent/work-plans/issue-130/plan.md
+++ b/.agent/work-plans/issue-130/plan.md
@@ -13,13 +13,22 @@ green/yellow/red staleness background; and retiring the old Heartbeat text dump 
 
 ## Approach
 
+### 0. Adopt the shared task model (`marine_nav_tasks::TaskList` / `Task`)
+Rather than hand-roll id-hierarchy parsing, ordering, done and YAML handling,
+`RunningTasksModel` now wraps a `marine_nav_tasks::TaskList` (the same model the
+boat uses). On each snapshot, `setTasks(current, tasks, clock)` calls
+`task_list_.update(tasks, clock)` (which builds the tree from the flat list,
+preserves message/run order, and creates/removes/reorders tasks), then snapshots
+the `Task` tree into display `Node`s (each `Node` keeps the `TaskPtr` so P2 map
+glue can read poses/markers). Adds `<depend>marine_nav_tasks</depend>` (ui→core).
+Note: `TaskList` does **not** synthesize missing intermediate parents, so there
+are no synthetic group rows — we render exactly the domain tree.
+
 ### 1. Done-to-bottom ordering (`running_tasks_model.cpp`)
-Execution order is already the message array order (boat `TaskList.task_order_ids`),
-which `rebuild()` preserves. Add a stable partition **per tree level**: not-done
-nodes first (in run order), done nodes last (in run order). Implement by sorting
-each node's `children` after the tree is built, with a stable comparator keyed on
-`(hasTask && row.done)`. Synthetic groups sort as not-done. `rowInParent` must be
-re-assigned after sorting so index/parent stay consistent.
+Run order comes from `TaskList` (message order). On top of the snapshot, add a
+stable partition **per tree level**: not-done nodes first (in run order), done
+nodes last. `sortChildrenRecursive` sorts each node's `children` keyed on
+`task->message().done` and re-assigns `rowInParent` so index/parent stay consistent.
 
 ### 2. Staleness background (`running_tasks_view.{h,cpp}`)
 Mirror `HelmManager::watchdogUpdate`:
@@ -47,7 +56,8 @@ Mirror `HelmManager::watchdogUpdate`:
 
 | File | Change |
 |------|--------|
-| `src/camp/running_tasks/running_tasks_model.cpp` | Sort children done-to-bottom; reindex `rowInParent` |
+| `CMakeLists.txt`, `package.xml` | Add `marine_nav_tasks` dependency |
+| `src/camp/running_tasks/running_tasks_model.{h,cpp}` | Wrap `marine_nav_tasks::TaskList`; Node holds `TaskPtr`; sort done-to-bottom; reindex `rowInParent` |
 | `src/camp/running_tasks/running_tasks_view.{h,cpp}` | Staleness QTimer + palette coloring |
 | `src/camp/mission_manager/mission_manager.ui` | Drop text browser, keep buttons |
 | `src/camp/mission_manager/mission_manager.{h,cpp}` | Drop Heartbeat sub + callbacks |

--- a/.agent/work-plans/issue-130/plan.md
+++ b/.agent/work-plans/issue-130/plan.md
@@ -24,11 +24,13 @@ glue can read poses/markers). Adds `<depend>marine_nav_tasks</depend>` (ui→cor
 Note: `TaskList` does **not** synthesize missing intermediate parents, so there
 are no synthetic group rows — we render exactly the domain tree.
 
-### 1. Done-to-bottom ordering (`running_tasks_model.cpp`)
-Run order comes from `TaskList` (message order). On top of the snapshot, add a
-stable partition **per tree level**: not-done nodes first (in run order), done
-nodes last. `sortChildrenRecursive` sorts each node's `children` keyed on
-`task->message().done` and re-assigns `rowInParent` so index/parent stay consistent.
+### 1. Ordering: by priority (run order), done to the bottom (`running_tasks_model.cpp`)
+Run order is **priority ascending** (lower number runs first; the priority-100
+`done_hover` fallback runs last) — NOT message/insertion order, which floats
+`done_hover` to the top because the boat adds it first at init. `sortChildrenRecursive`
+sorts each level by `(done, priority)` — not-done before done, then priority
+ascending (stable_sort keeps message order for ties) — and re-assigns `rowInParent`
+so index/parent stay consistent.
 
 ### 2. Staleness background (`running_tasks_view.{h,cpp}`)
 Mirror `HelmManager::watchdogUpdate`:
@@ -79,9 +81,9 @@ Mirror `HelmManager::watchdogUpdate`:
 
 ## Open Questions
 
-- "Order by how they'll be run" is taken as message array order (= boat
-  `task_order_ids`, the run order), not a priority re-sort. Flag in review if a
-  priority sort was intended instead.
+- ~~array order vs priority~~ RESOLVED (sim, Roland): order by **priority**
+  ascending — message/insertion order wrongly floated the priority-100
+  `done_hover` fallback to the top.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-130/plan.md
+++ b/.agent/work-plans/issue-130/plan.md
@@ -1,0 +1,78 @@
+# Plan: Running-task view polish (#130)
+
+## Issue
+
+https://github.com/rolker/camp/issues/130  (Part of #123)
+
+## Context
+
+First sim test of the P1 running-task view (#127) surfaced three polish items, all
+in `camp`: order tasks by run order with done at the bottom; a HelmManager-style
+green/yellow/red staleness background; and retiring the old Heartbeat text dump in
+`MissionManager` (keeping its buttons).
+
+## Approach
+
+### 1. Done-to-bottom ordering (`running_tasks_model.cpp`)
+Execution order is already the message array order (boat `TaskList.task_order_ids`),
+which `rebuild()` preserves. Add a stable partition **per tree level**: not-done
+nodes first (in run order), done nodes last (in run order). Implement by sorting
+each node's `children` after the tree is built, with a stable comparator keyed on
+`(hasTask && row.done)`. Synthetic groups sort as not-done. `rowInParent` must be
+re-assigned after sorting so index/parent stay consistent.
+
+### 2. Staleness background (`running_tasks_view.{h,cpp}`)
+Mirror `HelmManager::watchdogUpdate`:
+- `QTimer` at 500 ms → `watchdogUpdate()`.
+- Track `last_message_time_` (rclcpp::Time), set on each applied `TaskFeedback`
+  (GUI thread, in `applyPendingTasks`) from `node_->get_clock()->now()`.
+- In `watchdogUpdate`, if a message has been received: `diff = now - last_message_time_`;
+  `QPalette::Window` = green (<2 s) / yellow (<5 s) / red; `setAutoFillBackground(true)`.
+- Thresholds `max_green_duration_` = 2 s, `max_yellow_duration_` = 5 s (members).
+- Add a few px contents margin so the colored window frames the tree.
+- Timer needs the node clock; guard until `node_` is set (start timer in `setNode`,
+  like HelmManager).
+
+### 3. Retire Heartbeat display in `MissionManager` (`mission_manager.{h,cpp,ui}`)
+- `mission_manager.ui`: remove `missionStatusTextBrowser` (and its custom context
+  menu policy). Keep the button row: Cancel Override, Clear, Restart.
+- `mission_manager.{h,cpp}`: remove the `Heartbeat` subscription
+  (`mission_status_subscription_`), `missionStatusCallback`, `updateMissionStatus`,
+  and the `on_missionStatusTextBrowser_customContextMenuRequested` handler + the
+  `marine_interfaces/Heartbeat` include. Keep `send_command_publisher_`, the button
+  handlers, and `sendNextItem/sendHover/sendGoto/sendIdle/...` (used by projectview /
+  autonomousvehicleproject).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/camp/running_tasks/running_tasks_model.cpp` | Sort children done-to-bottom; reindex `rowInParent` |
+| `src/camp/running_tasks/running_tasks_view.{h,cpp}` | Staleness QTimer + palette coloring |
+| `src/camp/mission_manager/mission_manager.ui` | Drop text browser, keep buttons |
+| `src/camp/mission_manager/mission_manager.{h,cpp}` | Drop Heartbeat sub + callbacks |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| No regression | Removing the Heartbeat display is safe — the structured view replaces it; buttons + command paths used elsewhere are kept. |
+| Consistency | Staleness reuses HelmManager's exact mechanism/colors/thresholds. |
+| Model correctness | Re-sort must re-assign `rowInParent` so index()/parent()/indexForId stay consistent (verify with a tree walk). |
+
+## Consequences
+
+| If we change... | Also update... | In plan? |
+|---|---|---|
+| Remove MissionManager Heartbeat sub | Confirm no other consumer of `updateMissionStatus`/textBrowser | Yes (grep) |
+| Sort model children | `rowInParent` reindex + idForIndex/indexForId | Yes |
+
+## Open Questions
+
+- "Order by how they'll be run" is taken as message array order (= boat
+  `task_order_ids`, the run order), not a priority re-sort. Flag in review if a
+  priority sort was intended instead.
+
+## Estimated Scope
+
+Single PR in `camp`.

--- a/.agent/work-plans/issue-130/progress.md
+++ b/.agent/work-plans/issue-130/progress.md
@@ -15,3 +15,26 @@ issue: 130
 
 ### Open questions
 - [ ] "Order by how they'll run" taken as message array order (boat task_order_ids), not a priority re-sort — flag in review if priority sort intended.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-28 10:45 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved (suggestions addressed)
+
+**Branch**: feature/issue-130 at `56b74be` (+ review-fix commit)
+**Mode**: pre-push
+**Depth**: Standard (reason: model data-source refactor onto marine_nav_tasks::TaskList + cross-package integration)
+**Must-fix**: 0 | **Suggestions**: 3 (2 fixed, 1 flagged)
+**Round**: 1 | **Ship**: recommended — no must-fix; model correctness + threading + lifetime walked clean
+
+### Findings
+- [x] (suggestion) Current-task highlight compared raw fullId vs normalized current_task_ → could miss on stray-slash id. FIXED: normalize both sides in data() — `running_tasks_model.cpp`
+- [x] (suggestion) Dtor comment referenced removed pending_rows_ member. FIXED → pending_tasks_ — `running_tasks_view.cpp`
+- [ ] (suggestion, flagged to operator — pre-existing, out of scope) MissionManager has orphan auto-connect slots (on_gotoLine/startLine/nextMissionItemPushButton_clicked) for widgets absent from the .ui → Qt "No matching signal" runtime warnings. Also: "Next Mission Item" was context-menu-only and is now unreachable from the UI after removing the text browser — offer to add a Next button.
+
+### Verified clean (walked)
+- buildNodes + sortChildrenRecursive: rowInParent consistent with final order (re-indexed over sorted vector); 2-level done-task example round-trips index/parent/indexForId.
+- TaskPtr lifetime: Nodes hold shared_ptr copies; old tree freed on root_ reassign; no dangling across cycles. beginResetModel/endResetModel brackets whole rebuild.
+- Threading: callback only copies msg under mutex; TaskList touched GUI-thread-only. Clock fallback unreachable+harmless. Dtor resets subscription_ first (ordering holds post-refactor).
+- MissionManager Heartbeat removal complete; no residual refs; kept buttons match slots.

--- a/.agent/work-plans/issue-130/progress.md
+++ b/.agent/work-plans/issue-130/progress.md
@@ -1,0 +1,17 @@
+---
+issue: 130
+---
+
+# Issue #130 — Running-task view polish: ordering + done-to-bottom, staleness background, retire Heartbeat text
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-28 10:17 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-130/plan.md` at `1dedeee`
+**Branch**: feature/issue-130 at `1dedeee`
+**Phases**: single
+
+### Open questions
+- [ ] "Order by how they'll run" taken as message array order (boat task_order_ids), not a priority re-sort — flag in review if priority sort intended.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(pluginlib REQUIRED)
 find_package(marine_autonomy REQUIRED)
 find_package(marine_interfaces REQUIRED)
 find_package(marine_nav_interfaces REQUIRED)
+find_package(marine_nav_tasks REQUIRED)
 
 find_package(qt_gui_cpp REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
@@ -150,6 +151,7 @@ ament_target_dependencies(CCOMAutonomousMissionPlanner
     marine_autonomy
     marine_interfaces
     marine_nav_interfaces
+    marine_nav_tasks
 
     rclcpp
     tf2

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <depend>marine_autonomy</depend>
   <depend>marine_interfaces</depend>
   <depend>marine_nav_interfaces</depend>
+  <depend>marine_nav_tasks</depend>
 
   <!-- <depend>sound_play</depend> -->
   <depend>tf2</depend>

--- a/src/camp/mission_manager/mission_manager.cpp
+++ b/src/camp/mission_manager/mission_manager.cpp
@@ -1,8 +1,6 @@
 #include "mission_manager.h"
 #include "ui_mission_manager.h"
-#include <QMenu>
 #include <QGeoCoordinate>
-#include "ros/ros_context.h"
 
 MissionManager::MissionManager(QWidget *parent)
   :camp_ros::ROSWidget(parent), m_ui(new Ui::MissionManager)
@@ -19,10 +17,8 @@ void MissionManager::updateRobotNamespace(QString robot_namespace)
 {
   if(node_)
   {
-    rclcpp::SubscriptionOptions realtime_options;
-    if (auto ctx = camp_ros::RosContext::instance())
-      realtime_options.callback_group = ctx->group(camp_ros::RosContext::Group::Realtime);
-    mission_status_subscription_ = node_->create_subscription<marine_interfaces::msg::Heartbeat>("/"+robot_namespace.toStdString()+"/marine/status/mission_manager" , 1, std::bind(&MissionManager::missionStatusCallback, this, std::placeholders::_1), realtime_options);
+    // Mission status is now shown by the structured RunningTasksView; this
+    // widget is a command panel and no longer subscribes to the Heartbeat.
     send_command_publisher_ = node_->create_publisher<std_msgs::msg::String>("/"+robot_namespace.toStdString()+"/marine/send_command",1);
 
     rclcpp::QoS qos(1);
@@ -30,11 +26,6 @@ void MissionManager::updateRobotNamespace(QString robot_namespace)
 
     send_avoidance_costmap_publisher_ = node_->create_publisher<marine_interfaces::msg::GeoOccupancyVectorMap>("/"+robot_namespace.toStdString()+"/marine/avoidance_map", qos);
   }
-}
-
-void MissionManager::updateMissionStatus(const QString& status)
-{
-    m_ui->missionStatusTextBrowser->setText(status);
 }
 
 void MissionManager::on_gotoLinePushButton_clicked(bool checked)
@@ -45,22 +36,6 @@ void MissionManager::on_gotoLinePushButton_clicked(bool checked)
 void MissionManager::on_startLinePushButton_clicked(bool checked)
 {
     //sendStartLine(m_ui->lineNumberSpinBox->value());
-}
-
-void MissionManager::on_missionStatusTextBrowser_customContextMenuRequested(const QPoint &pos)
-{
-    QMenu menu(this);
-
-    QAction *nextItemAction = menu.addAction("Next Mission Item");
-    connect(nextItemAction, &QAction::triggered, this, &MissionManager::sendNextItem);
-
-    QAction *restartMissionAction = menu.addAction("Restart Mission");
-    connect(restartMissionAction, &QAction::triggered, this, &MissionManager::restartMission);
-
-    QAction *clearTasksAction = menu.addAction("Clear Tasks");
-    connect(clearTasksAction, &QAction::triggered, this, &MissionManager::clearTasks);
-
-    menu.exec(m_ui->missionStatusTextBrowser->mapToGlobal(pos));
 }
 
 void MissionManager::on_nextMissionItemPushButton_clicked(bool checked)
@@ -81,20 +56,6 @@ void MissionManager::on_clearTasksPushButton_clicked(bool checked)
 void MissionManager::on_cancelOverridePushButton_clicked(bool checked)
 {
   sendCancelOverride();
-}
-
-void MissionManager::missionStatusCallback(const marine_interfaces::msg::Heartbeat& message)
-{
-  QString status_string;
-  for(auto kv: message.values)
-  {
-    status_string += kv.key.c_str();
-    status_string += ": ";
-    status_string += kv.value.c_str();
-    status_string += "\n";
-  }
-  
-  QMetaObject::invokeMethod(this, "updateMissionStatus", Qt::QueuedConnection, Q_ARG(QString const&, status_string));
 }
 
 void MissionManager::sendMissionPlan(const QString& plan)

--- a/src/camp/mission_manager/mission_manager.h
+++ b/src/camp/mission_manager/mission_manager.h
@@ -3,7 +3,6 @@
 
 #include <QWidget>
 #include "ros/ros_widget.h"
-#include "marine_interfaces/msg/heartbeat.hpp"
 #include "marine_interfaces/msg/geo_occupancy_vector_map.hpp"
 #include "std_msgs/msg/string.hpp"
 
@@ -48,7 +47,6 @@ public slots:
 
 
 private slots:
-  void updateMissionStatus(QString const &status);
   void on_gotoLinePushButton_clicked(bool checked);
   void on_startLinePushButton_clicked(bool checked);
   void on_cancelOverridePushButton_clicked(bool checked);
@@ -56,14 +54,9 @@ private slots:
   void on_nextMissionItemPushButton_clicked(bool checked);
   void on_restartMissionPushButton_clicked(bool checked);
   void on_clearTasksPushButton_clicked(bool checked);
-  
-  void on_missionStatusTextBrowser_customContextMenuRequested(const QPoint &pos);
 
 private:
-  void missionStatusCallback(const marine_interfaces::msg::Heartbeat& message);
-
   Ui::MissionManager* m_ui;
-  rclcpp::Subscription<marine_interfaces::msg::Heartbeat>::SharedPtr mission_status_subscription_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr send_command_publisher_;
   rclcpp::Publisher<marine_interfaces::msg::GeoOccupancyVectorMap>::SharedPtr send_avoidance_costmap_publisher_;
 

--- a/src/camp/mission_manager/mission_manager.ui
+++ b/src/camp/mission_manager/mission_manager.ui
@@ -39,19 +39,6 @@
      </item>
     </layout>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/camp/mission_manager/mission_manager.ui
+++ b/src/camp/mission_manager/mission_manager.ui
@@ -15,19 +15,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTextBrowser" name="missionStatusTextBrowser">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QPushButton" name="cancelOverridePushButton">

--- a/src/camp/mission_manager/mission_manager.ui
+++ b/src/camp/mission_manager/mission_manager.ui
@@ -39,6 +39,19 @@
      </item>
     </layout>
    </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/camp/platform_manager/platform.cpp
+++ b/src/camp/platform_manager/platform.cpp
@@ -12,6 +12,12 @@ Platform::Platform(QWidget* parent, QGraphicsItem *parentItem):
   m_ui(new Ui::Platform)
 {
   m_ui->setupUi(this);
+  // Order: helm, running-task tree, mission command buttons. Give the tree all
+  // the vertical stretch so the helm panel and the (now header-less) button row
+  // stay at their natural, compact height instead of each taking a third.
+  m_ui->splitter->setStretchFactor(0, 0);  // helmManager
+  m_ui->splitter->setStretchFactor(1, 1);  // runningTasksView
+  m_ui->splitter->setStretchFactor(2, 0);  // missionManager (buttons)
   setAcceptHoverEvents(true);
   setZValue(6.0);
   connect(this, &Platform::pathUpdated, this, &Platform::updatePath, Qt::QueuedConnection);

--- a/src/camp/platform_manager/platform.ui
+++ b/src/camp/platform_manager/platform.ui
@@ -20,8 +20,8 @@
       <enum>Qt::Vertical</enum>
      </property>
      <widget class="HelmManager" name="helmManager" native="true"/>
-     <widget class="MissionManager" name="missionManager" native="true"/>
      <widget class="RunningTasksView" name="runningTasksView" native="true"/>
+     <widget class="MissionManager" name="missionManager" native="true"/>
     </widget>
    </item>
    <item>

--- a/src/camp/running_tasks/running_tasks_model.cpp
+++ b/src/camp/running_tasks/running_tasks_model.cpp
@@ -1,8 +1,11 @@
 #include "running_tasks/running_tasks_model.h"
 
+#include <algorithm>
+
 #include <QBrush>
 #include <QColor>
 #include <QFont>
+#include <QStringList>
 
 RunningTasksModel::RunningTasksModel(QObject* parent)
   : QAbstractItemModel(parent), root_(std::make_unique<Node>())
@@ -58,11 +61,11 @@ QVariant RunningTasksModel::data(const QModelIndex& index, int role) const
   if (!index.isValid())
     return QVariant();
   Node* n = nodeForIndex(index);
-  if (!n)
+  if (!n || !n->task)
     return QVariant();
 
-  const bool is_current = n->hasTask && !current_task_.isEmpty() &&
-                          n->fullId == current_task_;
+  const auto& msg = n->task->message();
+  const bool is_current = !current_task_.isEmpty() && n->fullId == current_task_;
 
   switch (role)
   {
@@ -72,16 +75,14 @@ QVariant RunningTasksModel::data(const QModelIndex& index, int role) const
         case Name:
           return n->segment;
         case Type:
-          return n->hasTask ? n->row.type : QVariant();
+          return QString::fromStdString(msg.type);
         case Priority:
-          return n->hasTask ? QVariant(n->row.priority) : QVariant();
+          return QVariant(msg.priority);
         case Status:
-          return n->hasTask ? n->row.status : QVariant();
+          // Status is a YAML blob; show its first line as a summary for now.
+          return QString::fromStdString(msg.status).section('\n', 0, 0).trimmed();
         case Done:
-          return n->hasTask
-                     ? QVariant(n->row.done ? QStringLiteral("done")
-                                            : QString())
-                     : QVariant();
+          return msg.done ? QStringLiteral("done") : QString();
         default:
           return QVariant();
       }
@@ -98,7 +99,7 @@ QVariant RunningTasksModel::data(const QModelIndex& index, int role) const
         return QBrush(QColor(0xDD, 0xEE, 0xFF));
       return QVariant();
     case Qt::ToolTipRole:
-      return n->hasTask ? n->fullId : QVariant();
+      return n->fullId;
     default:
       return QVariant();
   }
@@ -126,59 +127,63 @@ QVariant RunningTasksModel::headerData(int section, Qt::Orientation orientation,
   }
 }
 
-void RunningTasksModel::rebuild(const QVector<TaskRow>& rows)
+void RunningTasksModel::buildNodes(const marine_nav_tasks::TaskList& task_list,
+                                   Node* parent_node)
 {
-  root_ = std::make_unique<Node>();
-  for (const TaskRow& row : rows)
+  // Snapshot the domain task tree into display nodes, preserving the task list's
+  // (message / run) order. Done-to-bottom reordering happens afterwards.
+  for (const marine_nav_tasks::TaskPtr& task : task_list.tasks())
   {
-    const QStringList segments = row.id.split('/', Qt::SkipEmptyParts);
-    if (segments.isEmpty())
+    if (!task)
       continue;
-    Node* node = root_.get();
-    QString accumulated;
-    for (const QString& segment : segments)
-    {
-      accumulated = accumulated.isEmpty() ? segment
-                                          : accumulated + '/' + segment;
-      // Find an existing child for this segment, else create it.
-      Node* child = nullptr;
-      for (const std::unique_ptr<Node>& candidate : node->children)
-      {
-        if (candidate->segment == segment)
-        {
-          child = candidate.get();
-          break;
-        }
-      }
-      if (!child)
-      {
-        auto created = std::make_unique<Node>();
-        created->segment = segment;
-        created->fullId = accumulated;
-        created->parent = node;
-        created->rowInParent = static_cast<int>(node->children.size());
-        child = created.get();
-        node->children.push_back(std::move(created));
-      }
-      node = child;
-    }
-    // The leaf node for this id carries the task data. An intermediate node that
-    // is also an explicit task (both "survey_a" and "survey_a/line_1" present)
-    // gets its data filled here when its own row is processed.
-    node->row = row;
-    node->hasTask = true;
+    auto node = std::make_unique<Node>();
+    node->task = task;
+    node->fullId = QString::fromStdString(task->message().id);
+    const QStringList parts = node->fullId.split('/', Qt::SkipEmptyParts);
+    node->segment = parts.isEmpty() ? node->fullId : parts.last();
+    node->parent = parent_node;
+    node->rowInParent = static_cast<int>(parent_node->children.size());
+    Node* raw = node.get();
+    parent_node->children.push_back(std::move(node));
+    buildNodes(task->children(), raw);
   }
 }
 
-void RunningTasksModel::setTasks(const QString& current_task,
-                                 const QVector<TaskRow>& rows)
+void RunningTasksModel::sortChildrenRecursive(Node* node)
+{
+  // Float done tasks to the bottom at each level, preserving run order within
+  // each group (stable_sort), then re-index rowInParent so index()/parent()/
+  // indexForId stay consistent with the new order.
+  std::stable_sort(
+      node->children.begin(), node->children.end(),
+      [](const std::unique_ptr<Node>& a, const std::unique_ptr<Node>& b)
+      {
+        const bool a_done = a->task && a->task->message().done;
+        const bool b_done = b->task && b->task->message().done;
+        // not-done (false) sorts before done (true); equal keeps run order.
+        return a_done < b_done;
+      });
+  for (std::size_t i = 0; i < node->children.size(); ++i)
+  {
+    node->children[i]->rowInParent = static_cast<int>(i);
+    sortChildrenRecursive(node->children[i].get());
+  }
+}
+
+void RunningTasksModel::setTasks(
+    const QString& current_task,
+    const std::vector<marine_nav_interfaces::msg::TaskInformation>& tasks,
+    rclcpp::Clock::SharedPtr clock)
 {
   beginResetModel();
-  // Normalize the current-task id the same way node fullIds are built (split on
-  // '/', drop empty segments, re-join) so the highlight matches even if the id
-  // arrives with stray leading/trailing/double slashes.
+  // Normalize the current-task id the same way task ids are formed so the
+  // highlight matches even if it arrives with stray slashes.
   current_task_ = current_task.split('/', Qt::SkipEmptyParts).join('/');
-  rebuild(rows);
+  // TaskList owns the canonical hierarchy/order/done/data; we snapshot it.
+  task_list_.update(tasks, clock);
+  root_ = std::make_unique<Node>();
+  buildNodes(task_list_, root_.get());
+  sortChildrenRecursive(root_.get());
   endResetModel();
 }
 

--- a/src/camp/running_tasks/running_tasks_model.cpp
+++ b/src/camp/running_tasks/running_tasks_model.cpp
@@ -102,6 +102,11 @@ QVariant RunningTasksModel::data(const QModelIndex& index, int role) const
       if (is_current)
         return QBrush(QColor(0xDD, 0xEE, 0xFF));
       return QVariant();
+    case Qt::ForegroundRole:
+      // Grey out completed tasks (they also sink to the bottom of each level).
+      if (msg.done)
+        return QBrush(QColor(0x90, 0x90, 0x90));
+      return QVariant();
     case Qt::ToolTipRole:
       return n->fullId;
     default:

--- a/src/camp/running_tasks/running_tasks_model.cpp
+++ b/src/camp/running_tasks/running_tasks_model.cpp
@@ -160,17 +160,21 @@ void RunningTasksModel::buildNodes(const marine_nav_tasks::TaskList& task_list,
 
 void RunningTasksModel::sortChildrenRecursive(Node* node)
 {
-  // Float done tasks to the bottom at each level, preserving run order within
-  // each group (stable_sort), then re-index rowInParent so index()/parent()/
-  // indexForId stay consistent with the new order.
+  // Order each level by run order = priority ascending (lower number runs first,
+  // e.g. the priority-100 done_hover fallback sorts last), with done tasks sunk
+  // to the bottom of each group. stable_sort keeps message order for ties. Then
+  // re-index rowInParent so index()/parent()/indexForId stay consistent.
   std::stable_sort(
       node->children.begin(), node->children.end(),
       [](const std::unique_ptr<Node>& a, const std::unique_ptr<Node>& b)
       {
         const bool a_done = a->task && a->task->message().done;
         const bool b_done = b->task && b->task->message().done;
-        // not-done (false) sorts before done (true); equal keeps run order.
-        return a_done < b_done;
+        if (a_done != b_done)
+          return !a_done;  // not-done before done
+        const int a_pri = a->task ? a->task->message().priority : 0;
+        const int b_pri = b->task ? b->task->message().priority : 0;
+        return a_pri < b_pri;  // lower priority number runs first
       });
   for (std::size_t i = 0; i < node->children.size(); ++i)
   {

--- a/src/camp/running_tasks/running_tasks_model.cpp
+++ b/src/camp/running_tasks/running_tasks_model.cpp
@@ -65,7 +65,11 @@ QVariant RunningTasksModel::data(const QModelIndex& index, int role) const
     return QVariant();
 
   const auto& msg = n->task->message();
-  const bool is_current = !current_task_.isEmpty() && n->fullId == current_task_;
+  // current_task_ is already normalized (in setTasks); normalize fullId the same
+  // way for the comparison so the highlight matches regardless of stray slashes.
+  const bool is_current =
+      !current_task_.isEmpty() &&
+      n->fullId.split('/', Qt::SkipEmptyParts).join('/') == current_task_;
 
   switch (role)
   {

--- a/src/camp/running_tasks/running_tasks_model.h
+++ b/src/camp/running_tasks/running_tasks_model.h
@@ -1,29 +1,25 @@
 #ifndef CAMP_RUNNING_TASKS_MODEL_H
 #define CAMP_RUNNING_TASKS_MODEL_H
 
-#include <QAbstractItemModel>
-#include <QString>
-#include <QVector>
 #include <memory>
 #include <vector>
 
-/// A single task as displayed in the running-tasks tree. Populated from
-/// marine_nav_interfaces/TaskInformation on the GUI thread — the ROS message is
-/// converted to this Qt-friendly struct off the executor thread so the model
-/// never touches live ROS types.
-struct TaskRow
-{
-  QString id;       ///< full slash-delimited id, e.g. "survey_a/line_1"
-  QString type;     ///< task type, e.g. "survey_line"
-  int priority = 0;
-  QString status;   ///< status summary (first line of the status YAML)
-  bool done = false;
-};
+#include <QAbstractItemModel>
+#include <QString>
 
-/// Tree model over a flat TaskInformation list, keyed on the hierarchical id.
-/// "survey_a/line_1" becomes a child of "survey_a"; intermediate path segments
-/// with no explicit task get a synthetic group row. The task whose id equals the
-/// current navigation task is rendered bold + highlighted.
+#include "marine_nav_interfaces/msg/task_information.hpp"
+#include "marine_nav_tasks/task.h"
+#include "marine_nav_tasks/task_list.h"
+#include "rclcpp/rclcpp.hpp"
+
+/// Tree model over the boat's running task list. The hierarchy (slash-delimited
+/// ids), message ordering, add/remove, done handling and YAML parsing all come
+/// from marine_nav_tasks::TaskList / Task — the same model the boat uses — so the
+/// operator view stays consistent with the autonomy side. This class is a thin
+/// QAbstractItemModel adapter: it snapshots that domain tree into display nodes,
+/// floats done tasks to the bottom of each level, and highlights the current
+/// navigation task. Each display node keeps the marine_nav_tasks::TaskPtr it
+/// mirrors, so later phases (P2 map linkage) can read task poses/markers from it.
 class RunningTasksModel : public QAbstractItemModel
 {
   Q_OBJECT
@@ -43,8 +39,12 @@ public:
   QVariant headerData(int section, Qt::Orientation orientation,
                       int role = Qt::DisplayRole) const override;
 
-  /// Replace the whole tree from a fresh TaskFeedback snapshot.
-  void setTasks(const QString& current_task, const QVector<TaskRow>& rows);
+  /// Rebuild from a fresh TaskFeedback snapshot: the current navigation task id
+  /// plus the task list. `clock` is used by TaskList to stamp newly created tasks.
+  void setTasks(
+      const QString& current_task,
+      const std::vector<marine_nav_interfaces::msg::TaskInformation>& tasks,
+      rclcpp::Clock::SharedPtr clock);
 
   /// Full task id for an index (empty if invalid).
   QString idForIndex(const QModelIndex& index) const;
@@ -54,10 +54,9 @@ public:
 private:
   struct Node
   {
-    QString segment;          ///< this level's path segment (display name)
-    QString fullId;           ///< full path id ("" for the hidden root)
-    TaskRow row;              ///< task data; meaningful only when hasTask
-    bool hasTask = false;     ///< false for a synthesized intermediate group
+    marine_nav_tasks::TaskPtr task;  ///< domain task this row mirrors
+    QString segment;                 ///< last path component (display name)
+    QString fullId;                  ///< full task id
     Node* parent = nullptr;
     int rowInParent = 0;
     std::vector<std::unique_ptr<Node>> children;
@@ -65,8 +64,10 @@ private:
 
   Node* nodeForIndex(const QModelIndex& index) const;
   Node* findById(Node* node, const QString& id) const;
-  void rebuild(const QVector<TaskRow>& rows);
+  void buildNodes(const marine_nav_tasks::TaskList& task_list, Node* parent_node);
+  void sortChildrenRecursive(Node* node);
 
+  marine_nav_tasks::TaskList task_list_;
   std::unique_ptr<Node> root_;
   QString current_task_;
 };

--- a/src/camp/running_tasks/running_tasks_view.cpp
+++ b/src/camp/running_tasks/running_tasks_view.cpp
@@ -3,7 +3,9 @@
 #include <QHeaderView>
 #include <QItemSelectionModel>
 #include <QMetaObject>
+#include <QPalette>
 #include <QSignalBlocker>
+#include <QTimer>
 #include <QTreeView>
 #include <QVBoxLayout>
 
@@ -12,7 +14,10 @@
 RunningTasksView::RunningTasksView(QWidget* parent)
   : QWidget(parent),
     tree_(new QTreeView(this)),
-    model_(new RunningTasksModel(this))
+    model_(new RunningTasksModel(this)),
+    watchdog_timer_(new QTimer(this)),
+    max_green_duration_(2, 0),
+    max_yellow_duration_(5, 0)
 {
   tree_->setModel(model_);
   tree_->setRootIsDecorated(true);
@@ -22,11 +27,15 @@ RunningTasksView::RunningTasksView(QWidget* parent)
   tree_->header()->setStretchLastSection(true);
 
   auto* layout = new QVBoxLayout(this);
-  layout->setContentsMargins(0, 0, 0, 0);
+  // A small margin lets the staleness window color show as a frame around the
+  // tree (the tree viewport paints its own background over the rest).
+  layout->setContentsMargins(3, 3, 3, 3);
   layout->addWidget(tree_);
 
   connect(tree_->selectionModel(), &QItemSelectionModel::currentRowChanged,
           this, &RunningTasksView::onCurrentRowChanged);
+  connect(watchdog_timer_, &QTimer::timeout, this,
+          &RunningTasksView::watchdogUpdate);
 }
 
 RunningTasksView::~RunningTasksView()
@@ -43,6 +52,10 @@ void RunningTasksView::setNode(rclcpp::Node::SharedPtr node)
 {
   node_ = node;
   subscribe();
+  // The staleness watchdog needs the node clock; start it once we have a node
+  // (mirrors HelmManager, which starts its 500 ms watchdog after setNode).
+  if (node_ && !watchdog_timer_->isActive())
+    watchdog_timer_->start(500);
 }
 
 void RunningTasksView::updateRobotNamespace(QString robot_namespace)
@@ -81,27 +94,12 @@ void RunningTasksView::subscribe()
 void RunningTasksView::taskFeedbackCallback(
     const marine_nav_interfaces::msg::TaskFeedback& msg)
 {
-  // Runs on the ROS executor thread — convert to Qt-friendly rows here and
-  // hand off to the GUI thread; never touch widgets from this thread.
-  QVector<TaskRow> rows;
-  rows.reserve(static_cast<int>(msg.tasks.size()));
-  for (const auto& task : msg.tasks)
-  {
-    TaskRow row;
-    row.id = QString::fromStdString(task.id);
-    row.type = QString::fromStdString(task.type);
-    row.priority = task.priority;
-    // Status is a YAML blob; show its first line as a summary for P1.
-    row.status =
-        QString::fromStdString(task.status).section('\n', 0, 0).trimmed();
-    row.done = task.done;
-    rows.push_back(row);
-  }
-
+  // Runs on the ROS executor thread — stash the raw snapshot and hand off to the
+  // GUI thread; never touch widgets (or the model's TaskList) from this thread.
   {
     std::lock_guard<std::mutex> lock(pending_mutex_);
     pending_current_ = QString::fromStdString(msg.current_navigation_task);
-    pending_rows_ = rows;
+    pending_tasks_ = msg.tasks;
   }
   QMetaObject::invokeMethod(this, "applyPendingTasks", Qt::QueuedConnection);
 }
@@ -109,17 +107,28 @@ void RunningTasksView::taskFeedbackCallback(
 void RunningTasksView::applyPendingTasks()
 {
   QString current;
-  QVector<TaskRow> rows;
+  std::vector<marine_nav_interfaces::msg::TaskInformation> tasks;
   {
     std::lock_guard<std::mutex> lock(pending_mutex_);
     current = pending_current_;
-    rows = pending_rows_;
+    tasks = pending_tasks_;
+  }
+
+  // Record receipt for the staleness watchdog (TaskFeedback has no header, so
+  // staleness is measured from receive time).
+  if (node_)
+  {
+    last_message_time_ = node_->get_clock()->now();
+    has_message_ = true;
   }
 
   // Preserve the selected task across the model reset.
   const QString selected = model_->idForIndex(tree_->currentIndex());
 
-  model_->setTasks(current, rows);
+  // TaskList needs a clock to stamp newly created tasks; node_ is always set by
+  // the time feedback arrives (a subscription requires it).
+  model_->setTasks(current, tasks,
+                   node_ ? node_->get_clock() : rclcpp::Clock::make_shared());
   tree_->expandAll();
 
   if (!selected.isEmpty())
@@ -149,4 +158,24 @@ void RunningTasksView::setSelectedTask(QString id)
   const QModelIndex index = model_->indexForId(id);
   if (index.isValid())
     tree_->setCurrentIndex(index);
+}
+
+void RunningTasksView::watchdogUpdate()
+{
+  // Only color once messages have started arriving (matches HelmManager, which
+  // gates on a non-zero last-heartbeat timestamp). Before then, leave the
+  // default (un-filled) background.
+  if (!node_ || !has_message_)
+    return;
+
+  const auto age = node_->get_clock()->now() - last_message_time_;
+  QPalette pal = palette();
+  if (age < max_green_duration_)
+    pal.setColor(QPalette::Window, Qt::green);
+  else if (age < max_yellow_duration_)
+    pal.setColor(QPalette::Window, Qt::yellow);
+  else
+    pal.setColor(QPalette::Window, Qt::red);
+  setAutoFillBackground(true);
+  setPalette(pal);
 }

--- a/src/camp/running_tasks/running_tasks_view.cpp
+++ b/src/camp/running_tasks/running_tasks_view.cpp
@@ -26,6 +26,10 @@ RunningTasksView::RunningTasksView(QWidget* parent)
   tree_->setEditTriggers(QAbstractItemView::NoEditTriggers);
   tree_->header()->setStretchLastSection(true);
 
+  // The task tree is the primary pane; claim vertical space so it grows when the
+  // panel is stretched instead of the helm status / button row absorbing it.
+  setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
+
   auto* layout = new QVBoxLayout(this);
   // A small margin lets the staleness window color show as a frame around the
   // tree (the tree viewport paints its own background over the rest).

--- a/src/camp/running_tasks/running_tasks_view.cpp
+++ b/src/camp/running_tasks/running_tasks_view.cpp
@@ -41,7 +41,7 @@ RunningTasksView::RunningTasksView(QWidget* parent)
 RunningTasksView::~RunningTasksView()
 {
   // Stop new callback dispatch before the members the callback touches
-  // (pending_mutex_, pending_rows_) are torn down — they are declared after
+  // (pending_mutex_, pending_tasks_) are torn down — they are declared after
   // subscription_ and so are destroyed first under reverse-order destruction.
   // (Full safety on shutdown also relies on the CAMP executor being stopped
   // before these widgets are destroyed; this guards the local ordering.)

--- a/src/camp/running_tasks/running_tasks_view.h
+++ b/src/camp/running_tasks/running_tasks_view.h
@@ -3,13 +3,15 @@
 
 #include <QWidget>
 #include <QString>
-#include <QVector>
 #include <mutex>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "marine_nav_interfaces/msg/task_feedback.hpp"
+#include "marine_nav_interfaces/msg/task_information.hpp"
 #include "running_tasks/running_tasks_model.h"
 
+class QTimer;
 class QTreeView;
 
 /// Read-only structured running-task view. Node-injection widget (the
@@ -41,6 +43,9 @@ private slots:
   void applyPendingTasks();
   void onCurrentRowChanged(const QModelIndex& current,
                            const QModelIndex& previous);
+  /// Periodic staleness check — colors the background green/yellow/red by the
+  /// age of the last received TaskFeedback (mirrors HelmManager's watchdog).
+  void watchdogUpdate();
 
 private:
   void subscribe();
@@ -56,7 +61,14 @@ private:
 
   std::mutex pending_mutex_;
   QString pending_current_;
-  QVector<TaskRow> pending_rows_;
+  std::vector<marine_nav_interfaces::msg::TaskInformation> pending_tasks_;
+
+  // Message-staleness watchdog (green < max_green_ < yellow < max_yellow_ < red).
+  QTimer* watchdog_timer_;
+  rclcpp::Time last_message_time_;
+  bool has_message_ = false;
+  rclcpp::Duration max_green_duration_;
+  rclcpp::Duration max_yellow_duration_;
 };
 
 #endif  // CAMP_RUNNING_TASKS_VIEW_H


### PR DESCRIPTION
Closes #130

## Summary

Polish for the running-task view (#127) after first sim testing, **plus** a
refactor to reuse the boat's own task model. Three behaviors + one architecture
change, all in `camp`.

## Architecture: adopt `marine_nav_tasks::TaskList`

`RunningTasksModel` was hand-rolling id-hierarchy parsing, ordering and done
handling. It now wraps a **`marine_nav_tasks::TaskList`** — the same model the
boat's mission_manager uses. `setTasks()` calls `TaskList::update(tasks, clock)`
(which builds the tree from the flat list, preserves message/run order, and
handles add/remove/reorder/done), then snapshots the `Task` tree into display
nodes. Each node keeps its `marine_nav_tasks::TaskPtr`, so P2 map linkage (#129)
can read task poses/markers straight off it. One source of truth for the task
model; `camp` gains a `marine_nav_tasks` dependency (ui→core).

A consequence: `TaskList` doesn't synthesize missing parent tasks, so there are
**no synthetic group rows** — we render exactly the domain tree (this also
resolves the P1 carry-over about synthetic-group selection).

## 1. Order by run order, done tasks to the bottom

Run order comes from `TaskList` (message order). On top of that, each tree level
is stable-sorted so not-done tasks stay in run order at the top and **done tasks
sink to the bottom**; `rowInParent` is re-indexed to keep the Qt model consistent.

## 2. Message-staleness background (like HelmManager)

A 500 ms watchdog colors the widget background **green (<2 s) / yellow (<5 s) /
red** by the age of the last received `TaskFeedback`, **once messages start
arriving** (mirrors HelmManager's gate). Since `TaskFeedback` has no header,
staleness is measured from receive time. A small contents margin frames the tree.

## 3. Retire the Heartbeat text display in `MissionManager`

The structured view now shows status, so `MissionManager` becomes a command panel:
removed the `missionStatusTextBrowser`, its context menu, and the
`Heartbeat` subscription/callbacks. **Kept** Cancel Override / Clear / Restart and
all command paths used by `projectview` / `autonomousvehicleproject`.

## Testing

`colcon build` of `camp` clean (full + incremental), no new warnings from changed
files. Pre-push review (Standard, 2 lenses): model index/parent/`rowInParent`
consistency after the sort, `TaskPtr` lifetime, reset bracketing, and threading
all walked clean — **0 must-fix**. Two suggestions fixed (normalized the
current-task highlight compare; corrected a stale comment).

## Flagged for you (not changed here)

- **"Next Mission Item" was context-menu-only** and is now unreachable from the UI
  after removing the text browser. Want me to add a **Next** button to the
  MissionManager button row? (Its slot `on_nextMissionItemPushButton_clicked`
  already exists.)
- Pre-existing: `MissionManager` has orphan auto-connect slots
  (`on_gotoLine/startLine/nextMissionItemPushButton_clicked`) for widgets not in
  the `.ui`, which emit Qt "No matching signal" warnings. Out of scope here; easy
  cleanup if wanted.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
