### PR TITLE
Fix CAMP sim lockup: non-blocking TF lookup in running-task overlay

### DIFF
--- a/src/camp/ros/ros_widget.cpp
+++ b/src/camp/ros/ros_widget.cpp
@@ -11,7 +11,7 @@ ROSWidget::ROSWidget(QWidget *parent)
 
 }
 
-QGeoCoordinate ROSWidget::getGeoCoordinate(const geometry_msgs::msg::Pose &pose, const std_msgs::msg::Header &header)
+QGeoCoordinate ROSWidget::getGeoCoordinate(const geometry_msgs::msg::Pose &pose, const std_msgs::msg::Header &header, double timeout_sec)
 {
     if(header.frame_id.empty())
       return {};
@@ -23,7 +23,7 @@ QGeoCoordinate ROSWidget::getGeoCoordinate(const geometry_msgs::msg::Pose &pose,
     geometry_msgs::msg::PoseStamped ecef;
     try
     {
-      ecef = transform_buffer_->transform(ps, "earth", tf2::durationFromSec(1.5));
+      ecef = transform_buffer_->transform(ps, "earth", tf2::durationFromSec(timeout_sec));
     }
     catch (const tf2::TransformException &)
     {
@@ -37,7 +37,7 @@ QGeoCoordinate ROSWidget::getGeoCoordinate(const geometry_msgs::msg::Pose &pose,
       {
         ps.header.stamp.sec = 0;
         ps.header.stamp.nanosec = 0;
-        ecef = transform_buffer_->transform(ps, "earth", tf2::durationFromSec(1.5));
+        ecef = transform_buffer_->transform(ps, "earth", tf2::durationFromSec(timeout_sec));
       }
       catch (const tf2::TransformException &ex)
       {

--- a/src/camp/ros/ros_widget.h
+++ b/src/camp/ros/ros_widget.h
@@ -15,7 +15,11 @@ public:
   ROSWidget(QWidget *parent = nullptr);
 
 protected:
-  QGeoCoordinate getGeoCoordinate(const geometry_msgs::msg::Pose &pose, const std_msgs::msg::Header &header);
+  // timeout_sec bounds the TF wait. The default keeps the original blocking
+  // behaviour for existing callers; pass 0.0 for a non-blocking lookup (e.g. on
+  // the GUI thread in a per-frame loop, where a 1.5 s block per pose freezes the
+  // UI — see camp#136).
+  QGeoCoordinate getGeoCoordinate(const geometry_msgs::msg::Pose &pose, const std_msgs::msg::Header &header, double timeout_sec = 1.5);
 
 
 };

--- a/src/camp/running_tasks/running_tasks_overlay.cpp
+++ b/src/camp/running_tasks/running_tasks_overlay.cpp
@@ -72,10 +72,15 @@ void RunningTasksOverlay::rebuildItems(
     // TaskInformation.poses is geometry_msgs/PoseStamped[] with per-pose headers.
     // getGeoCoordinate transforms each to earth frame with stale-stamp retry,
     // so the source frame (commonly map or earth) is handled transparently.
+    // Use a NON-BLOCKING lookup (0 s timeout): this runs on the GUI thread on
+    // every TaskFeedback rebuild, and the default 1.5 s blocking wait per pose
+    // freezes the whole UI when map->earth isn't yet available (camp#136). A
+    // pose that isn't transformable this cycle is simply skipped and reappears
+    // on the next rebuild once the (quasi-static) transform is available.
     QList<QGeoCoordinate> geo_poses;
     for (const auto& ps : task.poses)
     {
-      QGeoCoordinate gc = getGeoCoordinate(ps.pose, ps.header);
+      QGeoCoordinate gc = getGeoCoordinate(ps.pose, ps.header, 0.0);
       if (gc.isValid())
         geo_poses.append(gc);
     }


### PR DESCRIPTION
Closes #136

## Summary

Fixes the CAMP sim lockup introduced by the P2 running-task overlay (#129 / PR #135).

`RunningTasksOverlay::rebuildItems` called `ROSWidget::getGeoCoordinate` per task
pose **on the GUI thread**, every `TaskFeedback` (~1 Hz+). `getGeoCoordinate` does
a **blocking** `transform(..., "earth", durationFromSec(1.5))` with a second 1.5 s
retry in its catch. When `map→earth` isn't immediately available, each pose blocks
the UI thread up to ~3 s × N poses × every cycle → CAMP freezes.

## Fix

`getGeoCoordinate` gains an optional `timeout_sec` (default `1.5`, so existing
callers are unchanged); the overlay passes `0.0` for a non-blocking lookup. A pose
that isn't transformable this cycle is skipped and reappears next rebuild once the
quasi-static `map→earth` transform is available. A blocking TF lookup on the GUI
thread is never acceptable.

## Testing

`colcon build` clean; **130 tests, 0 failures**. The map overlay still renders once
the transform is available; the UI no longer blocks when it isn't.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
