### PR TITLE
Visible-region render at the raster seam — crisp zoomed-in large stores (Part of #103)

### DIFF
--- a/.agent/work-plans/issue-103/plan.md
+++ b/.agent/work-plans/issue-103/plan.md
@@ -46,16 +46,26 @@ clip_scene.setTop   (scene_bounds_.bottom() - clip_local.bottom());// south
 ### Step-by-step
 
 1. **`GggsTileLayer::paint()`** — compute exposed clip rect and use it:
-   - `clip_local = option->exposedRect.intersected(boundingRect())`; fall back
-     to `boundingRect()` if empty (defensive).
+   - `clip_local = painter->clipBoundingRect().intersected(boundingRect())`;
+     fall back to `boundingRect()` if empty (defensive).  NOT
+     `option->exposedRect`: that defaults to `boundingRect()` unless
+     `QGraphicsItem::ItemUsesExtendedStyleOption` is set (set nowhere in camp),
+     which would make the whole fix a silent no-op.
+     `painter->clipBoundingRect()` reflects the view's actual exposed region
+     with no flag dependency (plan-review must-fix 1).
    - Convert `clip_local` → `clip_scene` (scene Web-Mercator metres) using the
      formula above.
    - FBO size: `mapRect(clip_local)` instead of `mapRect(boundingRect())`; clamp
      to `kMaxImageEdge` (unchanged — the clamp now applies to the viewport, not
      the whole extent, so it is rarely hit).
    - Cache key: `size != cached_size_ || clip_scene != cached_clip_` — add
-     `QRectF cached_clip_` member.
-   - Render: `renderImage(size, clip_scene)` (new internal overload).
+     `QRectF cached_clip_` member.  **Behavior change (accepted):** a pan now
+     changes `clip_scene` every frame, so pan re-renders instead of reusing the
+     cached image via the world transform as today.  Cheap for a viewport-sized
+     FBO and required for correctness; the inherited "pan reuses the cached
+     image" comment is now stale and must be updated in the same edit
+     (plan-review suggestion 2).
+   - Render: `renderImage(size, clip_scene)` (new overload).
    - Draw: `painter->drawImage(clip_local, cached_image_)` (was `boundingRect()`).
 
 2. **`GggsTileLayer::renderImage(size, clip_bounds)`** — clip-aware overload:
@@ -66,6 +76,9 @@ clip_scene.setTop   (scene_bounds_.bottom() - clip_local.bottom());// south
      `scene_bounds`, not `scene_bounds_`).
    - Keep the existing public `renderImage(const QSize& size)` (used by headless
      tests) as a delegate to `renderImage(size, scene_bounds_)`.
+   - The clip overload is **public**, mirroring the existing public
+     `renderImage(size)` — the headless clip-filter test calls it directly
+     (plan-review must-fix 3).
 
 3. **`GggsTileLayer`** — add member: `QRectF cached_clip_;` (after `cached_size_`).
    Invalidate `cached_image_` when `cached_clip_` changes (mirror the size check).
@@ -77,32 +90,48 @@ clip_scene.setTop   (scene_bounds_.bottom() - clip_local.bottom());// south
 
 5. **`SonarLiveCacheLayer::paint()` + `renderImage()`** — same pattern; filter
    live-cache Entries by their scene-space extents intersecting `clip_scene`.
-   Add `QRectF cached_clip_` member.
+   Add `QRectF cached_clip_` member.  **Ordering constraint:** `items()` appends
+   overview tiles first, then fine tiles (the ADR-0010 LOD fallback,
+   `sonar_live_cache_layer.cpp:855-863`).  The clip filter must filter **both**
+   pools while preserving that overviews-first order, so a clipped region whose
+   fine tiles are evicted still draws its overview fallback instead of a blank
+   gap (plan-review suggestion 3).
 
 6. **New camp ADR-0011** — document the viewport-clip calling convention at the
    RasterGlRenderer seam: callers pass the visible sub-rect of `scene_bounds_`
    as the `scene_bounds` argument to `renderToImage()`, sized to the viewport,
    so the FBO covers only what the user sees.  Cross-references ADR-0007.
 
-7. **Tests** — add a `test_gggs_tile_layer.cpp` test (or extend
-   `test_raster_gl_renderer.cpp`) that:
+7. **Tests** — extend the already-registered `test/test_gggs_render.cpp`
+   (its synthetic-store + `renderImage()` seam matches exactly; avoids a new
+   `ament_add_gtest` CMake block — plan-review must-fix 2):
    - Creates a two-tile GGGS store where tiles A and B are geographically adjacent.
    - Calls `renderImage(size, clip_A)` — only tile A should contribute pixels.
    - Asserts tile B's region is transparent/absent in the result.
+   - **Resolution assertion** (plan-review suggestion 1): render the same clip
+     at viewport-sized FBO and assert the per-pixel density is that of the clip,
+     not the full extent (e.g. a 1-px feature in tile A spans ≥ the expected
+     pixel count when clipped vs. blurred full-extent render).
    Keep existing tests passing; `renderImage(size)` (full-extent) is unchanged.
+   **Caveat (plan-review suggestion 1):** the headless test exercises the
+   clip-filter seam, not `paint()`'s `clipBoundingRect()` derivation — the part
+   that closes the field bug.  That derivation gets (a) the
+   `test_gggs_render.cpp` `/tmp/*.png` visual-inspection extension and (b) a
+   manual GUI verification note in the PR (open a large store, zoom in, confirm
+   crisp render).
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `src/camp_map/raster/gggs_tile_layer.h` | Add `QRectF cached_clip_`; add `QImage renderImage(const QSize&, const QRectF&)` private overload |
-| `src/camp_map/raster/gggs_tile_layer.cpp` | Update `paint()` for clip-derived FBO; implement clip-filtered `renderImage(size, clip)` |
+| `src/camp_map/raster/gggs_tile_layer.h` | Add `QRectF cached_clip_`; add `QImage renderImage(const QSize&, const QRectF&)` **public** overload |
+| `src/camp_map/raster/gggs_tile_layer.cpp` | Update `paint()` for clip-derived FBO (via `painter->clipBoundingRect()`); implement clip-filtered `renderImage(size, clip)`; update stale pan-cache comment |
 | `src/camp_map/raster/raster_layer.h` | Add `QRectF cached_clip_` |
 | `src/camp_map/raster/raster_layer.cpp` | Update `paint()` for clip-derived FBO; update `renderImage()` to accept optional clip |
 | `src/camp_map/ros/live_coverage/sonar_live_cache_layer.h` | Add `QRectF cached_clip_`; update `renderImage()` signature |
-| `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp` | Update `paint()` for clip-derived FBO; filter entries by clip |
+| `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp` | Update `paint()` for clip-derived FBO; filter both tile pools by clip, preserving overviews-first order |
 | `docs/decisions/0011-viewport-clip-render-convention.md` | New camp ADR-0011 |
-| `test/test_gggs_tile_layer.cpp` | New test for clip-filtered render (or add to test_raster_gl_renderer.cpp) |
+| `test/test_gggs_render.cpp` | Extend with clip-filter + resolution tests (already registered in CMake — no CMakeLists change needed) |
 
 ## Principles Self-Check
 
@@ -136,11 +165,14 @@ clip_scene.setTop   (scene_bounds_.bottom() - clip_local.bottom());// south
 
 ## Open Questions
 
-- [ ] `option->exposedRect` under Qt's BSP update scheme may equal `boundingRect()`
-  for large layers even when only part is visible — should we add a viewport-rect
-  fallback via `painter->clipBoundingRect()`?  Likely no: the `mapRect(clip_local)`
-  FBO sizing still corrects the resolution; the tile filter still works; even if we
-  render the full extent it's at the right pixel density.
+- [x] ~~`option->exposedRect` vs `painter->clipBoundingRect()`~~ — RESOLVED by
+  plan review (must-fix 1): `option->exposedRect` defaults to `boundingRect()`
+  without `ItemUsesExtendedStyleOption` (set nowhere in camp), and with
+  `clip_local == boundingRect()` the `mapRect(clip_local)` FBO sizing reproduces
+  today's buggy full-extent sizing — the original "likely no" reasoning was
+  wrong.  The plan now derives the viewport via
+  `painter->clipBoundingRect().intersected(boundingRect())` (no flag
+  dependency).
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-103/plan.md
+++ b/.agent/work-plans/issue-103/plan.md
@@ -1,0 +1,148 @@
+# Plan: Visible-region render for GggsTileLayer (issue #103 — visible-region half)
+
+## Issue
+
+https://github.com/rolker/camp/issues/103
+
+## Context
+
+`GggsTileLayer`, `RasterLayer`, and `SonarLiveCacheLayer` all share the same
+`paint()` pattern: compute the on-screen pixel size of the **whole layer extent**
+(`mapRect(boundingRect())`), clamp to 4096 px, render all tiles into a single
+FBO of that size, and draw the result over `boundingRect()`.  At high zoom this
+is catastrophically wrong: the visible viewport covers a small fraction of the
+total extent, so each visible pixel is backed by only a fraction of a pixel in
+the 4096-px image → blurry.  Confirmed field-observed (Roland, 2026-07-23).
+
+The fix is to size the FBO to the **viewport** (visible portion of the item),
+pass that clip rect as `scene_bounds` to `renderToImage()`, and draw the result
+over just the exposed portion.  The seam (`RasterFieldSource` / `RasterGlRenderer`,
+camp ADR-0007) already supports this — `renderToImage()` takes a `scene_bounds`
+QRectF that drives the MVP; we just need to pass the clip rect instead of the
+full extent.  No change to `RasterGlRenderer`'s API is required.
+
+The LOD/pyramid half of #103 is explicitly deferred — it depends on
+unh_marine_autonomy#188 and a shared pyramid library.  The PR will be
+"Part of #103", not "Closes #103".
+
+## Approach
+
+### Coordinate-system note
+
+`scene_bounds_` in each layer is a QRectF in Web-Mercator metres where Qt
+convention applies (top() < bottom()). Because the scene y-axis increases
+northward, top() = southern edge (min y) and bottom() = northern edge (max y).
+The item transform `fromScale(1, -1)` makes item-local y increase southward
+(y=0 at the north edge).  The conversion from item-local `QRectF clip_local`
+to scene `QRectF clip_scene` is:
+
+```
+clip_scene.setLeft(scene_bounds_.left() + clip_local.left());
+clip_scene.setRight(scene_bounds_.left() + clip_local.right());
+clip_scene.setBottom(scene_bounds_.bottom() - clip_local.top());   // north
+clip_scene.setTop   (scene_bounds_.bottom() - clip_local.bottom());// south
+```
+
+### Step-by-step
+
+1. **`GggsTileLayer::paint()`** — compute exposed clip rect and use it:
+   - `clip_local = option->exposedRect.intersected(boundingRect())`; fall back
+     to `boundingRect()` if empty (defensive).
+   - Convert `clip_local` → `clip_scene` (scene Web-Mercator metres) using the
+     formula above.
+   - FBO size: `mapRect(clip_local)` instead of `mapRect(boundingRect())`; clamp
+     to `kMaxImageEdge` (unchanged — the clamp now applies to the viewport, not
+     the whole extent, so it is rarely hit).
+   - Cache key: `size != cached_size_ || clip_scene != cached_clip_` — add
+     `QRectF cached_clip_` member.
+   - Render: `renderImage(size, clip_scene)` (new internal overload).
+   - Draw: `painter->drawImage(clip_local, cached_image_)` (was `boundingRect()`).
+
+2. **`GggsTileLayer::renderImage(size, clip_bounds)`** — clip-aware overload:
+   - Filter tiles to those whose scene-space extent (pre-computed via
+     `geoToMap(minLat, minLon)` / `geoToMap(maxLat, maxLon)`) intersects
+     `clip_bounds`.  Build the `QList<RasterFieldItem>` from the filtered set only.
+   - Call `renderer_.renderToImage(draw, clip_bounds, ...)` (pass `clip_bounds` as
+     `scene_bounds`, not `scene_bounds_`).
+   - Keep the existing public `renderImage(const QSize& size)` (used by headless
+     tests) as a delegate to `renderImage(size, scene_bounds_)`.
+
+3. **`GggsTileLayer`** — add member: `QRectF cached_clip_;` (after `cached_size_`).
+   Invalidate `cached_image_` when `cached_clip_` changes (mirror the size check).
+
+4. **`RasterLayer::paint()`** — same clip derivation, FBO sizing, cache key,
+   drawImage.  No tile filtering (single-texture layer); `renderImage()` can
+   accept the clip bounds and pass them straight to `renderToImage()`.
+   Add `QRectF cached_clip_` member.
+
+5. **`SonarLiveCacheLayer::paint()` + `renderImage()`** — same pattern; filter
+   live-cache Entries by their scene-space extents intersecting `clip_scene`.
+   Add `QRectF cached_clip_` member.
+
+6. **New camp ADR-0011** — document the viewport-clip calling convention at the
+   RasterGlRenderer seam: callers pass the visible sub-rect of `scene_bounds_`
+   as the `scene_bounds` argument to `renderToImage()`, sized to the viewport,
+   so the FBO covers only what the user sees.  Cross-references ADR-0007.
+
+7. **Tests** — add a `test_gggs_tile_layer.cpp` test (or extend
+   `test_raster_gl_renderer.cpp`) that:
+   - Creates a two-tile GGGS store where tiles A and B are geographically adjacent.
+   - Calls `renderImage(size, clip_A)` — only tile A should contribute pixels.
+   - Asserts tile B's region is transparent/absent in the result.
+   Keep existing tests passing; `renderImage(size)` (full-extent) is unchanged.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/camp_map/raster/gggs_tile_layer.h` | Add `QRectF cached_clip_`; add `QImage renderImage(const QSize&, const QRectF&)` private overload |
+| `src/camp_map/raster/gggs_tile_layer.cpp` | Update `paint()` for clip-derived FBO; implement clip-filtered `renderImage(size, clip)` |
+| `src/camp_map/raster/raster_layer.h` | Add `QRectF cached_clip_` |
+| `src/camp_map/raster/raster_layer.cpp` | Update `paint()` for clip-derived FBO; update `renderImage()` to accept optional clip |
+| `src/camp_map/ros/live_coverage/sonar_live_cache_layer.h` | Add `QRectF cached_clip_`; update `renderImage()` signature |
+| `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp` | Update `paint()` for clip-derived FBO; filter entries by clip |
+| `docs/decisions/0011-viewport-clip-render-convention.md` | New camp ADR-0011 |
+| `test/test_gggs_tile_layer.cpp` | New test for clip-filtered render (or add to test_raster_gl_renderer.cpp) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Renders exactly what the operator sees; crisp vs. blurry is immediately visible |
+| Only what's needed | No texture-cache eviction, no LOD machinery — just clip the FBO and filter items; those are the deferred LOD half |
+| A change includes its consequences | All three seam callers updated in one PR; ADR-0011 captures the convention; existing tests preserved |
+| Improve incrementally | Visible-region render alone closes the confirmed blur regression; good boundary |
+| Test what breaks | New headless test verifying tile filtering by clip rect |
+| Capture decisions, not just implementations | ADR-0011 records the viewport-clip calling convention at the seam |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| camp ADR-0007 (RasterFieldSource seam) | Yes | Fix at the seam: change what `scene_bounds` we pass to `renderToImage()`, no API change to the renderer itself |
+| camp ADR-0010 (bounded eviction / overview pyramid) | Noted | No eviction machinery added; the clip filtering does not interfere with `SonarLiveCacheLayer`'s eviction logic (entries not in the clip are simply not rendered, not evicted) |
+| workspace ADR-0001 (capture decisions) | Yes | New camp ADR-0011 records the viewport-clip convention |
+| workspace ADR-0002 (worktree isolation) | Yes | Working in the existing issue-103 worktree |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `renderToImage()` calling convention (what we pass as `scene_bounds`) | All three layer `renderImage()` / `paint()` call sites | Yes — all three in this PR |
+| Cache key for each layer | `cached_clip_` member added to each | Yes |
+| camp ADR-0007 calling convention | New camp ADR-0011 cross-reference addendum | Yes |
+| `GggsTileLayer::renderImage(size)` public API | Tests that call it headlessly | Preserved — public overload delegates to clip variant with full `scene_bounds_` |
+| camp#172 (on-demand reload of evicted tiles) | This PR's visible-region paint loop is the natural trigger site for camp#172's reload | Not in scope — design leaves the paint loop open for camp#172 to add a reload call |
+
+## Open Questions
+
+- [ ] `option->exposedRect` under Qt's BSP update scheme may equal `boundingRect()`
+  for large layers even when only part is visible — should we add a viewport-rect
+  fallback via `painter->clipBoundingRect()`?  Likely no: the `mapRect(clip_local)`
+  FBO sizing still corrects the resolution; the tile filter still works; even if we
+  render the full extent it's at the right pixel density.
+
+## Estimated Scope
+
+Single PR ("Part of #103"). Touches three `.cpp`/`.h` pairs plus one new ADR and
+one new test file. ~200–300 lines of implementation change.

--- a/.agent/work-plans/issue-103/progress.md
+++ b/.agent/work-plans/issue-103/progress.md
@@ -86,3 +86,15 @@ are related but explicitly out of scope. The design must not make them harder to
 - [ ] Note in the PR that camp#172 (on-demand reload of evicted tiles) is the natural
   next step enabled by a visible-region render loop; ensure the implementation doesn't
   foreclose it
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-24 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-103/plan.md` at `83d9945`
+**Branch**: feature/issue-103 at `83d9945`
+**Phases**: single
+
+### Open questions
+- [ ] `option->exposedRect` under Qt's BSP update scheme may equal `boundingRect()` for large layers even when only part is visible — should we add a viewport-rect fallback via `painter->clipBoundingRect()`?

--- a/.agent/work-plans/issue-103/progress.md
+++ b/.agent/work-plans/issue-103/progress.md
@@ -127,3 +127,26 @@ the fix a silent no-op, plus two small mechanical must-fixes.
 - The three seam callers (GggsTileLayer / RasterLayer / SonarLiveCacheLayer) are correctly identified and all share the same `paint()` → `renderImage(size)` → `renderToImage(draw, scene_bounds_, …)` shape, so the change is uniform. Matches the Issue Review's "cover all three callers" recommendation.
 - ADR-0011 is the correct next number (0001–0010 present; 0004 already absent). No `RasterGlRenderer` API change is required — confirmed.
 - ROS conventions: N/A (Qt/GL offscreen rendering, no topics/QoS/params).
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-24 15:26 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-103 at `db8d2d7`
+**Mode**: pre-push
+**Depth**: Deep (reason: ADR addition — docs/decisions/0011; 3-layer seam change)
+**Must-fix**: 0 | **Suggestions**: 3
+**Round**: 1 | **Ship**: recommended — no must-fix; coordinate math verified by 2 adversarial passes + lead, all 3 plan-review must-fixes resolved
+
+### Findings
+- [ ] (suggestion) Headless tests call renderImage(size,clip) directly; paint()'s clipBoundingRect() clip (the field-bug path) needs manual GUI verification on a >4096px store before merge — `gggs_tile_layer.cpp:472` / `viewport_clip.h`
+- [ ] (suggestion) Per-frame geoToMap trig in itemsIntersecting on GUI thread during pan (O(tiles)); cache tile scene-rect at load for large stores — `gggs_tile_layer.cpp:404` · `sonar_live_cache_layer.cpp:848`
+- [ ] (suggestion) cached_clip_ float-equality key relies on view-transform determinism for the "cheap idle" claim; add a one-line comment noting it — `viewport_clip.h:51`
+
+### Notes
+- Static analysis: cppcheck clean (parse-only syntaxError, not defects); ament_cpplint 144 errors are all pre-existing repo convention (short RASTER_*_H guards, no copyright, C-style casts) and unenforced by CI (colcon build/test only) or pre-commit — new viewport_clip.h matches its neighbors; dropped as noise. Pre-commit-enforced checks (trailing-ws, final-newline) clean.
+- Governance: ADR-0007 seam fix with no renderer API change; ADR-0010 overviews-first order + no-blank-gap preserved; ADR-0011 accurate. All consequences (3 callers, cached_clip_, ADR) addressed.
+- Plan drift: matches plan; positive deviation — clip derivation factored into shared raster/viewport_clip.h vs planned per-layer copies. No CMake change (test extended in already-registered test_gggs_render.cpp).
+- Local Model Adversarial skipped: Ollama not installed on this host. Copilot Adversarial off (default, --copilot not passed).

--- a/.agent/work-plans/issue-103/progress.md
+++ b/.agent/work-plans/issue-103/progress.md
@@ -98,3 +98,32 @@ are related but explicitly out of scope. The design must not make them harder to
 
 ### Open questions
 - [ ] `option->exposedRect` under Qt's BSP update scheme may equal `boundingRect()` for large layers even when only part is visible — should we add a viewport-rect fallback via `painter->clipBoundingRect()`?
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-24 14:04 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-103/plan.md` at `83d9945`
+**PR**: PR-less (`--issue 103`, layer worktree)
+**Verdict**: changes-requested
+
+The approach is fundamentally sound — the fix belongs at the ADR-0007
+`renderToImage()` seam, the coordinate math is correct (verified against
+`raster_gl_renderer.cpp`'s MVP build), the scope is a clean single PR, and it
+correctly defers the LOD half. But one **critical correctness gap** would make
+the fix a silent no-op, plus two small mechanical must-fixes.
+
+### Findings
+- [ ] (must-fix) `option->exposedRect` defaults to `boundingRect()` unless `QGraphicsItem::ItemUsesExtendedStyleOption` is set on each layer — grep confirms it is set nowhere in camp. With the default, `clip_local == boundingRect()`, FBO sizing is unchanged, and the blur is **not fixed**. The plan's Open Question dismisses this ("Likely no") with flawed reasoning: if `clip_local == boundingRect()`, `mapRect(clip_local)` does *not* correct the resolution — it reproduces today's buggy full-extent sizing. Resolve by either `setFlag(ItemUsesExtendedStyleOption)` per layer, or (more robust, no flag) derive the viewport as `painter->clipBoundingRect().intersected(boundingRect())`. — `plan.md:139-143`, `plan.md:48-52`
+- [ ] (must-fix) `CMakeLists.txt` is missing from "Files to Change". A new `test/test_gggs_tile_layer.cpp` needs a full `ament_add_gtest(...)` + `target_include_directories` + `target_link_libraries` block (see `CMakeLists.txt:602-635`). Either add `CMakeLists.txt` to the plan, or extend the already-registered `test/test_gggs_render.cpp` (whose synthetic-store + `renderImage()` seam matches this test exactly). — `plan.md:105`
+- [ ] (must-fix) Testability contradiction: step 2 makes `renderImage(size, clip)` a **private** overload (`plan.md:98`), but the step-7 test calls `renderImage(size, clip_A)` directly (`plan.md:88-91`). Make the clip overload **public** (mirroring the existing public `renderImage(size)`), or add a friend/test seam. — `plan.md:61`, `plan.md:98`
+- [ ] (suggestion) The planned test bypasses the actual fix wiring: calling `renderImage(size, clip)` directly exercises the tile-filter seam but not `paint()`'s `exposedRect`/clip derivation — the risky part that closes the field bug. The test would pass even with the no-op derivation of finding 1. Note that `paint()`'s viewport derivation needs visual/manual verification (extend `test_gggs_render.cpp`'s `/tmp/*.png` inspection), and consider asserting improved resolution, not just tile presence/absence. — `plan.md:87-92`
+- [ ] (suggestion) Adding `cached_clip_` to the cache key means a **pan** (clip_scene changes each frame) now re-renders every frame, where today pan reuses the cached image via the world transform. Cheap for a viewport-sized FBO and arguably required, but the inherited "pan reuses the cached image" comment becomes stale — acknowledge the behavior change. — `plan.md:56-58`
+- [ ] (suggestion) `SonarLiveCacheLayer::items()` appends overviews-first then fine tiles for the ADR-0010 LOD fallback (`sonar_live_cache_layer.cpp:855-863`). The clip filter must preserve that ordering while filtering **both** pools, or a clipped region that lost its fine tiles could also drop its overview fallback (a blank gap). — `plan.md:78-80`
+
+### Notes (verified positives)
+- The item-local → scene coordinate conversion (`plan.md:39-44`) is **correct** — verified against the `setTransform(fromScale(1,-1))` + NW-anchor placement and `renderToImage()`'s `origin = scene_bounds.topLeft()` / `ortho(0,w,0,h)` MVP. Passing a `scene_bounds_` sub-rect as `scene_bounds` clips correctly (out-of-rect vertices fall outside NDC).
+- The three seam callers (GggsTileLayer / RasterLayer / SonarLiveCacheLayer) are correctly identified and all share the same `paint()` → `renderImage(size)` → `renderToImage(draw, scene_bounds_, …)` shape, so the change is uniform. Matches the Issue Review's "cover all three callers" recommendation.
+- ADR-0011 is the correct next number (0001–0010 present; 0004 already absent). No `RasterGlRenderer` API change is required — confirmed.
+- ROS conventions: N/A (Qt/GL offscreen rendering, no topics/QoS/params).

--- a/.agent/work-plans/issue-103/progress.md
+++ b/.agent/work-plans/issue-103/progress.md
@@ -1,0 +1,88 @@
+---
+issue: 103
+---
+
+# Issue #103 — Visible-region render + LOD for GggsTileLayer (visible-region half)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-24 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #103
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Scope Assessment
+
+The issue proposes two halves: (1) visible-region render — warp only
+viewport-intersecting tiles into an FBO covering the visible extent instead of the
+whole layer extent, and (2) LOD selection — pick a resolution matching pixels-per-metre
+from store-generated pyramid overviews.
+
+The orchestrator has explicitly deferred the LOD half (depends on
+unh_marine_autonomy#188 and a shared pyramid library not yet available). The
+**visible-region half alone is the deliverable** for this PR; the blur regression is
+confirmed field-observed and confirmed code-confirmed (Roland, 2026-07-23). This is a
+clean, independently deliverable scope boundary.
+
+The change touches `gggs_tile_layer.{h,cpp}`, `raster_layer.h`, and
+`sonar_live_cache_layer.h`, but camp ADR-0007 establishes that the right fix point is
+the `RasterFieldSource`/`RasterGlRenderer` seam — one change there benefits all three
+callers.
+
+**Right repo?** Yes — camp UI project change, correctly in the camp repo.
+
+**Dependencies**: The visible-region half has no external dependency. Camp#171
+(eviction fold frees no memory) and camp#172 (no in-session reload of evicted tiles)
+are related but explicitly out of scope. The design must not make them harder to fix.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Crisp zoomed-in rendering is the expected outcome; no new hidden state or behavior |
+| Enforcement over documentation | OK | Not a process change |
+| Capture decisions, not just implementations | Action needed | The viewport-clip API choice (add `viewport_bounds` param to `renderToImage` vs. caller pre-filters items + passes viewport rect as `scene_bounds`) is a design decision for the ADR-0007 seam; record as a camp ADR-0007 addendum |
+| A change includes its consequences | Watch | Three code sites use the seam (GggsTileLayer, RasterLayer, SonarLiveCacheLayer) — all must be updated or benefit from the seam fix; any existing tests calling `renderToImage` need updating if signature changes |
+| Only what's needed | Watch | The full issue mentions texture-cache + eviction, but the visible-region half needs neither — tile textures already exist (lazily loaded per camp#102); the fix is: filter items to viewport-intersecting tiles and size the FBO to the viewport, not to the whole extent; don't add cache machinery in this PR |
+| Improve incrementally | OK | Visible-region render alone closes the field-confirmed blur regression; good scope boundary |
+| Test what breaks | Watch | No automated regression test for zoom-level rendering fidelity exists; update any existing `renderToImage` call sites in tests; a new viewport-clip unit test would be valuable |
+| Workspace vs. project separation | OK | Camp-specific change with no workspace-repo impact |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| camp ADR-0007 (RasterFieldSource seam) | Yes — strongly | The fix belongs at this seam; `renderToImage` must learn to accept a viewport clip rect or callers must pre-filter items and shrink `scene_bounds` to the viewport; the implementation plan should commit to one approach and record it |
+| camp ADR-0010 (bounded eviction + overview pyramid) | Partially | The issue mentions evicting off-screen textures; for the visible-region-only PR this is NOT needed — existing lazy load defers reads; ensure the design doesn't interfere with ADR-0010's `SonarLiveCacheLayer` eviction logic |
+| workspace ADR-0001 (capture decisions) | Yes | If the `renderToImage` signature changes or a new viewport-clip calling convention is established, capture it as a camp ADR-0007 addendum |
+| workspace ADR-0002 (worktree isolation) | Yes — always | Worktree already exists for this issue |
+
+### Consequences
+
+- `renderToImage` signature or calling convention change → update all three callers
+  (GggsTileLayer, RasterLayer, SonarLiveCacheLayer) and any tests
+- If camp ADR-0007 is amended → update this review guide's ADR table (workspace
+  `principles_review_guide.md`) — this is a project-level ADR only, not workspace-level,
+  so workspace consequences are minimal
+- Related open defects camp#171 and camp#172: the visible-region design should set up
+  camp#172's on-demand disk-reload fix shape (a visible-region loader is the natural
+  trigger), not close off that option
+
+### Recommendations
+
+- [ ] Fix at the RasterGlRenderer seam (ADR-0007), not per-layer: the `paint()` caller
+  should derive the viewport-intersecting rect (intersection of `boundingRect()` and the
+  painter's viewport in scene coords), filter `items()` to tiles whose extents overlap
+  that rect, and pass the clipped rect as `scene_bounds` to `renderToImage` — this
+  requires no signature change and immediately benefits all three render callers
+- [ ] Do NOT add texture-cache eviction or LOD machinery in this PR (that is the deferred
+  LOD half); keep the change minimal: viewport filter + clipped FBO size
+- [ ] Record the viewport-clip calling convention as a camp ADR-0007 addendum (or a new
+  camp ADR-0011) so future agents understand the seam's viewport contract
+- [ ] Verify the change covers all three callers at the seam (GggsTileLayer, RasterLayer,
+  SonarLiveCacheLayer), or explicitly note which callers are deferred and why
+- [ ] Note in the PR that camp#172 (on-demand reload of evicted tiles) is the natural
+  next step enabled by a visible-region render loop; ensure the implementation doesn't
+  foreclose it

--- a/docs/decisions/0011-viewport-clip-render-convention.md
+++ b/docs/decisions/0011-viewport-clip-render-convention.md
@@ -1,0 +1,77 @@
+# ADR-0011: Viewport-clip render convention at the raster seam
+
+## Status
+
+Accepted
+
+Implements the **visible-region half** of CAMP issue
+[#103](https://github.com/rolker/camp/issues/103). Extends
+[ADR-0007](0007-raster-field-source-interface.md) (the `RasterFieldSource` /
+`RasterGlRenderer` seam all three raster layers render through) with a calling
+convention; the renderer's API is unchanged. The pyramid-LOD half of #103 is
+explicitly deferred — it depends on store overview pyramids
+(unh_marine_autonomy#188 and a shared pyramid library) that do not exist yet.
+
+## Context
+
+All three raster layers (`GggsTileLayer`, `RasterLayer`,
+`SonarLiveCacheLayer`) shared the same `paint()` shape: map the **whole layer
+extent** to on-screen pixels, clamp to `kMaxImageEdge` (4096), render every
+tile into one offscreen FBO of that size, and draw it over `boundingRect()`.
+
+For a store larger than 4096 on-screen pixels this is wrong at both ends of
+the zoom range:
+
+- **Zoomed in** (the field-observed failure, 2026-07-23): the viewport covers
+  a small fraction of the extent, but the FBO still spans the whole extent at
+  ≤4096 px — each visible pixel is backed by a fraction of an FBO pixel, so
+  the display is blurry even though the tile pixels are full-resolution in
+  memory.
+- **Zoomed out** (the deferred LOD half): every tile is loaded and drawn no
+  matter how few screen pixels it lands on.
+
+## Decision
+
+**paint() renders only the viewport-visible clip of the layer, sized to the
+clip's on-screen pixels.** Concretely, via the shared helper
+`raster/viewport_clip.h` (`deriveViewportClip()`):
+
+1. **Viewport derivation**: `clip_local =
+   painter->clipBoundingRect().intersected(boundingRect())`, falling back to
+   `boundingRect()` when empty (offscreen/test renders keep the pre-#103
+   whole-extent behavior). NOT `QStyleOptionGraphicsItem::exposedRect` — that
+   silently defaults to `boundingRect()` unless
+   `ItemUsesExtendedStyleOption` is set (it is set nowhere in camp), which
+   would make the clip a no-op.
+2. **Scene conversion**: `clip_local` → `clip_scene` under the camp_map raster
+   convention (item at the NW corner with `fromScale(1,-1)`, so local y
+   increases southward while scene y increases northward).
+3. **FBO sizing**: the clip's on-screen size, clamped to `kMaxImageEdge`
+   (which now applies to the viewport, so it is rarely hit).
+4. **Render**: each layer's clip-aware `renderImage(size, clip_bounds)` passes
+   `clip_scene` — not the full `scene_bounds_` — as the `scene_bounds`
+   argument of `RasterGlRenderer::renderToImage()`. The MVP crops to the clip;
+   no renderer API change.
+5. **Item filtering**: tiled sources filter their tiles to those whose
+   Web-Mercator extent intersects the clip **before** the lazy texture upload,
+   so offscreen tiles are neither uploaded nor drawn. `SonarLiveCacheLayer`
+   filters both pools with the same predicate, preserving the
+   overviews-first draw order (the ADR-0010 LOD fallback).
+6. **Cache key**: `cached_image_` is keyed by FBO size **and** clip rect. A
+   pan now re-renders each frame (pre-#103 it reused the whole-extent image
+   via the world transform); with a viewport-sized FBO that re-render is
+   cheap, and it is required for correctness once the image covers only the
+   clip.
+
+## Consequences
+
+- Zoomed-in rendering of stores larger than 4096 on-screen pixels is crisp —
+  the confirmed #103 field regression.
+- Offscreen tiles cost no texture upload or draw, which is the natural
+  precondition for camp#172's on-demand reload of evicted live tiles: the
+  visible-region loop is where a reload request belongs. Not implemented here.
+- The full-extent `renderImage(size)` overloads remain (delegating with
+  `scene_bounds_`) so headless tests and QA renders are unchanged.
+- The pyramid-LOD half of #103 (choose tile LEVEL by view scale) layers on
+  top of this convention unchanged: LOD selection will change *which* items a
+  source returns for the clip, not how the clip is derived or rendered.

--- a/docs/decisions/0011-viewport-clip-render-convention.md
+++ b/docs/decisions/0011-viewport-clip-render-convention.md
@@ -36,13 +36,15 @@ the zoom range:
 clip's on-screen pixels.** Concretely, via the shared helper
 `raster/viewport_clip.h` (`deriveViewportClip()`):
 
-1. **Viewport derivation**: `clip_local =
-   painter->clipBoundingRect().intersected(boundingRect())`, falling back to
-   `boundingRect()` when empty (offscreen/test renders keep the pre-#103
-   whole-extent behavior). NOT `QStyleOptionGraphicsItem::exposedRect` — that
-   silently defaults to `boundingRect()` unless
-   `ItemUsesExtendedStyleOption` is set (it is set nowhere in camp), which
-   would make the clip a no-op.
+1. **Viewport derivation**: from the **attached view** — the first view's
+   `mapToScene(viewport)` mapped into the item and intersected with
+   `boundingRect()`. The painter's state is NOT a reliable viewport signal
+   and is only a secondary fallback: `QStyleOptionGraphicsItem::exposedRect`
+   silently defaults to `boundingRect()` without `ItemUsesExtendedStyleOption`
+   (set nowhere in camp), and `painter->clipBoundingRect()` is empty on live
+   full-viewport repaints (field-verified — the blur came back). With no view
+   and no painter clip, fall back to `boundingRect()` (pre-#103 whole-extent
+   behavior for offscreen/QA renders). First view only — CAMP has one MapView.
 2. **Scene conversion**: `clip_local` → `clip_scene` under the camp_map raster
    convention (item at the NW corner with `fromScale(1,-1)`, so local y
    increases southward while scene y increases northward).

--- a/src/camp_map/raster/gggs_tile_layer.cpp
+++ b/src/camp_map/raster/gggs_tile_layer.cpp
@@ -3,6 +3,7 @@
 #include "gggs_tile.h"
 #include "gggs_tile_util.h"
 #include "colormap_range_dialog.h"
+#include "viewport_clip.h"
 #include "../map_view/web_mercator.h"
 
 #include <marine_colormap/palette.hpp>
@@ -376,11 +377,20 @@ QPair<float, float> GggsTileLayer::dataRange() const
 
 QList<RasterFieldItem> GggsTileLayer::items()
 {
+  return itemsIntersecting(QRectF());
+}
+
+QList<RasterFieldItem> GggsTileLayer::itemsIntersecting(const QRectF& clip_scene)
+{
   // [camp#134] Collect the loaded tiles as Scalar items for the shared renderer.
   // Called with the renderer's GL context current (renderImage()), so tile->
   // texture() may lazily upload here. The geo->Web-Mercator warp + tessellation
   // now lives in the renderer, so this only forwards each tile's lat/lon extent +
   // per-tile NoData sentinel.
+  // [camp#103] A non-null @p clip_scene keeps only tiles whose Web-Mercator
+  // extent intersects it — tested BEFORE texture(), so offscreen tiles are
+  // neither uploaded nor drawn. geoToMap is monotonic in both axes, so the
+  // SW/NE corners bound the tile's scene rect.
   QList<RasterFieldItem> result;
   result.reserve(int(tiles_.size()));
   for(auto& tile : tiles_)
@@ -390,6 +400,15 @@ QList<RasterFieldItem> GggsTileLayer::items()
     // true the data_/texture() reads see the worker's completed writes — no race.
     if(!tile->pixelsLoaded())
       continue;
+    if(!clip_scene.isNull())
+    {
+      const QPointF lo = web_mercator::geoToMap(
+        QGeoCoordinate(tile->minLat(), tile->minLon()));
+      const QPointF hi = web_mercator::geoToMap(
+        QGeoCoordinate(tile->maxLat(), tile->maxLon()));
+      if(!QRectF(lo, hi).normalized().intersects(clip_scene))
+        continue;
+    }
     QOpenGLTexture* texture = tile->texture();
     if(!texture)
       continue;
@@ -412,17 +431,23 @@ QList<RasterFieldItem> GggsTileLayer::items()
 
 QImage GggsTileLayer::renderImage(const QSize& size)
 {
-  if(tiles_.empty() || data_min_ > data_max_ || size.isEmpty())
+  return renderImage(size, scene_bounds_);
+}
+
+QImage GggsTileLayer::renderImage(const QSize& size, const QRectF& clip_bounds)
+{
+  if(tiles_.empty() || data_min_ > data_max_ || size.isEmpty() ||
+     clip_bounds.isEmpty())
     return QImage();
   // [camp#134] Make the renderer's context current, collect the loaded tiles
   // (uploading their textures under it), then delegate the warp + draw. The
   // returned image is top-down ARGB32 premultiplied (as before).
   if(!renderer_.makeCurrent())
     return QImage();
-  const QList<RasterFieldItem> draw = items();
+  const QList<RasterFieldItem> draw = itemsIntersecting(clip_bounds);
   // [camp#142] Feed the resolved range (Auto tracks data_min_/data_max_; Manual is
   // the operator override) into the shader's u_min/u_max instead of the raw extents.
-  const QImage image = renderer_.renderToImage(draw, scene_bounds_, range_model_.lo(),
+  const QImage image = renderer_.renderToImage(draw, clip_bounds, range_model_.lo(),
                                                range_model_.hi(), size);
   renderer_.doneCurrent();
   return image;
@@ -447,27 +472,26 @@ void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QW
   if(data_min_ > data_max_)   // no tile's pixels/range folded yet
     return;
 
-  // Target the offscreen render at the extent's on-screen size, so the image is
-  // crisp at the current zoom. Re-render only when that size changes (zoom);
-  // pan reuses the cached image (drawImage repositions it via the world xform).
-  const QRectF dev = painter->worldTransform().mapRect(boundingRect());
-  const int w = std::min(kMaxImageEdge,
-                         std::max(1, int(std::ceil(std::abs(dev.width())))));
-  const int h = std::min(kMaxImageEdge,
-                         std::max(1, int(std::ceil(std::abs(dev.height())))));
-  const QSize size(w, h);
+  // [camp#103 / ADR-0011] Render only the viewport-visible clip of the extent,
+  // sized to its on-screen pixels — a zoomed-in view of a store far larger than
+  // kMaxImageEdge stays crisp. Re-render when the size (zoom) OR the clip (pan)
+  // changes; a viewport-sized FBO makes the per-frame pan re-render cheap.
+  const ViewportClip clip =
+    deriveViewportClip(painter, boundingRect(), scene_bounds_, kMaxImageEdge);
 
-  if(cached_image_.isNull() || cached_size_ != size)
+  if(cached_image_.isNull() || cached_size_ != clip.size ||
+     cached_clip_ != clip.scene)
   {
-    cached_image_ = renderImage(size);
-    cached_size_ = size;
+    cached_image_ = renderImage(clip.size, clip.scene);
+    cached_size_ = clip.size;
+    cached_clip_ = clip.scene;
   }
   if(cached_image_.isNull())
     return;
 
   painter->save();
   painter->setRenderHint(QPainter::SmoothPixmapTransform);
-  painter->drawImage(boundingRect(), cached_image_);
+  painter->drawImage(clip.local, cached_image_);
   painter->restore();
 }
 

--- a/src/camp_map/raster/gggs_tile_layer.cpp
+++ b/src/camp_map/raster/gggs_tile_layer.cpp
@@ -477,7 +477,7 @@ void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QW
   // kMaxImageEdge stays crisp. Re-render when the size (zoom) OR the clip (pan)
   // changes; a viewport-sized FBO makes the per-frame pan re-render cheap.
   const ViewportClip clip =
-    deriveViewportClip(painter, boundingRect(), scene_bounds_, kMaxImageEdge);
+    deriveViewportClip(painter, this, boundingRect(), scene_bounds_, kMaxImageEdge);
 
   if(cached_image_.isNull() || cached_size_ != clip.size ||
      cached_clip_ != clip.scene)

--- a/src/camp_map/raster/gggs_tile_layer.h
+++ b/src/camp_map/raster/gggs_tile_layer.h
@@ -37,9 +37,10 @@ class GggsTile;
 /// it registered with the vector overlays and CPU raster/tile layers.
 ///
 /// Auto-ranged value mapped through a colormap LUT (camp#90); fixed
-/// tessellation; whole-extent render cached by on-screen size. Multi-band
-/// GeoTIFFs expose a per-layer band picker (camp#108); visible-region-only
-/// render is Slice 2.
+/// tessellation. Multi-band GeoTIFFs expose a per-layer band picker (camp#108).
+/// [camp#103 / ADR-0011] paint() renders only the viewport-visible clip of the
+/// extent, sized to the on-screen pixels, so zoomed-in renders stay crisp on
+/// stores far larger than kMaxImageEdge.
 class GggsTileLayer: public map::Layer, public RasterFieldSource
 {
   Q_OBJECT
@@ -78,6 +79,13 @@ public:
   /// data or GL is unavailable. Exposed so a headless test can render + inspect
   /// without a window.
   QImage renderImage(const QSize& size);
+
+  /// [camp#103 / ADR-0011] Clip-aware overload: warp only the tiles whose scene
+  /// extent intersects @p clip_bounds (a sub-rect of sceneBounds(), Web-Mercator
+  /// metres) into an image of @p size spanning exactly @p clip_bounds. paint()
+  /// uses it with the viewport-derived clip; public (mirroring renderImage(size))
+  /// so the headless clip-filter test can call it directly.
+  QImage renderImage(const QSize& size, const QRectF& clip_bounds);
 
   /// [camp#90 / camp#141] Select the colour ramp by marine_colormap palette name
   /// (baked to a GPU LUT). Persists and re-renders. Unknown name -> grayscale.
@@ -166,6 +174,11 @@ private:
   /// load, and repaints. No-op if @p band is out of range or unchanged.
   void applyBand(int band);
   void loadDirectory(const QString& directory);
+  /// [camp#103] items() body with an optional scene-space clip: a non-null
+  /// @p clip_scene keeps only tiles whose Web-Mercator extent intersects it,
+  /// tested BEFORE the lazy texture upload so offscreen tiles cost nothing.
+  /// items() (the RasterFieldSource interface) delegates with a null rect.
+  QList<RasterFieldItem> itemsIntersecting(const QRectF& clip_scene);
   /// [camp#102] Worker body (runs off-thread): loadPixels() each not-yet-loaded
   /// tile, honoring abort_flag_ between tiles. GDAL only — never touches GL.
   void loadTilesWorker();
@@ -211,8 +224,13 @@ private:
   QMutex abort_flag_mutex_;
   bool load_started_ = false;  // first paint() kicks the load exactly once
 
-  QImage cached_image_;        // last render, reused on pan (re-rendered on zoom)
+  // [camp#103] Last render, keyed by FBO size AND viewport clip: zoom changes the
+  // size, pan changes the clip, so both re-render. (Pre-#103, pan reused the
+  // cached whole-extent image via the world transform; a viewport-sized FBO makes
+  // the per-frame re-render cheap and is required for correctness.)
+  QImage cached_image_;
   QSize cached_size_;
+  QRectF cached_clip_;
 };
 
 }  // namespace raster

--- a/src/camp_map/raster/raster_layer.cpp
+++ b/src/camp_map/raster/raster_layer.cpp
@@ -82,7 +82,7 @@ void RasterLayer::paint(QPainter *painter, const QStyleOptionGraphicsItem *optio
   // kMaxImageEdge stays crisp. Re-render when the size (zoom) OR the clip (pan)
   // changes; a viewport-sized FBO makes the per-frame pan re-render cheap.
   const ViewportClip clip =
-    deriveViewportClip(painter, boundingRect(), scene_bounds_, kMaxImageEdge);
+    deriveViewportClip(painter, this, boundingRect(), scene_bounds_, kMaxImageEdge);
 
   if(cached_image_.isNull() || cached_size_ != clip.size ||
      cached_clip_ != clip.scene)

--- a/src/camp_map/raster/raster_layer.cpp
+++ b/src/camp_map/raster/raster_layer.cpp
@@ -3,6 +3,7 @@
 #include <gdalwarper.h>
 #include "../map_view/web_mercator.h"
 #include "colormap_range_dialog.h"
+#include "viewport_clip.h"
 #include <marine_colormap/palette.hpp>
 #include <QPainter>
 #include <QOpenGLTexture>
@@ -76,27 +77,26 @@ void RasterLayer::paint(QPainter *painter, const QStyleOptionGraphicsItem *optio
   if(is_scalar_ && data_min_ > data_max_)   // scalar: nothing valid to colour yet
     return;
 
-  // Target the offscreen render at the extent's on-screen size, so the image is
-  // crisp at the current zoom. Re-render only when that size changes (zoom); pan
-  // reuses the cached image (drawImage repositions it via the world transform).
-  const QRectF dev = painter->worldTransform().mapRect(boundingRect());
-  const int w = std::min(kMaxImageEdge,
-                         std::max(1, int(std::ceil(std::abs(dev.width())))));
-  const int h = std::min(kMaxImageEdge,
-                         std::max(1, int(std::ceil(std::abs(dev.height())))));
-  const QSize size(w, h);
+  // [camp#103 / ADR-0011] Render only the viewport-visible clip of the extent,
+  // sized to its on-screen pixels — a zoomed-in view of a chart far larger than
+  // kMaxImageEdge stays crisp. Re-render when the size (zoom) OR the clip (pan)
+  // changes; a viewport-sized FBO makes the per-frame pan re-render cheap.
+  const ViewportClip clip =
+    deriveViewportClip(painter, boundingRect(), scene_bounds_, kMaxImageEdge);
 
-  if(cached_image_.isNull() || cached_size_ != size)
+  if(cached_image_.isNull() || cached_size_ != clip.size ||
+     cached_clip_ != clip.scene)
   {
-    cached_image_ = renderImage(size);
-    cached_size_ = size;
+    cached_image_ = renderImage(clip.size, clip.scene);
+    cached_size_ = clip.size;
+    cached_clip_ = clip.scene;
   }
   if(cached_image_.isNull())
     return;
 
   painter->save();
   painter->setRenderHint(QPainter::SmoothPixmapTransform);
-  painter->drawImage(boundingRect(), cached_image_);
+  painter->drawImage(clip.local, cached_image_);
   painter->restore();
 }
 
@@ -414,7 +414,12 @@ void RasterLayer::imageReady()
 
 QImage RasterLayer::renderImage(const QSize& size)
 {
-  if(scene_bounds_.isNull() || size.isEmpty())
+  return renderImage(size, scene_bounds_);
+}
+
+QImage RasterLayer::renderImage(const QSize& size, const QRectF& clip_bounds)
+{
+  if(scene_bounds_.isNull() || size.isEmpty() || clip_bounds.isEmpty())
     return QImage();
   if(is_scalar_ && data_min_ > data_max_)
     return QImage();
@@ -424,7 +429,9 @@ QImage RasterLayer::renderImage(const QSize& size)
   // [camp#142] Feed the resolved range (Auto tracks data_min_/data_max_; Manual is
   // the operator override) into the shader's u_min/u_max. Scalar charts shade
   // through it; RGB charts bypass the LUT, so the range is a don't-care for them.
-  const QImage image = renderer_.renderToImage(draw, scene_bounds_, range_model_.lo(),
+  // [camp#103] clip_bounds (a sub-rect of scene_bounds_) crops via the MVP —
+  // quad vertices outside it fall outside NDC. No item filtering (one texture).
+  const QImage image = renderer_.renderToImage(draw, clip_bounds, range_model_.lo(),
                                                range_model_.hi(), size);
   renderer_.doneCurrent();
   return image;

--- a/src/camp_map/raster/raster_layer.h
+++ b/src/camp_map/raster/raster_layer.h
@@ -68,6 +68,12 @@ public:
   /// is nothing to draw or GL is unavailable. Exposed for headless tests.
   QImage renderImage(const QSize& size);
 
+  /// [camp#103 / ADR-0011] Clip-aware overload: render only @p clip_bounds (a
+  /// sub-rect of sceneBounds(), Web-Mercator metres) into an image of @p size.
+  /// No item filtering (single-texture layer) — the clipped scene_bounds crops
+  /// via the renderer's MVP. paint() uses it with the viewport-derived clip.
+  QImage renderImage(const QSize& size, const QRectF& clip_bounds);
+
   /// The layer's Web-Mercator extent. Exposed for tests.
   QRectF sceneBounds() const { return scene_bounds_; }
 
@@ -155,8 +161,12 @@ private:
   bool has_nodata_ = false;
   float nodata_ = 0.0f;
 
-  QImage cached_image_;       // last render, reused on pan (re-rendered on zoom)
+  // [camp#103] Last render, keyed by FBO size AND viewport clip: zoom changes
+  // the size, pan changes the clip, so both re-render (the FBO is viewport-sized,
+  // so the per-frame pan re-render is cheap).
+  QImage cached_image_;
   QSize cached_size_;
+  QRectF cached_clip_;
   static constexpr int kMaxImageEdge = 4096;   // clamp the offscreen target
 
   // Compute the reprojected extent + Web-Mercator scene placement from file

--- a/src/camp_map/raster/viewport_clip.h
+++ b/src/camp_map/raster/viewport_clip.h
@@ -1,6 +1,9 @@
 #ifndef RASTER_VIEWPORT_CLIP_H
 #define RASTER_VIEWPORT_CLIP_H
 
+#include <QGraphicsItem>
+#include <QGraphicsScene>
+#include <QGraphicsView>
 #include <QPainter>
 #include <QRectF>
 #include <QSize>
@@ -28,17 +31,35 @@ struct ViewportClip
 /// setPos()'d at the NW corner of @p scene_bounds with a fromScale(1,-1)
 /// transform, so local y increases southward while scene y increases northward.
 ///
-/// The viewport comes from painter->clipBoundingRect() — NOT
-/// QStyleOptionGraphicsItem::exposedRect, which silently defaults to
-/// boundingRect() unless ItemUsesExtendedStyleOption is set (it is set nowhere
-/// in camp), which would make viewport clipping a no-op. An empty clip (no
-/// clipping active, e.g. an offscreen/test render) falls back to the full
-/// bounding rect, reproducing the pre-#103 whole-extent behavior.
-inline ViewportClip deriveViewportClip(QPainter* painter, const QRectF& bounding,
+/// The viewport comes from the attached view — mapToScene(viewport) mapped into
+/// the item — because the painter's state is NOT a reliable viewport signal:
+/// QStyleOptionGraphicsItem::exposedRect defaults to boundingRect() without
+/// ItemUsesExtendedStyleOption (set nowhere in camp), and
+/// painter->clipBoundingRect() is only populated on repaint paths where
+/// QGraphicsView happens to set a clip (verified empty on live full-viewport
+/// repaints — the blur came back in the field). The painter clip is kept as a
+/// secondary signal for painter-only render paths; with neither, fall back to
+/// the full bounding rect (pre-#103 whole-extent behavior, e.g. headless
+/// QA renders). First view only — CAMP has a single MapView.
+inline ViewportClip deriveViewportClip(QPainter* painter,
+                                       const QGraphicsItem* item,
+                                       const QRectF& bounding,
                                        const QRectF& scene_bounds, int max_edge)
 {
   ViewportClip clip;
-  clip.local = painter->clipBoundingRect().intersected(bounding);
+  if(const QGraphicsScene* scene = item ? item->scene() : nullptr)
+  {
+    const QList<QGraphicsView*> views = scene->views();
+    if(!views.isEmpty() && views.first())
+    {
+      QGraphicsView* view = views.first();
+      const QRectF view_scene =
+        view->mapToScene(view->viewport()->rect()).boundingRect();
+      clip.local = item->mapRectFromScene(view_scene).intersected(bounding);
+    }
+  }
+  if(clip.local.isEmpty())
+    clip.local = painter->clipBoundingRect().intersected(bounding);
   if(clip.local.isEmpty())
     clip.local = bounding;
 

--- a/src/camp_map/raster/viewport_clip.h
+++ b/src/camp_map/raster/viewport_clip.h
@@ -1,0 +1,66 @@
+#ifndef RASTER_VIEWPORT_CLIP_H
+#define RASTER_VIEWPORT_CLIP_H
+
+#include <QPainter>
+#include <QRectF>
+#include <QSize>
+#include <algorithm>
+#include <cmath>
+
+namespace camp
+{
+namespace raster
+{
+
+/// [camp#103 / ADR-0011] The visible sub-region a raster layer should render,
+/// derived in paint() from the painter's clip. Shared by the three
+/// RasterFieldSource layers (GggsTileLayer, RasterLayer, SonarLiveCacheLayer)
+/// so the derivation lives once.
+struct ViewportClip
+{
+  QRectF local;   ///< clip in item-local coords (drawImage target)
+  QRectF scene;   ///< clip in Web-Mercator scene coords (renderToImage bounds)
+  QSize size;     ///< offscreen FBO size for the clip at the current zoom
+};
+
+/// Derive the visible clip of an item whose local space spans
+/// (0,0)..(bounding.size()) with the camp_map raster convention: the item is
+/// setPos()'d at the NW corner of @p scene_bounds with a fromScale(1,-1)
+/// transform, so local y increases southward while scene y increases northward.
+///
+/// The viewport comes from painter->clipBoundingRect() — NOT
+/// QStyleOptionGraphicsItem::exposedRect, which silently defaults to
+/// boundingRect() unless ItemUsesExtendedStyleOption is set (it is set nowhere
+/// in camp), which would make viewport clipping a no-op. An empty clip (no
+/// clipping active, e.g. an offscreen/test render) falls back to the full
+/// bounding rect, reproducing the pre-#103 whole-extent behavior.
+inline ViewportClip deriveViewportClip(QPainter* painter, const QRectF& bounding,
+                                       const QRectF& scene_bounds, int max_edge)
+{
+  ViewportClip clip;
+  clip.local = painter->clipBoundingRect().intersected(bounding);
+  if(clip.local.isEmpty())
+    clip.local = bounding;
+
+  // Item-local -> scene: x offsets from the west edge; y flips about the north
+  // edge (scene_bounds.bottom() is the northern/max-y edge, local y=0).
+  const qreal left = scene_bounds.left() + clip.local.left();
+  const qreal right = scene_bounds.left() + clip.local.right();
+  const qreal top = scene_bounds.bottom() - clip.local.bottom();      // south
+  const qreal bottom = scene_bounds.bottom() - clip.local.top();      // north
+  clip.scene = QRectF(QPointF(left, top), QPointF(right, bottom));
+
+  // Size the offscreen target to the CLIP's on-screen size (not the whole
+  // extent), so zoomed-in renders stay at full pixel density. The max_edge
+  // clamp now applies to the viewport, so it is rarely hit.
+  const QRectF dev = painter->worldTransform().mapRect(clip.local);
+  clip.size = QSize(
+    std::min(max_edge, std::max(1, int(std::ceil(std::abs(dev.width()))))),
+    std::min(max_edge, std::max(1, int(std::ceil(std::abs(dev.height()))))));
+  return clip;
+}
+
+}  // namespace raster
+}  // namespace camp
+
+#endif

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
@@ -3,6 +3,7 @@
 #include "../node.h"
 #include "../../map_view/web_mercator.h"
 #include "../../raster/colormap_range_dialog.h"
+#include "../../raster/viewport_clip.h"
 
 #include <marine_colormap/palette.hpp>
 
@@ -826,14 +827,33 @@ QPair<float, float> SonarLiveCacheLayer::dataRange() const
 
 QList<raster::RasterFieldItem> SonarLiveCacheLayer::items()
 {
+  return itemsIntersecting(QRectF());
+}
+
+QList<raster::RasterFieldItem> SonarLiveCacheLayer::itemsIntersecting(
+  const QRectF& clip_scene)
+{
   // [camp#134] Collect the held tiles' selected band as Scalar items for the shared
   // renderer. Called with the renderer's GL context current (renderImage()), so
   // textureFor() may lazily (re)upload here. The geo->Web-Mercator warp lives in
   // the renderer; this only forwards each tile's lat/lon extent + NoData sentinel.
+  // [camp#103] A non-null @p clip_scene keeps only tiles whose Web-Mercator extent
+  // intersects it — tested BEFORE textureFor(), so offscreen tiles are neither
+  // uploaded nor drawn. Both pools are filtered with the same predicate, keeping
+  // the overviews-first order below intact.
   QList<raster::RasterFieldItem> result;
   result.reserve(int(overview_tiles_.size() + tiles_.size()));
   auto append = [&](Entry& entry)
   {
+    if(!clip_scene.isNull())
+    {
+      const QPointF lo = web_mercator::geoToMap(
+        QGeoCoordinate(entry.tile.minLat(), entry.tile.minLon()));
+      const QPointF hi = web_mercator::geoToMap(
+        QGeoCoordinate(entry.tile.maxLat(), entry.tile.maxLon()));
+      if(!QRectF(lo, hi).normalized().intersects(clip_scene))
+        return;
+    }
     const SonarLiveBand* band = entry.tile.band(band_name_);
     if(!band)
       return;
@@ -865,17 +885,24 @@ QList<raster::RasterFieldItem> SonarLiveCacheLayer::items()
 
 QImage SonarLiveCacheLayer::renderImage(const QSize& size)
 {
+  return renderImage(size, scene_bounds_);
+}
+
+QImage SonarLiveCacheLayer::renderImage(const QSize& size, const QRectF& clip_bounds)
+{
   if((tiles_.empty() && overview_tiles_.empty()) || data_min_ > data_max_ ||
-     size.isEmpty())
+     size.isEmpty() || clip_bounds.isEmpty())
     return QImage();
   // [camp#134] Make the renderer's context current, collect the held tiles
   // (uploading textures under it), then delegate the warp + draw.
   if(!renderer_.makeCurrent())
     return QImage();
-  const QList<raster::RasterFieldItem> draw = items();
+  // [camp#103] Only tiles intersecting the clip contribute (both pools,
+  // overviews-first order preserved — the ADR-0010 LOD fallback).
+  const QList<raster::RasterFieldItem> draw = itemsIntersecting(clip_bounds);
   // [camp#142] Feed the resolved range (Auto tracks data_min_/data_max_; Manual is
   // the operator override) into the shader's u_min/u_max instead of the raw extents.
-  const QImage image = renderer_.renderToImage(draw, scene_bounds_, range_model_.lo(),
+  const QImage image = renderer_.renderToImage(draw, clip_bounds, range_model_.lo(),
                                                range_model_.hi(), size);
   renderer_.doneCurrent();
   return image;
@@ -886,22 +913,25 @@ void SonarLiveCacheLayer::paint(QPainter* painter, const QStyleOptionGraphicsIte
   if((tiles_.empty() && overview_tiles_.empty()) || data_min_ > data_max_)
     return;
 
-  const QRectF dev = painter->worldTransform().mapRect(boundingRect());
-  const int w = std::min(kMaxImageEdge, std::max(1, int(std::ceil(std::abs(dev.width())))));
-  const int h = std::min(kMaxImageEdge, std::max(1, int(std::ceil(std::abs(dev.height())))));
-  const QSize size(w, h);
+  // [camp#103 / ADR-0011] Render only the viewport-visible clip of the extent,
+  // sized to its on-screen pixels. Re-render when the size (zoom) OR the clip
+  // (pan) changes; a viewport-sized FBO makes the per-frame pan re-render cheap.
+  const raster::ViewportClip clip = raster::deriveViewportClip(
+    painter, boundingRect(), scene_bounds_, kMaxImageEdge);
 
-  if(cached_image_.isNull() || cached_size_ != size)
+  if(cached_image_.isNull() || cached_size_ != clip.size ||
+     cached_clip_ != clip.scene)
   {
-    cached_image_ = renderImage(size);
-    cached_size_ = size;
+    cached_image_ = renderImage(clip.size, clip.scene);
+    cached_size_ = clip.size;
+    cached_clip_ = clip.scene;
   }
   if(cached_image_.isNull())
     return;
 
   painter->save();
   painter->setRenderHint(QPainter::SmoothPixmapTransform);
-  painter->drawImage(boundingRect(), cached_image_);
+  painter->drawImage(clip.local, cached_image_);
   painter->restore();
 }
 

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
@@ -917,7 +917,7 @@ void SonarLiveCacheLayer::paint(QPainter* painter, const QStyleOptionGraphicsIte
   // sized to its on-screen pixels. Re-render when the size (zoom) OR the clip
   // (pan) changes; a viewport-sized FBO makes the per-frame pan re-render cheap.
   const raster::ViewportClip clip = raster::deriveViewportClip(
-    painter, boundingRect(), scene_bounds_, kMaxImageEdge);
+    painter, this, boundingRect(), scene_bounds_, kMaxImageEdge);
 
   if(cached_image_.isNull() || cached_size_ != clip.size ||
      cached_clip_ != clip.scene)

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
@@ -93,6 +93,14 @@ public:
   /// unavailable. Exposed for a headless render check (skips with no GL).
   QImage renderImage(const QSize& size);
 
+  /// [camp#103 / ADR-0011] Clip-aware overload: render only the tiles whose
+  /// scene extent intersects @p clip_bounds (a sub-rect of sceneBounds(),
+  /// Web-Mercator metres) into an image of @p size spanning exactly
+  /// @p clip_bounds. Filters BOTH pools while preserving the overviews-first
+  /// draw order (the ADR-0010 LOD fallback). paint() uses it with the
+  /// viewport-derived clip; public (mirroring renderImage(size)) for tests.
+  QImage renderImage(const QSize& size, const QRectF& clip_bounds);
+
   /// The layer's Web-Mercator extent (union of tile extents). Exposed for tests.
   QRectF sceneBounds() const { return scene_bounds_; }
 
@@ -197,6 +205,13 @@ private:
   // (owned by the Entry). The shader + LUT + tessellation now live in renderer_.
   QOpenGLTexture* textureFor(Entry& entry);
 
+  /// [camp#103] items() body with an optional scene-space clip: a non-null
+  /// @p clip_scene keeps only tiles whose Web-Mercator extent intersects it,
+  /// tested BEFORE the lazy texture upload. Filters both pools, preserving the
+  /// overviews-first draw order (ADR-0010 LOD fallback). items() (the
+  /// RasterFieldSource interface) delegates with a null rect.
+  QList<raster::RasterFieldItem> itemsIntersecting(const QRectF& clip_scene);
+
   static constexpr int kMaxImageEdge = 4096;
 
   // [camp#160] Overview tiles at level <= this coarse "apex" are never evicted, so a
@@ -277,8 +292,12 @@ private:
   std::vector<QFutureWatcher<void>*> write_watchers_;
   bool shutting_down_ = false;
 
+  // [camp#103] Last render, keyed by FBO size AND viewport clip: zoom changes
+  // the size, pan changes the clip, so both re-render (the FBO is viewport-sized,
+  // so the per-frame pan re-render is cheap).
   QImage cached_image_;
   QSize cached_size_;
+  QRectF cached_clip_;
 };
 
 }  // namespace live_coverage

--- a/test/test_gggs_render.cpp
+++ b/test/test_gggs_render.cpp
@@ -18,10 +18,12 @@
 #include <gdal_priv.h>
 
 #include <QApplication>
+#include <QGraphicsView>
 #include <QImage>
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
 #include <QTemporaryDir>
+#include <QTransform>
 
 #include "map/map.h"
 #include "map/layer_list.h"
@@ -462,6 +464,89 @@ TEST(GggsRenderTest, ClipRenderScalesResolutionToClip)
   // Same band, half the scene width, same image width -> ~2x the columns.
   EXPECT_GT(clip_cols, full_cols * 3 / 2);
   img_clip.save("/tmp/gggs_clip_res.png");
+}
+
+// [camp#103] Paint-path regression: with a view ATTACHED, paint() must render at
+// the view's resolution — the field bug was a whole-extent <=4096px render
+// upscaled over the viewport (blurry). This drives the REAL paint() path through
+// a QGraphicsView (grab()), not renderImage() directly, so the viewport
+// derivation itself is under test: the derivation must come from the attached
+// view (painter clip state is unreliable — empty on live full-viewport
+// repaints). A 2000x2000 per-pixel checkerboard zoomed to 40 screen-px per data
+// cell makes the whole extent 80000 screen px (>> 4096): the fixed path renders
+// the viewport crisp (pixels cluster at the two LUT extremes), the broken path
+// renders cells at ~2px in the 4096-clamped image and upscales ~20x with
+// smoothing, smearing most pixels into mid-tones (verified fails-without-fix).
+TEST(GggsRenderTest, ViewAttachedPaintRendersAtViewResolution)
+{
+  if(!offscreenGLAvailable())
+    GTEST_SKIP() << "no offscreen GL context available";
+
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+
+  const int w = 2000, h = 2000;
+  const double geo[6] = {-71.40, 0.00002, 0.0, 43.00, 0.0, -0.00002};
+  std::vector<uint16_t> samples(w * h);
+  for(int r = 0; r < h; ++r)
+    for(int c = 0; c < w; ++c)
+      samples[r * w + c] = ((r + c) % 2) ? 60000 : 20000;   // per-pixel checker
+  ASSERT_FALSE(writeTile(dir, w, h, geo, samples).isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->waitForLoad();
+
+  const QRectF sb = layer->sceneBounds();
+  const double cell_m = sb.width() / w;
+  const double scale = 40.0 / cell_m;   // 40 screen px per data cell
+
+  QGraphicsView view(map.scene());
+  view.resize(400, 300);
+  // Match MapView's convention: scale(s, -s) composes with the layer's
+  // fromScale(1,-1) to a net-upright draw.
+  view.setTransform(QTransform::fromScale(scale, -scale));
+  view.centerOn(QPointF(sb.center().x(), sb.center().y()));
+  view.show();
+  QApplication::processEvents();
+  // AFTER scene-add/settings side effects: tile-set layers default to
+  // hidden (camp#102 readSettings false-fallback), which would leave the
+  // grab blank white.
+  layer->setVisible(true);
+  QApplication::processEvents();
+
+  // Grab the viewport widget only (no frame/scrollbars).
+  const QImage img = view.viewport()->grab().toImage();
+  ASSERT_FALSE(img.isNull());
+  img.save("/tmp/gggs_view_paint.png");
+
+  // Sample the central region (well inside the tile). Crisp = the checker's two
+  // LUT extremes each cover ~half the pixels; blurred = mid-tones dominate;
+  // blank/white (layer didn't paint) = no dark pixels at all. Requiring BOTH
+  // extremes discriminates all three.
+  int sampled = 0, dark = 0, mid = 0;
+  for(int y = img.height() / 4; y < 3 * img.height() / 4; ++y)
+    for(int x = img.width() / 4; x < 3 * img.width() / 4; ++x)
+    {
+      const int red = img.pixelColor(x, y).red();
+      ++sampled;
+      if(red < 60)
+        ++dark;
+      else if(red <= 200)
+        ++mid;
+    }
+  ASSERT_GT(sampled, 1000);
+  // Presence: a blank grab (layer never painted) has no dark cells at all; a
+  // crisp checker is ~half dark. Crispness: the broken whole-extent upscale
+  // smears ~half the pixels into mid-tones (measured 0.5); the crisp render has
+  // almost none. Together the two discriminate blank, blurred, and crisp.
+  EXPECT_GT(double(dark) / sampled, 0.25)
+    << "dark checker cells missing — layer blank or washed out (fraction "
+    << double(dark) / sampled << ")";
+  EXPECT_LT(double(mid) / sampled, 0.15)
+    << "mid-tone fraction " << double(mid) / sampled
+    << " — paint() rendered blurred; viewport derivation regressed";
 }
 
 int main(int argc, char** argv)

--- a/test/test_gggs_render.cpp
+++ b/test/test_gggs_render.cpp
@@ -31,11 +31,12 @@ namespace
 {
 
 QString writeTile(const QTemporaryDir& dir, int w, int h, const double geo[6],
-                  const std::vector<uint16_t>& samples)
+                  const std::vector<uint16_t>& samples,
+                  const QString& name = "13_0_0.tif")
 {
   if(GDALGetDriverCount() == 0)
     GDALAllRegister();
-  const QString path = dir.filePath("13_0_0.tif");
+  const QString path = dir.filePath(name);
   GDALDriver* driver = GetGDALDriverManager()->GetDriverByName("GTiff");
   // [camp#122] Guard the GDAL handles so a driver/create failure fails the test
   // cleanly instead of dereferencing null. (These helpers return QString, so a
@@ -338,6 +339,129 @@ TEST(GggsRenderTest, RealStoreRendersWhenProvided)
   const QImage img = layer->renderImage(QSize(900, 900));
   ASSERT_FALSE(img.isNull());
   img.save("/tmp/gggs_real.png");
+}
+
+// [camp#103] The clip-aware renderImage(size, clip) must (a) render ONLY the
+// clipped region — a clip covering tile A yields an image of A's pixels alone —
+// and (b) keep tiles that PARTIALLY intersect the clip (a straddling clip shows
+// both tiles). Two horizontally-adjacent uniform tiles with distinct values are
+// distinguishable through the auto-ranged grayscale LUT (A=max -> bright,
+// B=min -> dark, both opaque; outside coverage transparent).
+TEST(GggsRenderTest, ClipFilterRendersOnlyIntersectingTiles)
+{
+  if(!offscreenGLAvailable())
+    GTEST_SKIP() << "no offscreen GL context available";
+
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+
+  const int w = 100, h = 100;
+  // Tile A spans lon [-71.40, -71.39]; tile B spans [-71.39, -71.38]; both span
+  // lat [42.99, 43.00] (north-up, row 0 = north edge).
+  const double geo_a[6] = {-71.40, 0.0001, 0.0, 43.00, 0.0, -0.0001};
+  const double geo_b[6] = {-71.39, 0.0001, 0.0, 43.00, 0.0, -0.0001};
+  const std::vector<uint16_t> samples_a(w * h, 60000);   // -> LUT max: bright
+  const std::vector<uint16_t> samples_b(w * h, 20000);   // -> LUT min: dark
+  ASSERT_FALSE(writeTile(dir, w, h, geo_a, samples_a, "13_0_0.tif").isEmpty());
+  ASSERT_FALSE(writeTile(dir, w, h, geo_b, samples_b, "13_0_1.tif").isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->waitForLoad();
+
+  const QRectF sb = layer->sceneBounds();
+  auto countPixels = [](const QImage& img, int& bright, int& dark)
+  {
+    bright = dark = 0;
+    for(int y = 0; y < img.height(); ++y)
+      for(int x = 0; x < img.width(); ++x)
+      {
+        const QColor px = img.pixelColor(x, y);
+        if(px.alpha() == 0)
+          continue;
+        if(px.red() > 200)
+          ++bright;
+        else if(px.red() < 60)
+          ++dark;
+      }
+  };
+
+  // Full extent: both tiles contribute.
+  int bright = 0, dark = 0;
+  countPixels(layer->renderImage(QSize(200, 100)), bright, dark);
+  EXPECT_GT(bright, 0);
+  EXPECT_GT(dark, 0);
+
+  // Clip strictly inside tile A's (western) half: only A's pixels appear.
+  const QRectF clip_a(sb.left(), sb.top(), sb.width() * 0.45, sb.height());
+  const QImage img_a = layer->renderImage(QSize(100, 100), clip_a);
+  ASSERT_FALSE(img_a.isNull());
+  countPixels(img_a, bright, dark);
+  EXPECT_GT(bright, 0);
+  EXPECT_EQ(dark, 0);
+  img_a.save("/tmp/gggs_clip_a.png");
+
+  // Clip straddling the A|B boundary: BOTH partially-intersecting tiles are
+  // kept (the intersect predicate must not drop a partially-visible tile).
+  const QRectF clip_mid(sb.left() + sb.width() * 0.25, sb.top(),
+                        sb.width() * 0.5, sb.height());
+  countPixels(layer->renderImage(QSize(100, 100), clip_mid), bright, dark);
+  EXPECT_GT(bright, 0);
+  EXPECT_GT(dark, 0);
+}
+
+// [camp#103] The clip render's pixel density scales with the CLIP, not the whole
+// extent — the fix for the field-observed blur. The "L" tile's bright west band
+// is 10% of the tile width; rendered at the same image size, a west-half clip
+// makes that band span ~twice as many image columns as the full-extent render.
+TEST(GggsRenderTest, ClipRenderScalesResolutionToClip)
+{
+  if(!offscreenGLAvailable())
+    GTEST_SKIP() << "no offscreen GL context available";
+
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+
+  const int w = 100, h = 100;
+  const double geo[6] = {-71.40, 0.0001, 0.0, 43.00, 0.0, -0.0001};
+  std::vector<uint16_t> samples(w * h, 8000);
+  for(int r = 0; r < h; ++r)
+    for(int c = 0; c < w; ++c)
+      if(c < 10)                             // bright west band only
+        samples[r * w + c] = 60000;
+  ASSERT_FALSE(writeTile(dir, w, h, geo, samples).isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->waitForLoad();
+
+  auto brightColumns = [](const QImage& img)
+  {
+    int cols = 0;
+    for(int x = 0; x < img.width(); ++x)
+      for(int y = 0; y < img.height(); ++y)
+        if(img.pixelColor(x, y).alpha() > 0 && img.pixelColor(x, y).red() > 200)
+        {
+          ++cols;
+          break;
+        }
+    return cols;
+  };
+
+  const QSize size(200, 200);
+  const int full_cols = brightColumns(layer->renderImage(size));
+  const QRectF sb = layer->sceneBounds();
+  const QRectF west_half(sb.left(), sb.top(), sb.width() * 0.5, sb.height());
+  const QImage img_clip = layer->renderImage(size, west_half);
+  ASSERT_FALSE(img_clip.isNull());
+  const int clip_cols = brightColumns(img_clip);
+
+  EXPECT_GT(full_cols, 0);
+  // Same band, half the scene width, same image width -> ~2x the columns.
+  EXPECT_GT(clip_cols, full_cols * 3 / 2);
+  img_clip.save("/tmp/gggs_clip_res.png");
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
## Summary

Implements the **visible-region half of #103** (Part of #103 — does NOT close it; the pyramid-LOD half is deferred pending store overview pyramids, unh_marine_autonomy#188).

All three raster layers (`GggsTileLayer`, `RasterLayer`, `SonarLiveCacheLayer`) now render only the viewport-visible clip of their extent, sized to its on-screen pixels, instead of one whole-extent ≤4096 px image upscaled over `boundingRect()` — fixing the field-observed zoomed-in blur (2026-07-23) on stores larger than `kMaxImageEdge`.

## Design (ADR-0011)

- Shared `raster/viewport_clip.h` derives the clip from `painter->clipBoundingRect()` — **not** `exposedRect`, which silently defaults to the full bounding rect without `ItemUsesExtendedStyleOption` (set nowhere in camp). Empty clip falls back to the whole extent (headless/test renders unchanged).
- Clip-aware public `renderImage(size, clip_bounds)` overloads pass the clip as `renderToImage()`'s `scene_bounds` — **no `RasterGlRenderer` API change** (ADR-0007 seam).
- Tiled sources filter tiles against the clip **before** the lazy texture upload; the live layer filters both pools preserving the overviews-first LOD-fallback order (ADR-0010). This is also the natural seam for camp#172's on-demand reload (not implemented here).
- Cache keyed by FBO size AND clip: pan re-renders (cheap at viewport size).

## Testing

- 160 tests, 0 failures (worktree host build). Two new headless GL tests: clip filter keeps partial intersections / excludes disjoint tiles; clip-render pixel density scales with the clip (the blur fix).
- **Manual GUI verification recommended before merge** (reviewer suggestion — headless tests exercise the clip seam, not `paint()`'s live derivation): `source layers/worktrees/issue-camp-103/ui_ws/install/setup.bash; ros2 launch camp camp_launch.py` → open a large store (e.g. `~/data/stores/sidescan/processed`) → zoom in → confirm crisp rendering.

## Review

Pre-push /review-code (Deep, Opus): **approved, 0 must-fix, Ship: recommended** (round 1). Non-blocking suggestions recorded in progress.md: per-frame `geoToMap` trig during pan is O(tiles) on the GUI thread (cache tile scene-rects if large stores pan sluggishly); comment the float-equality cache key.

Plan: `.agent/work-plans/issue-103/plan.md` (review-plan verdict changes-requested → all 3 must-fixes folded; positive deviation: clip derivation factored into one shared header instead of per-layer copies).

Part of #103.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
