### PR TITLE
Per-layer smooth-interpolation opt-in for data layers — default unblended (Closes #132)

### DIFF
--- a/.agent/work-plans/issue-132/plan.md
+++ b/.agent/work-plans/issue-132/plan.md
@@ -25,46 +25,46 @@ RGBA charts and basemap/OSM/WMTS imagery must stay smoothed unconditionally
 (not data under QA). The colormap LUT texture stays Linear (it's a color ramp,
 not data — correct as-is).
 
-The PR targets `feature/issue-103` (stacked).
+The PR targets `jazzy` (#103 / PR#173 merged 2026-07-24; this branch carries
+the landed base via a forward-merge of jazzy).
 
 ## Approach
 
-1. **Add `smooth` field to `RasterFieldItem`** — the flag travels from layer to
-   renderer so the GL filter decision stays centralized in `RasterGlRenderer`.
+**Plan-review must-fix 1 (folded): the GL Scalar filter stays `Nearest`
+ALWAYS.** Driving it from the toggle would reintroduce the camp#122 NoData
+halo — Linear filtering blends the finite NoData sentinel with neighboring
+data into fabricated values the shader's exact-equality discard can't catch
+(the property `test_raster_gl_renderer.cpp:114-115` guards). The toggle
+governs ONLY the QPainter blit hint; a true GL smooth mode (NoData→NaN at
+upload) is out of scope.
 
-2. **Add `smooth_interpolation_` member to each data layer** — default `false`
-   (Nearest). Non-scalar `RasterLayer` (RGBA charts) always renders smooth
+1. **Add `smooth_interpolation_` member to each data layer** — default `false`
+   (Nearest). Non-scalar `RasterLayer` (RGBA charts) always blits smooth
    regardless; the toggle and its persistence are Scalar-only.
 
-3. **Update `RasterGlRenderer::renderToImage`** — for Scalar items, use
-   `item.smooth ? Linear : Nearest` instead of always Nearest. Rgba path
-   stays `Linear` as today.
+2. **Condition `SmoothPixmapTransform` in each `paint()`** on the flag
+   (`RasterLayer`: `smooth_interpolation_ || !is_scalar_`).
 
-4. **Set `item.smooth` in each layer's `items()` / `itemsIntersecting()`** so
-   the renderer picks up the per-layer choice.
-
-5. **Condition `SmoothPixmapTransform` in each `paint()`** on the same flag,
-   so the QPainter blit matches the GL filter.
-
-6. **Add context-menu toggle** — checkable "Smooth interpolation" action in each
+3. **Add context-menu toggle** — checkable "Smooth interpolation" action in each
    layer's `contextMenu()`. `RasterLayer` gates it behind the existing
    `if(!is_scalar_) return;` guard (same gate as Colormap/Range).
 
-7. **Persist** `smooth_interpolation_` via `readSettings`/`writeSettings` under
-   key `"smooth_interpolation"` in the existing `MapItem/<settingsKey()>` group.
+4. **Persist** `smooth_interpolation_` via `readSettings`/`writeSettings` under
+   key `"smooth_interpolation"` in **each layer's EXISTING settings group**
+   (plan-review must-fix 2): `GggsTileLayer`/`SonarLiveCacheLayer` use
+   `MapItem/<settingsKey()>`; `RasterLayer` persists under `MapItem/<itemID()>`
+   (raster_layer.cpp:558-559,608-609) — do NOT move it to settingsKey().
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `src/camp_map/raster/raster_field_source.h` | Add `bool smooth = false` to `RasterFieldItem` |
-| `src/camp_map/raster/raster_gl_renderer.cpp` | Scalar filter: `item.smooth ? Linear : Nearest` |
 | `src/camp_map/raster/gggs_tile_layer.h` | Add `bool smooth_interpolation_ = false` |
-| `src/camp_map/raster/gggs_tile_layer.cpp` | Set `item.smooth` in `itemsIntersecting()`; condition `paint()` hint; add context-menu toggle; read/write settings |
+| `src/camp_map/raster/gggs_tile_layer.cpp` | Condition `paint()` hint; add context-menu toggle; read/write settings (settingsKey group) |
 | `src/camp_map/raster/raster_layer.h` | Add `bool smooth_interpolation_ = false` |
-| `src/camp_map/raster/raster_layer.cpp` | Set `item.smooth` in `items()`; condition `paint()` hint (`smooth_interpolation_ \|\| !is_scalar_`); add context-menu toggle (scalar-gated); read/write settings |
+| `src/camp_map/raster/raster_layer.cpp` | Condition `paint()` hint (`smooth_interpolation_ \|\| !is_scalar_`); add context-menu toggle (scalar-gated); read/write settings (itemID group) |
 | `src/camp_map/ros/live_coverage/sonar_live_cache_layer.h` | Add `bool smooth_interpolation_ = false` |
-| `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp` | Set `item.smooth` in `itemsIntersecting()`; condition `paint()` hint; add context-menu toggle; read/write settings |
+| `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp` | Condition `paint()` hint; add context-menu toggle; read/write settings (settingsKey group) |
 
 Paths relative to `ui_ws/src/camp/`.
 
@@ -89,18 +89,19 @@ Paths relative to `ui_ws/src/camp/`.
 
 | If we change... | Also update... | Included in plan? |
 |---|---|---|
-| `RasterFieldItem` (add `smooth`) | `items()` callers in all three layers | Yes |
-| `RasterGlRenderer::renderToImage` Scalar filter logic | `test_raster_gl_renderer.cpp` if it asserts filter state | Verify in step 3 — no existing filter-state test found; likely no change needed |
+| GL filter behavior | NOTHING — the GL Scalar filter is untouched (must-fix 1); `test_raster_gl_renderer.cpp:114-115` (Nearest / no-bleed assertion) keeps passing unchanged | Yes |
 | `paint()` in all three layers | No other callers of `cached_image_` | Yes — no other blit sites |
 | Per-layer persistence | `readSettings`/`writeSettings` in each layer | Yes |
 
 ## Open Questions
 
-- None — approach is fully specified by orchestrator context. RGBA `RasterLayer`
-  (palette/RGB charts) always gets `smooth = true` via `format_ == Format::Rgba`
-  check; the context-menu toggle is scalar-only, matching the existing Colormap gate.
-  No operator confirmation needed before implementation.
+- None. RGBA `RasterLayer` (palette/RGB charts) always blits smooth; the
+  context-menu toggle is scalar-only, matching the existing Colormap gate.
+- PR description must record the default-Nearest QA rationale (plan-review
+  suggestion): interpolation fabricates values that aren't in the data and can
+  mask the artifacts the operator is looking for; Nearest is the faithful
+  default for data under QA, smoothing is the opt-in.
 
 ## Estimated Scope
 
-Single stacked PR targeting `feature/issue-103`.
+Single PR targeting `jazzy` (~60-line diff + toggle wiring).

--- a/.agent/work-plans/issue-132/plan.md
+++ b/.agent/work-plans/issue-132/plan.md
@@ -1,0 +1,106 @@
+# Plan: Per-layer smooth interpolation toggle for data layers
+
+## Issue
+
+camp#132 — Make data-layer QPainter blit interpolation operator-selectable
+(default Nearest/unblended for data layers; basemap/RGBA charts stay smoothed).
+
+## Context
+
+Post-#103 (this worktree branches from `feature/issue-103`), three data-layer
+`paint()` methods unconditionally set `QPainter::SmoothPixmapTransform` when
+blitting the GL-rendered QImage to the scene:
+
+- `gggs_tile_layer.cpp` (GGGS tile stores)
+- `raster_layer.cpp` (single-GeoTIFF scalar and palette/RGB charts)
+- `sonar_live_cache_layer.cpp` (live sonar coverage)
+
+The GL texture filter for Scalar data is already `Nearest` (camp#122), so
+`SmoothPixmapTransform` is the remaining smoothing source. With the
+viewport-sized FBO from #103, the blit is ~1:1, so the softening is sub-pixel
+only — but it still affects cell-faithful QA rendering. The operator wants to
+A/B Nearest vs smoothed on real data.
+
+RGBA charts and basemap/OSM/WMTS imagery must stay smoothed unconditionally
+(not data under QA). The colormap LUT texture stays Linear (it's a color ramp,
+not data — correct as-is).
+
+The PR targets `feature/issue-103` (stacked).
+
+## Approach
+
+1. **Add `smooth` field to `RasterFieldItem`** — the flag travels from layer to
+   renderer so the GL filter decision stays centralized in `RasterGlRenderer`.
+
+2. **Add `smooth_interpolation_` member to each data layer** — default `false`
+   (Nearest). Non-scalar `RasterLayer` (RGBA charts) always renders smooth
+   regardless; the toggle and its persistence are Scalar-only.
+
+3. **Update `RasterGlRenderer::renderToImage`** — for Scalar items, use
+   `item.smooth ? Linear : Nearest` instead of always Nearest. Rgba path
+   stays `Linear` as today.
+
+4. **Set `item.smooth` in each layer's `items()` / `itemsIntersecting()`** so
+   the renderer picks up the per-layer choice.
+
+5. **Condition `SmoothPixmapTransform` in each `paint()`** on the same flag,
+   so the QPainter blit matches the GL filter.
+
+6. **Add context-menu toggle** — checkable "Smooth interpolation" action in each
+   layer's `contextMenu()`. `RasterLayer` gates it behind the existing
+   `if(!is_scalar_) return;` guard (same gate as Colormap/Range).
+
+7. **Persist** `smooth_interpolation_` via `readSettings`/`writeSettings` under
+   key `"smooth_interpolation"` in the existing `MapItem/<settingsKey()>` group.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/camp_map/raster/raster_field_source.h` | Add `bool smooth = false` to `RasterFieldItem` |
+| `src/camp_map/raster/raster_gl_renderer.cpp` | Scalar filter: `item.smooth ? Linear : Nearest` |
+| `src/camp_map/raster/gggs_tile_layer.h` | Add `bool smooth_interpolation_ = false` |
+| `src/camp_map/raster/gggs_tile_layer.cpp` | Set `item.smooth` in `itemsIntersecting()`; condition `paint()` hint; add context-menu toggle; read/write settings |
+| `src/camp_map/raster/raster_layer.h` | Add `bool smooth_interpolation_ = false` |
+| `src/camp_map/raster/raster_layer.cpp` | Set `item.smooth` in `items()`; condition `paint()` hint (`smooth_interpolation_ \|\| !is_scalar_`); add context-menu toggle (scalar-gated); read/write settings |
+| `src/camp_map/ros/live_coverage/sonar_live_cache_layer.h` | Add `bool smooth_interpolation_ = false` |
+| `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp` | Set `item.smooth` in `itemsIntersecting()`; condition `paint()` hint; add context-menu toggle; read/write settings |
+
+Paths relative to `ui_ws/src/camp/`.
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Toggle is per-layer in the context menu the operator already uses; default Nearest preserves the faithful QA baseline; behavior is visible and reversible |
+| Capture decisions, not just implementations | This plan explains why basemap/LUT stay Linear and why the flag lives on `RasterFieldItem` rather than being passed as a separate render arg |
+| A change includes its consequences | Tests checked; `raster_gl_renderer.cpp` is the one filter-decision site — no duplicated logic |
+| Only what's needed | No global setting added; no new widget; no new class; the toggle reuses the existing context-menu + QSettings pattern |
+| Improve incrementally | Stacked on #103; single PR, small diff |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0007 (unified GL render path) | Yes | Filter decision stays in `RasterGlRenderer::renderToImage`, not in individual layers — consistent with the "ONE render path" intent |
+| ADR-0008 (LUT stays identity-transfer) | No | LUT texture filter unchanged (Linear, correct — it's a color ramp) |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `RasterFieldItem` (add `smooth`) | `items()` callers in all three layers | Yes |
+| `RasterGlRenderer::renderToImage` Scalar filter logic | `test_raster_gl_renderer.cpp` if it asserts filter state | Verify in step 3 — no existing filter-state test found; likely no change needed |
+| `paint()` in all three layers | No other callers of `cached_image_` | Yes — no other blit sites |
+| Per-layer persistence | `readSettings`/`writeSettings` in each layer | Yes |
+
+## Open Questions
+
+- None — approach is fully specified by orchestrator context. RGBA `RasterLayer`
+  (palette/RGB charts) always gets `smooth = true` via `format_ == Format::Rgba`
+  check; the context-menu toggle is scalar-only, matching the existing Colormap gate.
+  No operator confirmation needed before implementation.
+
+## Estimated Scope
+
+Single stacked PR targeting `feature/issue-103`.

--- a/.agent/work-plans/issue-132/progress.md
+++ b/.agent/work-plans/issue-132/progress.md
@@ -1,0 +1,71 @@
+---
+issue: 132
+---
+
+# Issue #132 — Operator-selectable data-layer interpolation (Nearest default)
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-24 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #132
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Summary
+
+Issue #132 proposes making interpolation mode for data layers operator-selectable,
+defaulting to Nearest (faithful/unblended) — an operator request following camp#122
+which fixed the GGGS data texture but left three QPainter blit sites still applying
+`SmoothPixmapTransform`. The suggested shape: per-layer `smooth_interpolation_` bool
+(default false), persisted via `settingsKey()`, plumbed to `RasterGlRenderer` via a
+`smooth` flag on `RasterFieldItem`, with a context-menu toggle. Basemap/OSM/WMTS/chart
+imagery stays smoothed unconditionally.
+
+### Scope
+
+- **Well-scoped?** Yes — one PR can add the bool, persist it, wire the context-menu item,
+  plumb it through `RasterFieldItem`, and update the three blit sites. No sub-splitting needed.
+- **Right repo?** Yes — all changes are in `camp` (project repo, `ui_ws`).
+- **Dependencies?** Critical: this worktree branches from `feature/issue-103` (PR#173, OPEN,
+  approved, awaiting operator merge). The PR for #132 **must target `feature/issue-103`** (stacked PR),
+  not `jazzy`. The diff description must not re-include #103's commits.
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Human control and transparency | OK | Operator-selectable toggle with clear default (Nearest); per-layer control is more transparent than a hidden blit hint |
+| Only what's needed | OK | Minimal scope — adds one bool per layer class, one settings key, one menu item; no speculative additions |
+| Improve incrementally | OK | Follows up camp#122's texture-level fix; completes the Nearest path without a blanket change |
+| Capture decisions, not just implementations | Watch | The default-Nearest-for-data-layers design decision is meaningful; the PR rationale (or a follow-up ADR) should record *why* this is the default — fabrication risk in QA context |
+| A change includes its consequences | Watch | RGBA chart layers (`raster_layer.cpp`) have mipmaps and use `Linear`/`LinearMipMapLinear` in the GL renderer; verify that the smooth=false path in `RasterGlRenderer` does not accidentally set `Nearest` on chart-type `RasterLayer` instances (the orchestrator context says RGBA chart/basemap should stay smoothed) |
+| Test what breaks | Watch | Rendering behavior is hard to unit-test, but if any snapshot/integration tests exist for the map view, they may need updating to reflect the default Nearest appearance |
+| Workspace vs. project separation | OK | All changes are project-repo (camp) code |
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Already in worktree `issue-camp-132`; OK |
+| 0013 — progress.md vocabulary | Yes | This entry; OK |
+| 0001 — Adopt ADRs | Watch | Default-Nearest-for-data-layers is a meaningful persistent design decision; capturing it in an ADR or PR description is recommended so it isn't accidentally reverted in a future "let's make things smoother" change |
+
+### Consequences
+
+- Changing `SmoothPixmapTransform` behavior in `gggs_tile_layer.cpp`, `raster_layer.cpp`,
+  `sonar_live_cache_layer.cpp`: check whether any operator documentation or onboarding material
+  describes the current rendering behavior that would need updating.
+- The `RasterGlRenderer` currently branches on `Scalar` vs `Rgba` for texture filters. If
+  `smooth` is plumbed as a flag on `RasterFieldItem`, ensure the flag is ignored (or always
+  smooth=true) for Rgba items representing charts — so the per-layer toggle applies only to data
+  layers, not accidentally to chart rasters routed through the same renderer.
+- `settingsKey()`-persisted preference: verify the key namespace doesn't collide with existing
+  per-layer settings from camp#126.
+
+### Actions
+- [ ] Verify that the `smooth` flag path in `RasterGlRenderer` does not override Nearest→Linear for Rgba chart rasters (RGBA chart layers must remain smoothed regardless of per-layer toggle).
+- [ ] Ensure the stacked PR targets `feature/issue-103`, not `jazzy`; PR diff description should not include #103 commits.
+- [ ] Add a note in the PR description capturing *why* Nearest is the default (QA use case: interpolation fabricates values, masking artifacts the operator is looking for).
+- [ ] Check for any snapshot or integration tests that render the map view and may need updating to reflect the new Nearest default appearance.

--- a/.agent/work-plans/issue-132/progress.md
+++ b/.agent/work-plans/issue-132/progress.md
@@ -81,3 +81,23 @@ imagery stays smoothed unconditionally.
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-24 18:38 +00:00
+**By**: Claude Code Agent (Claude Opus)
+<!-- Independent review: the Plan Authored entry's agent-name portion matches
+     $AGENT_NAME ("Claude Code Agent"), but that is a workspace naming artifact —
+     this review is a fresh-context dispatch on a different model (Sonnet authored,
+     Opus reviewed), so no "author self-review" annotation is applied. -->
+
+**Plan**: `.agent/work-plans/issue-132/plan.md` at `236b128`
+**PR**: PR-less (--issue / worktree mode)
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) GL Scalar filter driven by `smooth` (steps 1 & 3) reintroduces the camp#122 NoData halo — a finite sentinel linearly blends with real data into a fabricated cell that no longer `== u_nodata` and isn't discarded (the property `test_raster_gl_renderer.cpp:114-115` guards). Toggle only the QPainter blit hint; keep GL Scalar filter Nearest always (drops steps 1 & 3). — `plan.md:32-44`
+- [ ] (must-fix) Step 7 assumes `MapItem/<settingsKey()>` for all three layers, but `RasterLayer` persists under `MapItem/itemID()`, NOT `settingsKey()` (raster_layer.cpp:558-559,608-609; note at :566-567). Match each layer's existing group. — `plan.md:53-54`
+- [ ] (suggestion) Consequences claim "no existing filter-state test found" is false — `test_raster_gl_renderer.cpp:7,114-115` asserts Nearest scalar sampling / no bleed. If the GL-filter coupling is kept, add a smooth=true scalar test. — `plan.md:93`
+- [ ] (suggestion) Record the default-Nearest QA rationale in the PR description (review-issue Action 3 / ADR-0001 watch) — plan explains basemap/LUT/flag-placement but not why Nearest is the data-layer default. — `plan.md:76`
+- [ ] (note) Confirm layer-render/persistence tests (`test_gggs_render.cpp`, `test_gggs_persistence.cpp`, `test_depth_raster.cpp`) need no changes — default behavior unchanged, low risk. — review-issue Action 4

--- a/.agent/work-plans/issue-132/progress.md
+++ b/.agent/work-plans/issue-132/progress.md
@@ -69,3 +69,15 @@ imagery stays smoothed unconditionally.
 - [ ] Ensure the stacked PR targets `feature/issue-103`, not `jazzy`; PR diff description should not include #103 commits.
 - [ ] Add a note in the PR description capturing *why* Nearest is the default (QA use case: interpolation fabricates values, masking artifacts the operator is looking for).
 - [ ] Check for any snapshot or integration tests that render the map view and may need updating to reflect the new Nearest default appearance.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-24 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-132/plan.md` at `236b128`
+**Branch**: feature/issue-132 at `236b128`
+**Phases**: single
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-132/progress.md
+++ b/.agent/work-plans/issue-132/progress.md
@@ -101,3 +101,22 @@ imagery stays smoothed unconditionally.
 - [ ] (suggestion) Consequences claim "no existing filter-state test found" is false — `test_raster_gl_renderer.cpp:7,114-115` asserts Nearest scalar sampling / no bleed. If the GL-filter coupling is kept, add a smooth=true scalar test. — `plan.md:93`
 - [ ] (suggestion) Record the default-Nearest QA rationale in the PR description (review-issue Action 3 / ADR-0001 watch) — plan explains basemap/LUT/flag-placement but not why Nearest is the data-layer default. — `plan.md:76`
 - [ ] (note) Confirm layer-render/persistence tests (`test_gggs_render.cpp`, `test_gggs_persistence.cpp`, `test_depth_raster.cpp`) need no changes — default behavior unchanged, low risk. — review-issue Action 4
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-24 19:41 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-132 at `2105e8c`
+**Mode**: pre-push
+**Depth**: Standard (reason: 9 files / ~124 code lines; no security/cross-layer/ADR Deep triggers)
+**Must-fix**: 0 | **Suggestions**: 3
+**Round**: 1 | **Ship**: recommended — no must-fix; both adversarial passes + static/governance/plan-drift converged clean; plan-review must-fixes verified folded (GL filter untouched; Raster persists under itemID()).
+
+**Specialists**: Static Analysis (ament_cpplint + cppcheck — clean on changed lines) · Governance · Plan Drift · Claude Adversarial x2 (Lens A + Lens B) · Local Adversarial skipped (no Ollama server at http://localhost:11434). Copilot off (default).
+
+### Findings
+- [ ] (suggestion) Persistence round-trip tested for GggsTileLayer only; RasterLayer (itemID group) and SonarLiveCacheLayer (settingsKey group) untested — a future group/key mismatch would go uncaught; harnesses already exist. Cross-pass confirmed (Lens A + Lens B + Governance). — `test/test_range_persist.cpp:127`
+- [ ] (suggestion) For non-scalar (RGBA) RasterLayer the setSmoothInterpolation setter + persistence are dead (menu gated out, paint forces smooth via `|| !is_scalar_`); harmless but writes/reads a pointless key — drop, gate, or note as intentionally inert. — `src/camp_map/raster/raster_layer.cpp:566`
+- [ ] (suggestion) Record the default-Nearest QA rationale in the PR description when opening the PR (plan-review Action 3 / ADR-0001 watch). — PR body

--- a/src/camp_map/raster/gggs_tile_layer.cpp
+++ b/src/camp_map/raster/gggs_tile_layer.cpp
@@ -490,9 +490,20 @@ void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QW
     return;
 
   painter->save();
-  painter->setRenderHint(QPainter::SmoothPixmapTransform);
+  // [camp#132] Smoothing is operator-opt-in per layer; the default Nearest blit
+  // keeps data cells faithful for QA (the GL data filter is Nearest regardless).
+  painter->setRenderHint(QPainter::SmoothPixmapTransform, smooth_interpolation_);
   painter->drawImage(clip.local, cached_image_);
   painter->restore();
+}
+
+void GggsTileLayer::setSmoothInterpolation(bool smooth)
+{
+  if(smooth == smooth_interpolation_)
+    return;
+  smooth_interpolation_ = smooth;
+  writeSettings();
+  update(boundingRect());   // blit-hint-only change: no re-render needed
 }
 
 void GggsTileLayer::setColormap(const std::string& name)
@@ -657,6 +668,15 @@ void GggsTileLayer::contextMenu(QMenu* menu)
   QAction* rescan_action = menu->addAction("Rescan");
   connect(rescan_action, &QAction::triggered, this, [this]() { rescan(); });
 
+  // [camp#132] Per-layer blit-smoothing opt-in (default OFF = Nearest, the
+  // faithful-QA baseline; interpolation fabricates values that aren't in the
+  // data and can mask the artifacts the operator is looking for).
+  QAction* smooth_action = menu->addAction("Smooth interpolation");
+  smooth_action->setCheckable(true);
+  smooth_action->setChecked(smooth_interpolation_);
+  connect(smooth_action, &QAction::triggered, this,
+          [this](bool on) { setSmoothInterpolation(on); });
+
   // [camp#141] Expose the FULL marine_colormap registry (grayscale/bronze/thermal/
   // viridis/turbo/quality), not just the three legacy ramps.
   QMenu* colormap_menu = menu->addMenu("Colormap");
@@ -762,6 +782,8 @@ void GggsTileLayer::readSettings()
     settings.contains("range_min") && settings.contains("range_max");
   const float range_min = settings.value("range_min", 0.0).toFloat();
   const float range_max = settings.value("range_max", 1.0).toFloat();
+  // [camp#132] Persisted blit-smoothing opt-in (default OFF = Nearest).
+  smooth_interpolation_ = settings.value("smooth_interpolation", false).toBool();
   settings.endGroup();
   settings.endGroup();
   if(colormap != renderer_.colormap())
@@ -794,6 +816,7 @@ void GggsTileLayer::writeSettings()
                                                                               : "auto");
   settings.setValue("range_min", range_model_.lo());
   settings.setValue("range_max", range_model_.hi());
+  settings.setValue("smooth_interpolation", smooth_interpolation_);   // [camp#132]
   settings.endGroup();
   settings.endGroup();
 }

--- a/src/camp_map/raster/gggs_tile_layer.h
+++ b/src/camp_map/raster/gggs_tile_layer.h
@@ -116,6 +116,15 @@ public:
   /// QSettings. No-op if @p band is out of range or unchanged.
   void setBand(int band);
 
+  /// [camp#132] Toggle the QPainter blit smoothing for this layer's paint()
+  /// (default OFF = Nearest, the faithful-QA baseline). Governs ONLY the blit
+  /// hint — the GL scalar data-texture filter stays Nearest always (a Linear
+  /// filter would blend the finite NoData sentinel into fabricated values the
+  /// shader's exact-equality discard can't catch — the camp#122 halo).
+  /// Persists and repaints.
+  void setSmoothInterpolation(bool smooth);
+  bool smoothInterpolation() const { return smooth_interpolation_; }
+
   /// [camp#108] Test-only: the 1-indexed band each held tile is currently set to
   /// read, in tile order. Exposed as the narrow, GL-free seam a headless test uses
   /// to assert applyBand()/rescan() propagated the layer band to EVERY tile (the
@@ -197,6 +206,7 @@ private:
 
   QString directory_;
   int band_ = 1;               // [camp#108] selected 1-indexed band (persisted)
+  bool smooth_interpolation_ = false;   // [camp#132] blit hint only (persisted)
   std::vector<std::unique_ptr<GggsTile>> tiles_;
   QRectF scene_bounds_;        // union of tile extents in Web-Mercator scene units
   double data_min_ = 1.0;      // auto-range over all tiles (crossed => no data)

--- a/src/camp_map/raster/raster_layer.cpp
+++ b/src/camp_map/raster/raster_layer.cpp
@@ -565,6 +565,11 @@ void RasterLayer::contextMenu(QMenu* menu)
 
 void RasterLayer::setSmoothInterpolation(bool smooth)
 {
+  // For non-scalar (RGBA) charts this setter and its persisted key are
+  // intentionally inert: the context-menu toggle is scalar-gated and paint()
+  // forces a smooth blit via `|| !is_scalar_` — imagery is not data under QA.
+  // Kept unconditional so a file later re-opened as scalar honors the stored
+  // preference.
   if(smooth == smooth_interpolation_)
     return;
   smooth_interpolation_ = smooth;

--- a/src/camp_map/raster/raster_layer.cpp
+++ b/src/camp_map/raster/raster_layer.cpp
@@ -95,7 +95,11 @@ void RasterLayer::paint(QPainter *painter, const QStyleOptionGraphicsItem *optio
     return;
 
   painter->save();
-  painter->setRenderHint(QPainter::SmoothPixmapTransform);
+  // [camp#132] Scalar (data) charts default to a faithful Nearest blit with a
+  // per-layer opt-in; RGBA charts (palette/RGB imagery, not data under QA)
+  // always blit smooth.
+  painter->setRenderHint(QPainter::SmoothPixmapTransform,
+                         smooth_interpolation_ || !is_scalar_);
   painter->drawImage(clip.local, cached_image_);
   painter->restore();
 }
@@ -518,6 +522,14 @@ void RasterLayer::contextMenu(QMenu* menu)
   map::Layer::contextMenu(menu);
   if(!is_scalar_)              // colormap only applies to scalar (depth) rasters
     return;
+
+  // [camp#132] Per-layer blit-smoothing opt-in for scalar (data) charts
+  // (default OFF = Nearest, the faithful-QA baseline).
+  QAction* smooth_action = menu->addAction("Smooth interpolation");
+  smooth_action->setCheckable(true);
+  smooth_action->setChecked(smooth_interpolation_);
+  connect(smooth_action, &QAction::triggered, this,
+          [this](bool on) { setSmoothInterpolation(on); });
   // [camp#141] Expose the FULL marine_colormap registry, not just the legacy ramps.
   QMenu* colormap_menu = menu->addMenu("Colormap");
   for(const std::string& name : marine_colormap::palette_names())
@@ -551,12 +563,23 @@ void RasterLayer::contextMenu(QMenu* menu)
   });
 }
 
+void RasterLayer::setSmoothInterpolation(bool smooth)
+{
+  if(smooth == smooth_interpolation_)
+    return;
+  smooth_interpolation_ = smooth;
+  writeSettings();
+  update(boundingRect());   // blit-hint-only change: no re-render needed
+}
+
 void RasterLayer::readSettings()
 {
   map::Layer::readSettings();
   QSettings settings;
   settings.beginGroup("MapItem");
   settings.beginGroup(itemID());
+  // [camp#132] Persisted blit-smoothing opt-in (default OFF = Nearest).
+  smooth_interpolation_ = settings.value("smooth_interpolation", false).toBool();
   // [camp#141] Persisted palette name; case-insensitive read + registry-validated
   // (unknown -> grayscale).
   std::string colormap = settings.value(
@@ -608,6 +631,7 @@ void RasterLayer::writeSettings()
   settings.beginGroup("MapItem");
   settings.beginGroup(itemID());
   settings.setValue("colormap", QString::fromStdString(renderer_.colormap()));
+  settings.setValue("smooth_interpolation", smooth_interpolation_);   // [camp#132]
   // [camp#142] Persist the colormap range mode + bounds so a Manual override (and
   // its [lo, hi]) survives a restart; Auto persists as "auto".
   settings.setValue("range_mode",

--- a/src/camp_map/raster/raster_layer.h
+++ b/src/camp_map/raster/raster_layer.h
@@ -53,6 +53,13 @@ public:
   /// the LUT — no re-warp). No effect on RGB rasters. Unknown name -> grayscale.
   void setColormap(const std::string& name);
 
+  /// [camp#132] Toggle the QPainter blit smoothing for scalar charts (default
+  /// OFF = Nearest). Blit hint only — the GL scalar filter stays Nearest
+  /// (camp#122 NoData-halo guard). RGBA charts always blit smooth. Persists
+  /// (itemID group) and repaints.
+  void setSmoothInterpolation(bool smooth);
+  bool smoothInterpolation() const { return smooth_interpolation_; }
+
   /// [#59 ADR-0003] Source file this layer renders (kept for re-render, removal,
   /// and app-state persistence of the loaded-chart list).
   const QString& filename() const { return filename_; }
@@ -167,6 +174,7 @@ private:
   QImage cached_image_;
   QSize cached_size_;
   QRectF cached_clip_;
+  bool smooth_interpolation_ = false;   // [camp#132] scalar blit hint (persisted)
   static constexpr int kMaxImageEdge = 4096;   // clamp the offscreen target
 
   // Compute the reprojected extent + Web-Mercator scene placement from file

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
@@ -930,7 +930,9 @@ void SonarLiveCacheLayer::paint(QPainter* painter, const QStyleOptionGraphicsIte
     return;
 
   painter->save();
-  painter->setRenderHint(QPainter::SmoothPixmapTransform);
+  // [camp#132] Smoothing is operator-opt-in per layer; the default Nearest blit
+  // keeps data cells faithful for QA (the GL data filter is Nearest regardless).
+  painter->setRenderHint(QPainter::SmoothPixmapTransform, smooth_interpolation_);
   painter->drawImage(clip.local, cached_image_);
   painter->restore();
 }
@@ -1007,6 +1009,14 @@ void SonarLiveCacheLayer::contextMenu(QMenu* menu)
             &SonarLiveCacheLayer::enableLiveCoverage);
   }
 
+  // [camp#132] Per-layer blit-smoothing opt-in (default OFF = Nearest, the
+  // faithful-QA baseline).
+  QAction* smooth_action = menu->addAction("Smooth interpolation");
+  smooth_action->setCheckable(true);
+  smooth_action->setChecked(smooth_interpolation_);
+  connect(smooth_action, &QAction::triggered, this,
+          [this](bool on) { setSmoothInterpolation(on); });
+
   // [camp#141] Expose the FULL marine_colormap registry, not just the legacy ramps.
   QMenu* colormap_menu = menu->addMenu("Colormap");
   for(const std::string& name : marine_colormap::palette_names())
@@ -1061,12 +1071,23 @@ void SonarLiveCacheLayer::contextMenu(QMenu* menu)
 
 // --------------------------------- persistence -------------------------------
 
+void SonarLiveCacheLayer::setSmoothInterpolation(bool smooth)
+{
+  if(smooth == smooth_interpolation_)
+    return;
+  smooth_interpolation_ = smooth;
+  writeSettings();
+  update(boundingRect());   // blit-hint-only change: no re-render needed
+}
+
 void SonarLiveCacheLayer::readSettings()
 {
   Layer::readSettings();
   QSettings settings;
   settings.beginGroup("MapItem");
   settings.beginGroup(settingsKey());
+  // [camp#132] Persisted blit-smoothing opt-in (default OFF = Nearest).
+  smooth_interpolation_ = settings.value("smooth_interpolation", false).toBool();
   // Default discovered layers OFF in the tree (like GGGS tile-sets) — the operator
   // turns coverage on explicitly.
   setVisible(settings.value("visible", false).toBool());
@@ -1119,6 +1140,7 @@ void SonarLiveCacheLayer::writeSettings()
   settings.setValue("colormap", QString::fromStdString(renderer_.colormap()));
   settings.setValue("band", QString::fromStdString(band_name_));
   settings.setValue("live_enabled", enabled_);
+  settings.setValue("smooth_interpolation", smooth_interpolation_);   // [camp#132]
   // [camp#142] Persist the colormap range mode + bounds so a Manual override (and
   // its [lo, hi]) survives a restart; Auto persists as "auto".
   settings.setValue("range_mode",

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
@@ -108,6 +108,12 @@ public:
   /// (data_min_/data_max_, folded in foldAutoRange()); Manual pins an operator
   /// [lo, hi] so an outlier band can't collapse the useful colour range. Applied at
   /// render time (shader u_min/u_max via renderToImage), transparent to the fold.
+  /// [camp#132] Toggle the QPainter blit smoothing (default OFF = Nearest).
+  /// Blit hint only — the GL scalar filter stays Nearest (camp#122 NoData-halo
+  /// guard). Persists (settingsKey group) and repaints.
+  void setSmoothInterpolation(bool smooth);
+  bool smoothInterpolation() const { return smooth_interpolation_; }
+
   void setRangeOverride(float lo, float hi);   ///< -> Manual [lo, hi]
   void resetRangeToAuto();                      ///< -> Auto (tracks the data extents)
   marine_colormap::RangeMode rangeMode() const { return range_model_.mode(); }
@@ -298,6 +304,7 @@ private:
   QImage cached_image_;
   QSize cached_size_;
   QRectF cached_clip_;
+  bool smooth_interpolation_ = false;   // [camp#132] blit hint only (persisted)
 };
 
 }  // namespace live_coverage

--- a/test/test_range_persist.cpp
+++ b/test/test_range_persist.cpp
@@ -222,6 +222,31 @@ TEST(RangePersist, RasterManualRoundTrips)
   }
 }
 
+// [camp#132] RasterLayer's smooth opt-in persists under the itemID() group (NOT
+// settingsKey()) — this round-trip catches a future group/key mismatch.
+TEST(RangePersist, RasterSmoothInterpolationRoundTrips)
+{
+  QSettings().clear();
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const QString file = dir.filePath("chart.tif");   // need not exist for this API
+
+  {
+    auto* layer = new TestableRasterLayer(layers, file);
+    EXPECT_FALSE(layer->smoothInterpolation());   // faithful-QA default
+    layer->setSmoothInterpolation(true);          // persists via writeSettings
+  }
+  {
+    auto* layer = new TestableRasterLayer(layers, file);
+    layer->readSettings();
+    EXPECT_TRUE(layer->smoothInterpolation())
+        << "persisted smooth opt-in must restore from the itemID() group";
+  }
+}
+
 TEST(RangePersist, RasterAutoRoundTrips)
 {
   QSettings().clear();
@@ -311,6 +336,28 @@ TEST(RangePersist, SonarAutoRoundTrips)
     // override; with no source loaded it stays at the RangeModel default extents.
     EXPECT_FLOAT_EQ(layer->rangeLo(), 0.0f);
     EXPECT_FLOAT_EQ(layer->rangeHi(), 1.0f);
+  }
+}
+
+// [camp#132] SonarLiveCacheLayer's smooth opt-in persists under its settingsKey()
+// group ("live:" + namespace) — round-trip catches a future group/key mismatch.
+TEST(RangePersist, LiveSmoothInterpolationRoundTrips)
+{
+  QSettings().clear();
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+
+  {
+    auto* layer = new TestableSonarLiveCacheLayer(layers, nullptr, "/test_source");
+    EXPECT_FALSE(layer->smoothInterpolation());   // faithful-QA default
+    layer->setSmoothInterpolation(true);          // persists via writeSettings
+  }
+  {
+    auto* layer = new TestableSonarLiveCacheLayer(layers, nullptr, "/test_source");
+    layer->readSettings();
+    EXPECT_TRUE(layer->smoothInterpolation())
+        << "persisted smooth opt-in must restore from the settingsKey() group";
   }
 }
 

--- a/test/test_range_persist.cpp
+++ b/test/test_range_persist.cpp
@@ -124,6 +124,30 @@ TEST(RangePersist, GggsManualRoundTrips)
   }
 }
 
+// [camp#132] The per-layer blit-smoothing opt-in round-trips: default OFF,
+// enabled + persisted by one layer instance, restored by the next.
+TEST(RangePersist, GggsSmoothInterpolationRoundTrips)
+{
+  QSettings().clear();
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  QTemporaryDir tileset;
+  ASSERT_TRUE(tileset.isValid());
+
+  {
+    auto* layer = new TestableGggsTileLayer(layers, tileset.path());
+    EXPECT_FALSE(layer->smoothInterpolation());   // faithful-QA default
+    layer->setSmoothInterpolation(true);          // persists via writeSettings
+  }
+  {
+    auto* layer = new TestableGggsTileLayer(layers, tileset.path());
+    layer->readSettings();
+    EXPECT_TRUE(layer->smoothInterpolation())
+        << "persisted smooth-interpolation opt-in must survive a restart";
+  }
+}
+
 TEST(RangePersist, GggsAutoRoundTrips)
 {
   QSettings().clear();


### PR DESCRIPTION
## Summary

Data layers (GGGS tile stores, live sonar coverage, scalar charts) now default to a **faithful Nearest blit**, with a per-layer checkable **"Smooth interpolation"** context-menu opt-in, persisted alongside each layer's other display settings.

**Why Nearest is the default** (the QA rationale, per operator direction): interpolation fabricates values that aren't in the data and can mask exactly the artifacts the operator is inspecting for — dropouts, seams, single-cell targets. For survey/sensor data under quality assessment, cell-faithful rendering wins; smoothing is the opt-in, not the baseline.

## Design constraints honored

- **Blit hint ONLY** — the GL scalar data-texture filter stays `Nearest` unconditionally: a Linear filter would blend the finite NoData sentinel with neighboring data into fabricated values the shader's exact-equality discard can't catch (the camp#122 halo; plan-review must-fix). A true GL smooth mode (NoData→NaN at upload) is possible future work, out of scope here.
- **RGBA charts / basemap imagery always blit smooth** — not data under QA. RasterLayer's setter is intentionally inert for RGBA (documented in-code).
- **Persistence matches each layer's existing group** (plan-review must-fix 2): `settingsKey()` for GGGS/live layers, `itemID()` for RasterLayer. Round-trip tests cover all three groups so a future key mismatch fails a test.

## Testing

164 tests, 0 failures (worktree host build). New: three persistence round-trip tests (default-off + opt-in restore per layer). One unrelated flake observed and cleared: `test_topic_bridge` timed out once under heavy host load, passes in ~2s on rerun.

## Review

Pre-push /review-code (Standard, Opus): **approved, 0 must-fix, Ship: recommended** (round 1); all 3 suggestions folded before publish. Plan: `.agent/work-plans/issue-132/plan.md` (review-plan changes-requested → both must-fixes folded).

Closes #132.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
