### PR TITLE
GGGS store layers: depth-at-cursor readout via the depth-provider walk

### DIFF
--- a/.agent/work-plans/issue-180/plan.md
+++ b/.agent/work-plans/issue-180/plan.md
@@ -12,59 +12,112 @@ depth band. GGGS store layers (`GggsTileLayer`, spawned by `GggsStoreSource`)
 never register in this walk, so hovering over an open bathy store silently
 omits depth from the status bar.
 
-`GggsTile` already loads pixel data off-thread (via `loadPixels()`) and holds
-a `geo_transform_[6]` + extent bounds from construction. After `texture()` is
-called (first paint), the CPU buffer is freed — so a point query must re-read
-a 1×1 region from the GDAL source, not the in-memory buffer.
+`GggsTile` already loads pixel data off-thread (via `loadPixels()`, driven over
+**all** tiles by `GggsTileLayer::loadTilesWorker()`) and holds a
+`geo_transform_[6]` + extent bounds from construction. Historically `texture()`
+freed the CPU buffer (`data_`) after the first paint uploaded it to the GPU, so
+a point query would have had to re-read from GDAL. **Plan Review finding #4**
+(operator-approved) requires the per-cursor-move cost to be a cheap in-memory
+lookup with no synchronous GDAL open on the GUI thread. We therefore **retain
+`data_` resident** after the GPU upload (stop freeing it in `texture()`) and
+sample the resident buffer. Trade-off: a painted tile now keeps both a CPU copy
+and its GL texture (the pre-#180 "halve resident memory per tile" optimization
+is dropped for painted tiles); acceptable at the store scale this lands against,
+noted as revisit-if-observed.
+
+Sampling reads `data_`/`nodata_` **only** through the tile's `pixelsLoaded()`
+acquire gate. That gate is the same happens-before the paint path uses, and it
+is set by `loadPixels()` *after* `nodata_`/`has_nodata_` are populated — so
+`sampleAt()` can never read the deferred NoData members while they are unset
+(**Plan Review finding #1**, must-fix).
 
 GGGS store values are ellipsoidal up-positive heights, not chart-datum depths;
 the two need distinct labels in the status bar.
 
+## Plan Review findings folded in (operator-approved 2026-07-31)
+
+1. **[must-fix]** NoData mask must not read `has_nodata_`/`nodata_` while unset.
+   Resolved: `sampleAt()` early-returns NaN unless `pixelsLoaded()` (acquire) is
+   true; `loadPixels()` populates the NoData members *before* the release store,
+   so a true gate guarantees they are valid. A unit test samples an unloaded tile
+   and asserts NaN.
+2. **[suggestion]** Tests beyond `sampleAt()`. Resolved: add a `tileLevel()`
+   basename-parse test, and a headless `getElevation()` test (extent filter,
+   descending-level "finest covering tile wins", out-of-extent → NaN, NoData →
+   NaN). `getStoreElevation()`'s enabled-layer walk is covered by a manual
+   protocol note (constructing a full `AutonomousVehicleProject` in a unit test
+   is disproportionate; the walk is a thin `dynamic_cast` + `isVisible()` filter).
+3. **[suggestion]** Honor the Layers-tab enable/disable state. Resolved:
+   `getStoreElevation()` skips layers where `!isVisible()` (the Layers-tab
+   checkbox maps to `MapItem::isVisible()` — `map.cpp:89`/`:111`), per ADR-0003
+   §2's enabled-layer contract. Decision recorded: a hidden store does **not**
+   report elevation.
+4. **[suggestion]** No synchronous GDAL open per cursor move on the GUI thread.
+   Resolved by retaining `data_` (above): `sampleAt()` is a pure in-memory index
+   into the resident buffer.
+
 ## Approach
 
-1. **`GggsTile::sampleAt(lon, lat)`** — invert the geotransform (north-up
-   `geo_transform_`, no rotation) to get pixel (col, row), reject if
-   out-of-bounds, then do a 1×1 `GDALRasterBand::RasterIO` read on `band_`
-   from `path_`. Apply the tile's NoData mask and return `std::nanf` on
-   no-data / not-valid. Safe to call on any thread.
+1. **`GggsTile::sampleAt(lon, lat) const`** — return NaN immediately unless
+   `pixelsLoaded()` (acquire) — this guards both `data_` and the deferred
+   `nodata_`/`has_nodata_` (finding #1). Invert the north-up geotransform
+   (`geo_transform_`, `geo[2]==geo[4]==0`) to pixel (col, row); reject
+   out-of-bounds → NaN. Index the **resident** `data_` buffer (finding #4 — no
+   GDAL open). Apply the same value filter as `loadPixels()`'s range loop
+   (`!isfinite` or `has_nodata_ && v == float(nodata_)`) → NaN. Otherwise return
+   the sample. Reads only members published by the tile's acquire gate, so it is
+   safe on the GUI thread against the load worker.
 
-2. **`GggsTileLayer::getElevation(QGeoCoordinate)`** — walk `tiles_`, filter
-   to those whose lat/lon extent contains the point, sort by descending tile
-   level (parsed from the basename `<level>_<row>_<col>.tif`), call
-   `sampleAt()` on each until a non-NaN result. Returns NaN if nothing covers
-   the point. The finest-level tile is queried regardless of the rendered LOD
-   (inspection > display — issue note, #103 follow-on).
+   Enabling change: **`GggsTile::texture()` no longer frees `data_`** after the
+   GPU upload — the resident buffer is what `sampleAt()` indexes.
 
-3. **`AutonomousVehicleProject::getStoreElevation(QGeoCoordinate)`** — walk
-   the Map's `topLevelLayers()` child list dynamically on each call, cast to
-   `GggsTileLayer*`, call `getElevation()`, return first non-NaN. No separate
-   list: dynamic walk tracks layer add/remove automatically and avoids a
-   dangling-pointer risk on layer teardown.
+2. **`camp::raster::tileLevel(basename)`** (new, in `gggs_tile_util.h`) — parse
+   the LEVEL (first digit group) from a `<level>_<row>_<col>.tif` basename;
+   `-1` if not a value tile. Directly unit-tested (finding #2).
 
-4. **`ProjectView::mouseMoveEvent()`** — try `getStoreElevation()` first
+3. **`GggsTileLayer::getElevation(QGeoCoordinate) const`** — collect `tiles_`
+   whose lat/lon extent contains the point, pair each with its `tileLevel()`,
+   sort by descending level (finest covering tile first), call `sampleAt()` on
+   each until a non-NaN result. NaN if nothing covers the point. The finest-level
+   tile is queried regardless of the rendered LOD (inspection > display — issue
+   note, #103 follow-on).
+
+4. **`AutonomousVehicleProject::getStoreElevation(QGeoCoordinate) const`** — walk
+   the Map's `topLevelLayers()` child list dynamically on each call,
+   `dynamic_cast` to `GggsTileLayer*`, **skip layers where `!isVisible()`**
+   (finding #3 — Layers-tab enabled state, ADR-0003 §2), call `getElevation()`,
+   return first non-NaN. No separate list: the dynamic walk tracks layer
+   add/remove automatically and avoids a dangling-pointer risk on layer teardown.
+
+5. **`ProjectView::mouseMoveEvent()`** — try `getStoreElevation()` first
    (stores have precedence; issue precedence rule); if non-NaN, append
    `" Elev: X (ellipsoid)"`. Then try `getDepth()` (chart rasters); if
    non-NaN, append `" Depth: X"`. Both can appear when a store and a chart
    overlap. The two-label design makes the datum difference explicit until
    the datum service (#288) arrives.
 
-5. **Unit test** in `test_gggs_tile.cpp` — write a 1-band Float32 north-up
-   GeoTIFF with known data using the existing GDAL test-fixture helper,
-   construct a `GggsTile`, call `sampleAt()` at in-bound and out-of-bound
-   coordinates, and at a NoData pixel; assert expected values.
+6. **Unit tests** — in `test_gggs_tile.cpp`: `sampleAt()` in-bound / out-of-bound
+   / NoData-pixel / **unloaded-tile → NaN** (finding #1), plus a `tileLevel()`
+   basename-parse test (finding #2). New `test/test_gggs_elevation.cpp` (headless,
+   GL-free — mirrors `test_gggs_rescan.cpp`): a two-level overlapping tile-set
+   asserts `getElevation()` returns the finest covering tile's value, out-of-extent
+   → NaN, all-NoData → NaN (finding #2).
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
 | `src/camp_map/raster/gggs_tile.h` | Declare `float sampleAt(double lon, double lat) const` |
-| `src/camp_map/raster/gggs_tile.cpp` | Implement `sampleAt()`: geotransform inversion + 1×1 GDAL RasterIO |
-| `src/camp_map/raster/gggs_tile_layer.h` | Declare `float getElevation(const QGeoCoordinate& location) const` |
+| `src/camp_map/raster/gggs_tile.cpp` | Implement `sampleAt()` (resident-buffer index, `pixelsLoaded()` gate); stop freeing `data_` in `texture()` |
+| `src/camp_map/raster/gggs_tile_util.h` | Add `int tileLevel(const QString& filename)` |
+| `src/camp_map/raster/gggs_tile_layer.h` | Declare `float getElevation(const QGeoCoordinate& location) const`; `#include <QGeoCoordinate>` |
 | `src/camp_map/raster/gggs_tile_layer.cpp` | Implement `getElevation()`: extent filter, level sort, `sampleAt()` loop |
 | `src/camp/autonomousvehicleproject.h` | Declare `float getStoreElevation(const QGeoCoordinate&) const` |
-| `src/camp/autonomousvehicleproject.cpp` | Implement `getStoreElevation()`: dynamic LayerList walk |
+| `src/camp/autonomousvehicleproject.cpp` | Implement `getStoreElevation()`: dynamic LayerList walk, `isVisible()` filter |
 | `src/camp/projectview.cpp` | Update `mouseMoveEvent()` to call both query methods with appropriate labels |
-| `test/test_gggs_tile.cpp` | Add `sampleAt()` unit tests |
+| `test/test_gggs_tile.cpp` | Add `sampleAt()` + `tileLevel()` unit tests |
+| `test/test_gggs_elevation.cpp` (new) | Headless `getElevation()` tests (extent/level/NoData) |
+| `CMakeLists.txt` | Register `test_gggs_elevation` gtest target |
 
 ## Principles Self-Check
 
@@ -83,27 +136,31 @@ the two need distinct labels in the status bar.
 |---|---|---|
 | camp ADR-0003 (Depth-layer tree) | Yes | GGGS stores go in a separate `getStoreElevation()` path, not `m_depthRasters`, preserving the semantic distinction between ellipsoidal height and chart-datum depth until the full depth-tree is fronted |
 | camp ADR-0005 (Catalog browser / flat layers) | Yes | Dynamic walk of `topLevelLayers()` tracks the `GggsStoreSource` add/remove lifecycle without the AVP needing to own layer pointers |
-| camp ADR-0007 (RasterFieldSource) | No | `sampleAt()` reads raw GDAL pixels outside the render path; the `RasterFieldSource` render contract is unchanged |
+| camp ADR-0007 (RasterFieldSource) | No | `sampleAt()` indexes the tile's already-resident CPU pixel buffer outside the render path; the `RasterFieldSource` render contract is unchanged (retaining `data_` past upload only affects resident memory, not the render interface) |
 
 ## Consequences
 
 | If we change… | Also update… | Included in plan? |
 |---|---|---|
-| `GggsTile` public API | `test_gggs_tile.cpp` | Yes — step 5 |
+| `GggsTile` public API | `test_gggs_tile.cpp` | Yes — step 6 |
 | `GggsTileLayer` public API | Any code that includes `gggs_tile_layer.h` (scan for consumers) | Yes — check includes; no other callers expected |
+| `GggsTile::texture()` stops freeing `data_` | Resident memory per painted tile ~doubles (CPU + GPU copy) | Yes — noted trade-off; revisit if memory pressure observed |
 | Status-bar label in `projectview.cpp` | Any screenshot-based integration notes / docs mentioning the "Depth:" label | No — follow-up if formal docs exist |
-| `getStoreElevation()` queries on mouse move | Performance acceptable given single-point 1×1 GDAL read; profile if operator reports latency | No — noted as acceptable, revisit if needed |
+| `getStoreElevation()` queries on mouse move | Cheap in-memory index (finding #4); no per-move I/O | Yes — resolved by resident buffer |
 
-## Open Questions
+## Open Questions (resolved by the folded-in review findings)
 
-- The 1×1 GDAL RasterIO in `sampleAt()` opens and closes the file on each call;
-  NVMe-backed stores are fast but network-mounted stores could lag. Should a
-  debounce (query only when the cursor stops) or a read-ahead cache be added
-  now, or treated as a follow-on if latency is observed in the field?
-- When a chart raster and a GGGS store both cover the cursor, the plan shows
-  both labels ("Elev: X (ellipsoid)" and "Depth: Y"). Is that the preferred
-  operator UX, or should only one value be shown (with stores taking precedence
-  and suppressing the chart depth)?
+- ~~The 1×1 GDAL RasterIO in `sampleAt()` opens the file per call…~~ **Resolved
+  (finding #4):** `sampleAt()` no longer opens GDAL — it indexes the resident
+  `data_` buffer (kept alive by not freeing it in `texture()`). Per-move cost is
+  a cheap in-memory lookup; the network-mount latency concern no longer applies.
+- **Decided:** both labels are shown when a store and a chart overlap ("Elev: X
+  (ellipsoid)" and "Depth: Y"). Store takes precedence only in query *order*, not
+  by suppressing the chart depth; distinct labels keep ellipsoidal height and
+  chart-datum depth visibly separate until the datum service (#288).
+- **Decided (finding #3):** a hidden (Layers-tab unchecked) store does NOT report
+  elevation — `getStoreElevation()` filters on `isVisible()`, matching ADR-0003
+  §2's enabled-layer contract for `getDepth`.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-180/plan.md
+++ b/.agent/work-plans/issue-180/plan.md
@@ -1,0 +1,110 @@
+# Plan: Depth-at-cursor for GGGS store layers
+
+## Issue
+
+https://github.com/rolker/camp/issues/180
+
+## Context
+
+`AutonomousVehicleProject::getDepth()` walks `m_depthRasters` — a list of
+`DepthRaster` objects, one per loaded background chart that carries a Float32
+depth band. GGGS store layers (`GggsTileLayer`, spawned by `GggsStoreSource`)
+never register in this walk, so hovering over an open bathy store silently
+omits depth from the status bar.
+
+`GggsTile` already loads pixel data off-thread (via `loadPixels()`) and holds
+a `geo_transform_[6]` + extent bounds from construction. After `texture()` is
+called (first paint), the CPU buffer is freed — so a point query must re-read
+a 1×1 region from the GDAL source, not the in-memory buffer.
+
+GGGS store values are ellipsoidal up-positive heights, not chart-datum depths;
+the two need distinct labels in the status bar.
+
+## Approach
+
+1. **`GggsTile::sampleAt(lon, lat)`** — invert the geotransform (north-up
+   `geo_transform_`, no rotation) to get pixel (col, row), reject if
+   out-of-bounds, then do a 1×1 `GDALRasterBand::RasterIO` read on `band_`
+   from `path_`. Apply the tile's NoData mask and return `std::nanf` on
+   no-data / not-valid. Safe to call on any thread.
+
+2. **`GggsTileLayer::getElevation(QGeoCoordinate)`** — walk `tiles_`, filter
+   to those whose lat/lon extent contains the point, sort by descending tile
+   level (parsed from the basename `<level>_<row>_<col>.tif`), call
+   `sampleAt()` on each until a non-NaN result. Returns NaN if nothing covers
+   the point. The finest-level tile is queried regardless of the rendered LOD
+   (inspection > display — issue note, #103 follow-on).
+
+3. **`AutonomousVehicleProject::getStoreElevation(QGeoCoordinate)`** — walk
+   the Map's `topLevelLayers()` child list dynamically on each call, cast to
+   `GggsTileLayer*`, call `getElevation()`, return first non-NaN. No separate
+   list: dynamic walk tracks layer add/remove automatically and avoids a
+   dangling-pointer risk on layer teardown.
+
+4. **`ProjectView::mouseMoveEvent()`** — try `getStoreElevation()` first
+   (stores have precedence; issue precedence rule); if non-NaN, append
+   `" Elev: X (ellipsoid)"`. Then try `getDepth()` (chart rasters); if
+   non-NaN, append `" Depth: X"`. Both can appear when a store and a chart
+   overlap. The two-label design makes the datum difference explicit until
+   the datum service (#288) arrives.
+
+5. **Unit test** in `test_gggs_tile.cpp` — write a 1-band Float32 north-up
+   GeoTIFF with known data using the existing GDAL test-fixture helper,
+   construct a `GggsTile`, call `sampleAt()` at in-bound and out-of-bound
+   coordinates, and at a NoData pixel; assert expected values.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/camp_map/raster/gggs_tile.h` | Declare `float sampleAt(double lon, double lat) const` |
+| `src/camp_map/raster/gggs_tile.cpp` | Implement `sampleAt()`: geotransform inversion + 1×1 GDAL RasterIO |
+| `src/camp_map/raster/gggs_tile_layer.h` | Declare `float getElevation(const QGeoCoordinate& location) const` |
+| `src/camp_map/raster/gggs_tile_layer.cpp` | Implement `getElevation()`: extent filter, level sort, `sampleAt()` loop |
+| `src/camp/autonomousvehicleproject.h` | Declare `float getStoreElevation(const QGeoCoordinate&) const` |
+| `src/camp/autonomousvehicleproject.cpp` | Implement `getStoreElevation()`: dynamic LayerList walk |
+| `src/camp/projectview.cpp` | Update `mouseMoveEvent()` to call both query methods with appropriate labels |
+| `test/test_gggs_tile.cpp` | Add `sampleAt()` unit tests |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Only what's needed | No separate registration list; datum conversion deferred; LOD complexity deferred to #103 follow-on |
+| Improve incrementally | Narrow change: point-query + status-bar label; no depth-model redesign |
+| A change includes its consequences | Lifecycle managed by dynamic walk (no dangling pointer); label change avoids silent datum confusion |
+| Capture decisions, not just implementations | Precedence rule (stores first), finest-tile-for-query, and CPU-buffer vs. GDAL-RasterIO choice noted here |
+| Human control and transparency | Distinct "Elev: (ellipsoid)" label makes datum difference visible to the operator |
+| Test what breaks | Unit test for `sampleAt()` covers the new query path; existing GGGS tile tests remain valid |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| camp ADR-0003 (Depth-layer tree) | Yes | GGGS stores go in a separate `getStoreElevation()` path, not `m_depthRasters`, preserving the semantic distinction between ellipsoidal height and chart-datum depth until the full depth-tree is fronted |
+| camp ADR-0005 (Catalog browser / flat layers) | Yes | Dynamic walk of `topLevelLayers()` tracks the `GggsStoreSource` add/remove lifecycle without the AVP needing to own layer pointers |
+| camp ADR-0007 (RasterFieldSource) | No | `sampleAt()` reads raw GDAL pixels outside the render path; the `RasterFieldSource` render contract is unchanged |
+
+## Consequences
+
+| If we change… | Also update… | Included in plan? |
+|---|---|---|
+| `GggsTile` public API | `test_gggs_tile.cpp` | Yes — step 5 |
+| `GggsTileLayer` public API | Any code that includes `gggs_tile_layer.h` (scan for consumers) | Yes — check includes; no other callers expected |
+| Status-bar label in `projectview.cpp` | Any screenshot-based integration notes / docs mentioning the "Depth:" label | No — follow-up if formal docs exist |
+| `getStoreElevation()` queries on mouse move | Performance acceptable given single-point 1×1 GDAL read; profile if operator reports latency | No — noted as acceptable, revisit if needed |
+
+## Open Questions
+
+- The 1×1 GDAL RasterIO in `sampleAt()` opens and closes the file on each call;
+  NVMe-backed stores are fast but network-mounted stores could lag. Should a
+  debounce (query only when the cursor stops) or a read-ahead cache be added
+  now, or treated as a follow-on if latency is observed in the field?
+- When a chart raster and a GGGS store both cover the cursor, the plan shows
+  both labels ("Elev: X (ellipsoid)" and "Depth: Y"). Is that the preferred
+  operator UX, or should only one value be shown (with stores taking precedence
+  and suppressing the chart depth)?
+
+## Estimated Scope
+
+Single PR.

--- a/.agent/work-plans/issue-180/progress.md
+++ b/.agent/work-plans/issue-180/progress.md
@@ -179,3 +179,21 @@ for the thin `dynamic_cast` + `isVisible()` filter, so verify in the app:
   pressure is observed (noted in plan Consequences).
 - The finest-tile-regardless-of-LOD query is the interim inspection>display choice
   pending the LOD work in camp#103.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-31 18:56 +0000
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-180 at `abff516`
+**Mode**: pre-push
+**Depth**: Standard (reason: ~350 LOC new logic across the camp ↔ camp_map boundary; new cross-layer provider path + camp#102 threading contract)
+**Must-fix**: 0 | **Suggestions**: 4
+**Round**: 1 | **Ship**: recommended — no must-fix; all four folded Plan-Review findings honored; container tests 194/0/12 (12 pre-existing GL skips). Two independent adversarial passes confirmed the acquire/release + GUI-thread-only tiles_ mutation is race-free.
+
+### Findings
+- [ ] (suggestion) getElevation re-parses tileLevel (QFileInfo + QRegularExpression) and allocates + stable_sorts a vector on every cursor move — cache the immutable level on GggsTile / track max-level covering tile in one pass — `src/camp_map/raster/gggs_tile_layer.cpp:356`
+- [ ] (suggestion) Retained data_ is held for every LOADED tile, not just painted ones; the code comment ("a painted tile now holds both copies") understates scope — tweak comment + note footprint scales with loaded tiles — `src/camp_map/raster/gggs_tile.cpp:205`
+- [ ] (suggestion) Enabled-layer semantics diverge: getStoreElevation honors isVisible() (ADR-0003 §2) but sibling getDepth filters only on depthValid() (membership driven by add/remove, not visibility) — unchecking a chart still shows Depth:; consistency follow-up belongs on getDepth — `src/camp/autonomousvehicleproject.cpp:382`
+- [ ] (suggestion) sampleAt inverts only the diagonal geotransform terms (north-up assumption; ignores geo[2]/geo[4] shear) — consistent with the north-up-by-construction subsystem; optional one-line guard — `src/camp_map/raster/gggs_tile.cpp:145`

--- a/.agent/work-plans/issue-180/progress.md
+++ b/.agent/work-plans/issue-180/progress.md
@@ -89,3 +89,16 @@ finest available tile regardless of rendered LOD, which requires no dependency o
 - [ ] Confirm deregister-on-close is handled in both the Layers-tab Remove path and any app-shutdown teardown.
 - [ ] Consider an ADR addendum or PR-description note on the precedence decision and the "finest tile regardless of LOD" query strategy, to satisfy "Capture decisions."
 - [ ] Identify an automated test or a manual test protocol for the readout (unit test on `getDepth()` with a mock GGGS tile, or a test note in the PR).
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-07-31 10:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-180/plan.md` at `4b4af74`
+**Branch**: feature/issue-180 at `4b4af74`
+**Phases**: single
+
+### Open questions
+- [ ] `sampleAt()` opens the GDAL file per call; on network-mounted stores this may lag. Add a debounce or cursor-stop trigger now, or treat as follow-on if latency is observed?
+- [ ] When both a GGGS store and a chart raster cover the cursor, the plan shows both labels ("Elev: X (ellipsoid)" and "Depth: Y"). Preferred UX: show both, or suppress chart depth when a store value is present?

--- a/.agent/work-plans/issue-180/progress.md
+++ b/.agent/work-plans/issue-180/progress.md
@@ -242,3 +242,26 @@ Lifecycle: **Implementation** → **review-code** (re-review the fixes). Hand of
 a fresh-context sub-agent:
 
     .agent/scripts/dispatch_subagent.sh --mode in-process --issue 180 --skill review-code
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-31 19:44 +0000
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-180 at `0b90cf1`
+**Mode**: pre-push
+**Depth**: Standard (reason: camp↔camp_map boundary + camp#102 threading contract; focused confirmation of the R1-approved fix delta)
+**Must-fix**: 0 | **Suggestions**: 1
+**Round**: 2 | **Ship**: recommended — R1 approved (0 must-fix); this round confirms the 4 fix commits (`cda1ebb`,`d095e94`,`d38258a`,`4da941d`) are correct, complete, regression-free. Two disjoint-lens adversarial passes clean. Full-stack rebuild (installs had been wiped post-R1) clean; camp tests 194/0/0/12 (12 pre-existing GL skips), gggs_elevation 3/0 + gggs_tile 13/0 green.
+
+### Findings
+- [ ] (suggestion) Shear guard has no dedicated unit test — low-value (can't-happen-by-construction input); track or skip — `src/camp_map/raster/gggs_tile.cpp:157`
+
+### Notes
+- `cda1ebb` LOD cache: `level_` parsed once from immutable `path_` in ctor; value identical to the old per-move `tileLevel(QFileInfo(path).fileName())`. Coherent with lifecycle — `setBand()` leaves `level_` untouched; `rescan()` builds fresh tiles. Thread-safe: ctor write happens-before publish to `tiles_`; `level()` read on GUI thread. Covered by `FinestCoveringTileWins` + `TileLevelParse`.
+- `d095e94` shear guard: returns NaN before the col/row inversion on `geo[2]!=0||geo[4]!=0` — a miss, never a mis-indexed value; caller treats NaN as no-value and falls through.
+- `d38258a` / `4da941d`: comment-only; both claims verified factually accurate against the code (CPU buffer held by every loaded tile; `getDepth` filters `depthValid()` only vs `getStoreElevation` honoring `isVisible()`).
+
+### Next step
+Lifecycle: **Local Review** (approved) → push / open PR → **triage-reviews**. No must-fix; the single suggestion is optional. Ready to publish.

--- a/.agent/work-plans/issue-180/progress.md
+++ b/.agent/work-plans/issue-180/progress.md
@@ -1,0 +1,91 @@
+---
+issue: 180
+---
+
+# Issue #180 — Depth-at-cursor for GGGS store layers
+
+## Issue Review
+**Status**: complete
+**When**: 2026-07-31 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #180
+**Comment**: (best-effort post follows this entry; not recorded inline)
+**Scope verdict**: well-scoped
+
+### Summary
+
+Issue requests wiring GGGS store layers (Stores tab, `GggsTileLayer`) into the
+`getDepth()` query path so hovering over an open bathy store reports depth in the
+status bar. Currently `m_depthRasters` is populated only by legacy `DepthRaster`
+objects (one per loaded chart that carries a depth band); GGGS store layers never
+register, so the readout silently returns NaN over store data.
+
+The issue defers datum conversion explicitly, which is correct scope hygiene.
+The multi-level / post-#103 consideration is flagged as future work with a clear
+rationale. The "label as ellipsoidal up-positive" note is helpful context.
+
+---
+
+### Scope Assessment
+
+**Well-scoped?** Yes — single PR. The proposed change has three parts (point-query
+method, registration/deregistration lifecycle, label text) all in the render layer
+and the depth-provider list. Datum conversion is explicitly deferred to the
+follow-on datum service (#288). No splitting needed.
+
+**Right repo?** Yes — `camp` owns `GggsTileLayer`, `GggsStoreSource`,
+`AutonomousVehicleProject::getDepth()`, and `ProjectView`. All changes are inside
+this repo.
+
+**Dependencies**: The S-102 reference store (rolker/unh_marine_autonomy#278) is
+the suggested test target — it must be importable to verify the readout, but the
+feature itself does not depend on that PR landing. Issue #103 (LOD selection) is
+flagged as a future consideration; the issue correctly scopes the query to the
+finest available tile regardless of rendered LOD, which requires no dependency on
+#103.
+
+---
+
+### Principle Alignment
+
+| Principle | Status | Notes |
+|---|---|---|
+| Only what's needed | OK | Datum conversion and LOD interaction explicitly deferred; narrow scope |
+| Improve incrementally | OK | One concrete gap (no store depth readout) closed without redesigning the depth model |
+| A change includes its consequences | Watch | Deregister-on-close must be handled symmetrically with registration; lifecycle should be tested or reviewed carefully |
+| Capture decisions, not just implementations | Watch | The precedence choice (stores first, load-order within) and the point-query strategy (finest tile regardless of LOD) are design decisions worth recording in the PR description or an ADR addendum |
+| Human control and transparency | OK | Labeling the value as ellipsoidal up-positive (not chart datum depth) is the right transparency measure until the datum service exists |
+| Test what breaks | Watch | No test mention in the issue; `getDepth()` is queried on mouse move so a unit test or integration note would reduce regression risk |
+
+---
+
+### ADR Applicability
+
+| ADR | Triggered | Notes |
+|---|---|---|
+| camp ADR-0003 (Depth-layer tree) | Yes | `m_depthRasters` is the current depth-provider list; ADR-0003 §2 specifies `getDepth()` walks enabled depth layers in tree order. The AVP header comment reads "stage 4 will front it with a tree." Extending `m_depthRasters` with GGGS stores is consistent with the interim model, but the plan should note how the extension fits (or will be subsumed by) the eventual depth-tree. |
+| camp ADR-0005 (Catalog browser + flat layers) | Yes | `GggsTileLayer` is a flat display layer produced by `GggsStoreSource`. Registration in the depth-provider walk must respect the display-layer lifecycle (created by catalog selection, removed by the Layers tab Remove action). The deregister path for `GggsStoreSource`-spawned layers may need the same care as the `GggsStores/roots` persistence path. |
+| camp ADR-0007 (RasterFieldSource) | Partially | `GggsTile` already holds geographic extent + pixel data per ADR-0007. A point-query reuses that data without changing the render abstraction, so ADR-0007's contract is untouched. Worth noting if the point-query is added as a method on `GggsTileLayer` vs. directly on `GggsTile`. |
+| camp ADR-0001 (TopicBridge/executor) | No | No ROS callbacks involved |
+
+---
+
+### Consequences
+
+- `AutonomousVehicleProject::getDepth()` / `m_depthRasters` will need a parallel
+  mechanism (or extension) for store-layer depth providers. If they share
+  `m_depthRasters`, `DepthRaster` (which wraps chart rasters) and the GGGS
+  store provider need a common interface — or a separate list with the same walk.
+- The label "Depth:" in `ProjectView::mouseMoveEvent` may need to distinguish
+  store-reported values from chart-reported values (ellipsoidal height vs. chart
+  datum depth), at least in a tooltip or secondary label, until the datum service
+  exists.
+- Remove / close action on the Stores tab must deregister the depth provider;
+  this should be tested to avoid a dangling pointer or stale readout.
+
+### Actions
+- [ ] In the plan, clarify whether GGGS store providers share `m_depthRasters` with `DepthRaster` objects or use a separate list; document the precedence rule (stores first).
+- [ ] Confirm deregister-on-close is handled in both the Layers-tab Remove path and any app-shutdown teardown.
+- [ ] Consider an ADR addendum or PR-description note on the precedence decision and the "finest tile regardless of LOD" query strategy, to satisfy "Capture decisions."
+- [ ] Identify an automated test or a manual test protocol for the readout (unit test on `getDepth()` with a mock GGGS tile, or a test note in the PR).

--- a/.agent/work-plans/issue-180/progress.md
+++ b/.agent/work-plans/issue-180/progress.md
@@ -102,3 +102,22 @@ finest available tile regardless of rendered LOD, which requires no dependency o
 ### Open questions
 - [ ] `sampleAt()` opens the GDAL file per call; on network-mounted stores this may lag. Add a debounce or cursor-stop trigger now, or treat as follow-on if latency is observed?
 - [ ] When both a GGGS store and a chart raster cover the cursor, the plan shows both labels ("Elev: X (ellipsoid)" and "Depth: Y"). Preferred UX: show both, or suppress chart depth when a store value is present?
+
+## Plan Review
+**Status**: complete
+**When**: 2026-07-31 18:05 +00:00
+**By**: Claude Code Agent (Claude Opus) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-180/plan.md` at `4b4af74`
+**PR**: PR-less (`--issue` / file-path mode; no draft PR — `gh` unauthenticated in this environment)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix) `sampleAt()` "apply the tile's NoData mask" relies on `has_nodata_`/`nodata_`, which are populated only by `loadPixels()` (constructor defers them — `gggs_tile.h:30`; confirmed `test_gggs_tile.cpp:208`). Since `getElevation()` queries the finest-level tile regardless of rendered LOD, it may sample a tile that was never painted → `has_nodata_==false` → the NoData sentinel is returned as a real elevation. Query the band's NoData directly via GDAL in `sampleAt()`, and add a NoData-on-unloaded-tile test — `plan.md:29`
+- [ ] (suggestion) Test coverage stops at `GggsTile::sampleAt()`. The riskier new logic — `getElevation()`'s extent filter, `<level>_<row>_<col>` basename parse, descending-level sort, and `getStoreElevation()`'s dynamic-cast walk — is untested. Add a multi-tile `getElevation()` test (overlapping levels: finest covering tile wins; out-of-extent → NaN), or at least a manual protocol in the PR — `plan.md:51`
+- [ ] (suggestion) `getStoreElevation()` walks all `GggsTileLayer`s regardless of the operator's Layers-tab enable/disable, whereas ADR-0003 §2 specifies `getDepth` walks *enabled* depth layers. (Current `getDepth`/`m_depthRasters` also ignores visibility — `autonomousvehicleproject.cpp:381` checks only `depthValid()` — so this matches today's behavior.) State the decision explicitly: should a hidden store still report elevation at the cursor? — `plan.md:39`
+- [ ] (suggestion) `sampleAt()` opens the GeoTIFF per call and `mouseMoveEvent` runs on the GUI thread → a synchronous GDAL open per cursor move (the "safe on any thread" property isn't exploited; the call chain is GUI-thread). Deferring a debounce/cache is fine, but commit to defer-and-revisit-if-observed rather than leaving Open Question #1 fully open — it directly affects the operator UX this issue targets — `plan.md:99`
+
+Non-blocking: `gggs_tile_layer.h` will need a `<QGeoCoordinate>` include for the new `getElevation(const QGeoCoordinate&)` signature (trivial implementation detail).
+
+Strengths worth noting: file targeting is accurate (all 8 files verified to exist with the described members; integration point confirmed exact at `projectview.cpp:212`). The dynamic `topLevelLayers()->childMapItems()` walk (no stored pointer list) elegantly resolves the deregister/dangling-pointer lifecycle concern the Issue Review flagged, addressing its Actions 1–2. The separate `getStoreElevation()` path plus the distinct "Elev: (ellipsoid)" label is a defensible interim reading of ADR-0003 §2 that keeps ellipsoidal height and chart-datum depth semantically distinct until the datum service (#288).

--- a/.agent/work-plans/issue-180/progress.md
+++ b/.agent/work-plans/issue-180/progress.md
@@ -193,7 +193,52 @@ for the thin `dynamic_cast` + `isVisible()` filter, so verify in the app:
 **Round**: 1 | **Ship**: recommended — no must-fix; all four folded Plan-Review findings honored; container tests 194/0/12 (12 pre-existing GL skips). Two independent adversarial passes confirmed the acquire/release + GUI-thread-only tiles_ mutation is race-free.
 
 ### Findings
-- [ ] (suggestion) getElevation re-parses tileLevel (QFileInfo + QRegularExpression) and allocates + stable_sorts a vector on every cursor move — cache the immutable level on GggsTile / track max-level covering tile in one pass — `src/camp_map/raster/gggs_tile_layer.cpp:356`
-- [ ] (suggestion) Retained data_ is held for every LOADED tile, not just painted ones; the code comment ("a painted tile now holds both copies") understates scope — tweak comment + note footprint scales with loaded tiles — `src/camp_map/raster/gggs_tile.cpp:205`
-- [ ] (suggestion) Enabled-layer semantics diverge: getStoreElevation honors isVisible() (ADR-0003 §2) but sibling getDepth filters only on depthValid() (membership driven by add/remove, not visibility) — unchecking a chart still shows Depth:; consistency follow-up belongs on getDepth — `src/camp/autonomousvehicleproject.cpp:382`
-- [ ] (suggestion) sampleAt inverts only the diagonal geotransform terms (north-up assumption; ignores geo[2]/geo[4] shear) — consistent with the north-up-by-construction subsystem; optional one-line guard — `src/camp_map/raster/gggs_tile.cpp:145`
+- [x] (suggestion) getElevation re-parses tileLevel (QFileInfo + QRegularExpression) and allocates + stable_sorts a vector on every cursor move — cache the immutable level on GggsTile / track max-level covering tile in one pass — `src/camp_map/raster/gggs_tile_layer.cpp:356`
+- [x] (suggestion) Retained data_ is held for every LOADED tile, not just painted ones; the code comment ("a painted tile now holds both copies") understates scope — tweak comment + note footprint scales with loaded tiles — `src/camp_map/raster/gggs_tile.cpp:205`
+- [x] (suggestion) Enabled-layer semantics diverge: getStoreElevation honors isVisible() (ADR-0003 §2) but sibling getDepth filters only on depthValid() (membership driven by add/remove, not visibility) — unchecking a chart still shows Depth:; consistency follow-up belongs on getDepth — `src/camp/autonomousvehicleproject.cpp:382`
+- [x] (suggestion) sampleAt inverts only the diagonal geotransform terms (north-up assumption; ignores geo[2]/geo[4] shear) — consistent with the north-up-by-construction subsystem; optional one-line guard — `src/camp_map/raster/gggs_tile.cpp:145`
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-31 19:16 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-180 at `4da941d`
+**Addressed**: `## Local Review (Pre-Push)` (When 2026-07-31 18:56 +0000, branch feature/issue-180 at `abff516`) — all 4 unchecked suggestions, none deferred
+**Commits**: `cda1ebb`, `d095e94`, `d38258a`, `4da941d`
+
+**Build**: `./ui_ws/build.sh camp` — camp built clean (warnings only). This
+worktree had no lower layers built, so the stack was bootstrapped bottom-up
+first: `colcon build` in `underlay_ws` (22 pkgs) → `core_ws` (38 pkgs), then
+`build.sh camp`.
+
+**Tests**: `./ui_ws/test.sh camp` → **194 tests, 0 errors, 0 failures, 12
+skipped** (the 12 skips are the pre-existing offscreen-GL render tests — no GL
+in-container; unchanged from the Implementation baseline). The headless
+`GggsElevation`/`GggsTile` suites that exercise the touched code all passed.
+
+### Actions
+- [x] Cache GGGS tile LOD level; getElevation() drops the per-cursor-move
+  QFileInfo + QRegularExpression parse — `src/camp_map/raster/gggs_tile_layer.cpp:356`
+  (`cda1ebb`). Level parsed once in the GggsTile ctor, exposed via `level()`;
+  the descending-level sort and finest-tile-wins fallback are unchanged, so
+  `GggsElevationTest.FinestCoveringTileWins` still holds.
+- [x] Correct the CPU-buffer retention comment in `texture()` — the resident
+  `data_` is held by every LOADED tile (footprint scales with loaded tiles),
+  not just painted ones; only the GL texture is painted-tile-only —
+  `src/camp_map/raster/gggs_tile.cpp:205` (`d38258a`). Comment-only.
+- [x] Document the getDepth vs getStoreElevation visibility divergence at
+  `getDepth` (chart membership on `depthValid()`, not `isVisible()`); aligning
+  the two is an out-of-scope follow-up on the chart path —
+  `src/camp/autonomousvehicleproject.cpp:382` (`4da941d`). Comment-only; runtime
+  behavior of the chart depth path intentionally unchanged for #180.
+- [x] Guard `sampleAt()` against sheared geotransforms (geo[2]/geo[4] != 0) —
+  return NaN rather than a mis-indexed sample; the diagonal-only inversion holds
+  for all north-up GGGS tiles by construction — `src/camp_map/raster/gggs_tile.cpp:145`
+  (`d095e94`).
+
+### Next step
+Lifecycle: **Implementation** → **review-code** (re-review the fixes). Hand off to
+a fresh-context sub-agent:
+
+    .agent/scripts/dispatch_subagent.sh --mode in-process --issue 180 --skill review-code

--- a/.agent/work-plans/issue-180/progress.md
+++ b/.agent/work-plans/issue-180/progress.md
@@ -121,3 +121,61 @@ finest available tile regardless of rendered LOD, which requires no dependency o
 Non-blocking: `gggs_tile_layer.h` will need a `<QGeoCoordinate>` include for the new `getElevation(const QGeoCoordinate&)` signature (trivial implementation detail).
 
 Strengths worth noting: file targeting is accurate (all 8 files verified to exist with the described members; integration point confirmed exact at `projectview.cpp:212`). The dynamic `topLevelLayers()->childMapItems()` walk (no stored pointer list) elegantly resolves the deregister/dangling-pointer lifecycle concern the Issue Review flagged, addressing its Actions 1–2. The separate `getStoreElevation()` path plus the distinct "Elev: (ellipsoid)" label is a defensible interim reading of ADR-0003 §2 that keeps ellipsoidal height and chart-datum depth semantically distinct until the datum service (#288).
+
+## Implementation
+**Status**: complete
+**When**: 2026-07-31 18:45 +00:00
+**By**: Claude Opus
+
+**Branch**: feature/issue-180
+**Commits**:
+- `f5a3d07` plan(#180): fold in all four Plan Review findings (plan sync)
+- `b495036` feat(#180): depth-at-cursor readout for GGGS store layers
+- `ff279c8` test(#180): cover sampleAt(), tileLevel(), and getElevation()
+
+**Build**: `./ui_ws/build.sh camp` (this worktree had no lower layers built,
+so the stack was bootstrapped bottom-up first: `colcon build` in `underlay_ws`
+→ `core_ws`, then `colcon build --packages-up-to camp` in `ui_ws`). camp built
+clean (warnings only).
+
+**Tests**: `./ui_ws/test.sh camp` → **194 tests, 0 errors, 0 failures, 12
+skipped** (the 12 skips are the offscreen-GL render tests, no GL in-container —
+pre-existing). New tests all ran GL-free and passed:
+- `GggsTileTest.SampleAtResidentBuffer` — NaN before `loadPixels()` (the
+  finding-#1 gate), then valid/NoData/out-of-extent after load.
+- `GggsTileUtilTest.TileLevelParse` — `<level>_<row>_<col>` parse + rejections.
+- `GggsElevationTest.{FinestCoveringTileWins,OutOfExtentIsNaN,AllNoDataCoveringTileIsNaN}`.
+
+### Plan Review findings — all four folded in and implemented
+1. **[must-fix]** NoData-on-unloaded-tile: `GggsTile::sampleAt()` early-returns
+   NaN unless `pixelsLoaded()` (acquire). `loadPixels()` populates
+   `nodata_`/`has_nodata_` *before* its release store, so a true gate guarantees
+   they are set — the members are never read unset. Pinned by
+   `SampleAtResidentBuffer` (asserts NaN pre-load). `gggs_tile.cpp`.
+2. **[suggestion]** Tests beyond `sampleAt()`: added `tileLevel()` parse test and
+   the headless `getElevation()` suite (extent filter, descending-level sort,
+   all-NoData). `getStoreElevation()`'s enabled walk is a manual protocol (below).
+3. **[suggestion]** Enabled-layer state: `getStoreElevation()` skips
+   `!isVisible()` stores (Layers-tab checkbox ↔ `MapItem::isVisible()`), per
+   ADR-0003 §2. Decision recorded in plan: a hidden store does not report.
+4. **[suggestion]** No per-move GDAL open: `texture()` no longer frees `data_`;
+   `sampleAt()` indexes the resident buffer — a cheap in-memory lookup. Trade-off
+   (a painted tile keeps CPU+GPU copies) noted in the plan Consequences table.
+
+### Manual verification protocol (getStoreElevation enabled-walk — finding #2/#3)
+Constructing a full `AutonomousVehicleProject` in a unit test is disproportionate
+for the thin `dynamic_cast` + `isVisible()` filter, so verify in the app:
+1. Open a GGGS bathymetry store (Stores/Catalog tab) so a `GggsTileLayer` appears
+   in the Layers tab. Hover over it → status bar shows `Elev: <value> (ellipsoid)`.
+2. Hover off the store's extent → the `Elev:` label disappears (NaN).
+3. Uncheck the store in the Layers tab (isVisible=false) → hovering over it shows
+   NO `Elev:` label (finding #3).
+4. With a depth chart also loaded and overlapping, both `Elev:` and `Depth:`
+   appear together (two-label design; store queried first for precedence).
+
+### Follow-ups / notes
+- Resident-memory trade-off (finding #4): a painted tile now holds both a CPU
+  buffer and its GL texture. Acceptable at current store scale; revisit if memory
+  pressure is observed (noted in plan Consequences).
+- The finest-tile-regardless-of-LOD query is the interim inspection>display choice
+  pending the LOD work in camp#103.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -841,6 +841,24 @@ if(BUILD_TESTING)
     ${GDAL_LIBRARY}
   )
 
+  # [camp#180] GggsTileLayer::getElevation() — the store depth-at-cursor query.
+  # Headless (GL-free): builds a layer + waitForLoad() (pure GDAL), then samples
+  # the resident tile buffers. Same link surface as test_gggs_rescan.
+  ament_add_gtest(test_gggs_elevation
+    test/test_gggs_elevation.cpp
+  )
+  target_include_directories(test_gggs_elevation PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp_map
+  )
+  target_link_libraries(test_gggs_elevation
+    camp_map
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
+  )
+
   # [camp#121] Live tile cache (Part B): warm-load + patch-apply/dequantize
   # (SonarLiveTile, GDAL) and the downtime-gap reconcile + prune timestamp-gate
   # (the node-boundary catalog conversion + TileCatalogReconciler). Headless: no

--- a/src/camp/autonomousvehicleproject.cpp
+++ b/src/camp/autonomousvehicleproject.cpp
@@ -379,6 +379,13 @@ float AutonomousVehicleProject::getDepth(QGeoCoordinate const &location) const
     // [#59 ADR-0003] Walk the depth-provider list in load order; the first
     // provider with a valid (non-NaN) sounding at this location wins (order
     // resolves overlap between charts). NaN if no provider covers the point.
+    //
+    // [camp#180] Note this filters on depthValid() only — chart membership is
+    // driven by add/remove, NOT the Layers-tab checkbox — so an unchecked chart
+    // still reports Depth: here. getStoreElevation() (the sibling GGGS-store path)
+    // deliberately DIVERGES: it honors isVisible() per ADR-0003 §2's enabled-layer
+    // contract. Aligning getDepth to also skip hidden providers is a follow-up on
+    // this path (it would change existing chart behavior, so out of scope for #180).
     for(auto* depth : m_depthRasters)
     {
         if(!depth->depthValid())

--- a/src/camp/autonomousvehicleproject.cpp
+++ b/src/camp/autonomousvehicleproject.cpp
@@ -37,6 +37,7 @@
 #include "map/map_item.h"
 #include "map/layer_list.h"
 #include "raster/raster_layer.h"
+#include "raster/gggs_tile_layer.h"
 #include <QSettings>
 #include <algorithm>
 
@@ -64,7 +65,7 @@ AutonomousVehicleProject::AutonomousVehicleProject(QObject *parent) : QAbstractI
     m_root->setObjectName("root");
     m_currentGroup = m_root;
     setObjectName("projectModel");
-    
+
     //m_ROSLink =  new ROSLink(this);
     //connect(this,&AutonomousVehicleProject::showTail,m_ROSLink, &ROSLink::showTail);
     //connect(this,&AutonomousVehicleProject::followRobot,m_ROSLink, &ROSLink::followRobot);
@@ -397,6 +398,28 @@ bool AutonomousVehicleProject::hasDepth() const
     return false;
 }
 
+float AutonomousVehicleProject::getStoreElevation(QGeoCoordinate const &location) const
+{
+    // [camp#180] Walk the Map's top-level layers dynamically (no owned list, so
+    // add/remove needs no bookkeeping and can't dangle). Query only ENABLED
+    // (isVisible()) GGGS store layers — the Layers-tab checkbox maps to
+    // MapItem::isVisible() (map.cpp), matching ADR-0003 §2's enabled-layer
+    // contract for getDepth. First store with a value at the point wins.
+    auto* layers = m_map ? m_map->topLevelLayers() : nullptr;
+    if(!layers)
+        return std::nanf("");
+    for(auto* item : layers->childMapItems())
+    {
+        auto* store = dynamic_cast<camp::raster::GggsTileLayer*>(item);
+        if(!store || !store->isVisible())
+            continue;
+        const float elevation = store->getElevation(location);
+        if(!std::isnan(elevation))
+            return elevation;
+    }
+    return std::nanf("");
+}
+
 Behavior * AutonomousVehicleProject::createBehavior()
 {
     Behavior *b = potentialParentItemFor("Behavior")->createMissionItem<Behavior>(generateUniqueLabel("behavior"));
@@ -463,7 +486,7 @@ MissionItem *AutonomousVehicleProject::potentialParentItemFor(std::string const 
 
 Waypoint *AutonomousVehicleProject::addWaypoint(QGeoCoordinate position)
 {
-    
+
     Waypoint *wp = potentialParentItemFor("Waypoint")->createMissionItem<Waypoint>(generateUniqueLabel("waypoint"));
     wp->setLocation(position);
     connect(this,&AutonomousVehicleProject::updatingBackground,wp,&Waypoint::updateBackground);
@@ -477,7 +500,7 @@ SurveyPattern * AutonomousVehicleProject::createSurveyPattern(MissionItem* paren
     SurveyPattern *sp;
     if(label.isEmpty())
         label = generateUniqueLabel("pattern");
-    if(!parent) 
+    if(!parent)
         sp = potentialParentItemFor("SurveyPattern")->createMissionItem<SurveyPattern>(label, row);
     else
         sp = parent->createMissionItem<SurveyPattern>(label, row);
@@ -543,7 +566,7 @@ SearchPattern * AutonomousVehicleProject::createSearchPattern(MissionItem* paren
   SearchPattern *sp;
   if(label.isEmpty())
     label = generateUniqueLabel("pattern");
-  if(!parent) 
+  if(!parent)
     sp = potentialParentItemFor("SearchPattern")->createMissionItem<SearchPattern>(label, row);
   else
     sp = parent->createMissionItem<SearchPattern>(label, row);
@@ -700,13 +723,13 @@ QJsonDocument AutonomousVehicleProject::generateMissionTask(const QModelIndex& i
 {
     MissionItem *mi = itemFromIndex(index);
     QJsonDocument plan;// = generateMissionPlan(index);
-    
+
     QJsonArray topArray;
     QJsonObject miObject;
     mi->write(miObject);
     topArray.append(miObject);
     plan.setArray(topArray);
-    
+
     return plan;
 }
 
@@ -714,7 +737,7 @@ void AutonomousVehicleProject::sendToROS(const QModelIndex& index)
 {
     MissionItem *mi = itemFromIndex(index);
     QJsonDocument plan = generateMissionTask(index);
-    
+
     if(m_activePlatform)
     {
         m_activePlatform->missionManager()->sendMissionPlan(plan.toJson());
@@ -891,7 +914,7 @@ void AutonomousVehicleProject::deleteItem(MissionItem *item)
 void AutonomousVehicleProject::setCurrent(const QModelIndex &index)
 {
     auto last_selected = m_currentSelected;
-    
+
     m_currentSelected = itemFromIndex(index);
     if(m_currentSelected)
     {
@@ -947,7 +970,7 @@ QModelIndex AutonomousVehicleProject::index(int row, int column, const QModelInd
 
 QModelIndex AutonomousVehicleProject::indexFromItem(MissionItem* item) const
 {
-    if(item) 
+    if(item)
     {
         if(item == m_root)
             return createIndex(0,0,item);
@@ -988,7 +1011,7 @@ int AutonomousVehicleProject::columnCount(const QModelIndex& parent) const
 QModelIndex AutonomousVehicleProject::parent(const QModelIndex& child) const
 {
     if(child.isValid() && itemFromIndex(child))
-    {        
+    {
         MissionItem* item = qobject_cast<MissionItem*>(itemFromIndex(child)->parent());
         if(item)
             return createIndex(item->row(),0,item);
@@ -1032,7 +1055,7 @@ Qt::ItemFlags AutonomousVehicleProject::flags(const QModelIndex& index) const
 
         if(qobject_cast<Point*>(item))
             return QAbstractItemModel::flags(index)|Qt::ItemIsDragEnabled;
-        
+
         if(qobject_cast<Polygon*>(item))
             return QAbstractItemModel::flags(index)|Qt::ItemIsDragEnabled;
 
@@ -1041,7 +1064,7 @@ Qt::ItemFlags AutonomousVehicleProject::flags(const QModelIndex& index) const
 
         return QAbstractItemModel::flags(index)|Qt::ItemIsDragEnabled|Qt::ItemIsDropEnabled;
     }
-    
+
     return Qt::ItemIsDropEnabled;
 }
 
@@ -1097,24 +1120,24 @@ QMimeData * AutonomousVehicleProject::mimeData(const QModelIndexList& indexes) c
         if(item)
             itemList.append(item);
     }
-    
+
     if(itemList.empty())
         return nullptr;
 
     QMimeData *mimeData = new QMimeData();
-    
+
     QJsonArray mimeArray;
-    
+
     for(MissionItem *item: itemList)
     {
         QJsonObject itemObject;
         item->write(itemObject);
         mimeArray.append(itemObject);
     }
-    
+
     mimeData->setData("application/json", QJsonDocument(mimeArray).toJson());
     mimeData->setData("text/plain", QJsonDocument(mimeArray).toJson());
-        
+
     return mimeData;
 }
 
@@ -1124,16 +1147,16 @@ bool AutonomousVehicleProject::canDropMimeData(const QMimeData* data, Qt::DropAc
     // qDebug() << "  parent valid:" << parent.isValid();
     // qDebug() << "  dropMimeData: " << row << ", " << column;
     // qDebug() << "  mime encoded: " << data->data("application/json");
-    
+
     QJsonDocument doc(QJsonDocument::fromJson(data->data("application/json")));
-    
+
     MissionItem * parentItem = itemFromIndex(parent);
     if(!parentItem)
     {
         parentItem = m_root;
         row = -1;
     }
-    
+
     // qDebug() << "  parent: " << parentItem->objectName();
 
     if(doc.array().empty())
@@ -1153,22 +1176,22 @@ bool AutonomousVehicleProject::dropMimeData(const QMimeData* data, Qt::DropActio
     // qDebug() << "parent valid:" << parent.isValid();
     qDebug() << "dropMimeData: " << row << ", " << column;
     qDebug() << "mime encoded: " << data->data("application/json");
-    
+
     QJsonDocument doc(QJsonDocument::fromJson(data->data("application/json")));
-    
+
     MissionItem * parentItem = itemFromIndex(parent);
     if(!parentItem)
     {
         parentItem = m_root;
         row = -1;
     }
-    
+
     // qDebug() << "parent: " << parentItem->objectName();
 
     parentItem->readChildren(doc.array(), row);
 
     return true;
-        
+
 }
 
 void AutonomousVehicleProject::updateMapScale(qreal scale)
@@ -1205,13 +1228,13 @@ QString AutonomousVehicleProject::generateUniqueLabel(std::string const &prefix)
     std::stringstream number;
     number << unique_label_counter;
     unique_label_counter++;
-    
+
     int padding = 4-number.str().length();
     for(int i = 0; i < padding; i++)
         ret << '0';
-    
+
     ret << number.str();
-    
+
     return QString(ret.str().c_str());
 }
 
@@ -1259,4 +1282,3 @@ AutonomousVehicleProject::RowInserter::~RowInserter()
 {
     m_project.endInsertRows();
 }
-

--- a/src/camp/autonomousvehicleproject.h
+++ b/src/camp/autonomousvehicleproject.h
@@ -76,13 +76,23 @@ public:
     // data. hasDepth() gates depth-aware planning. See ADR-0002.
     float getDepth(QGeoCoordinate const &location) const;
     bool hasDepth() const;
+
+    // [camp#180] Ellipsoidal up-positive elevation at a geographic point from the
+    // open GGGS store layers (Stores tab), or NaN where none covers the point.
+    // Walks the Map's top-level layers dynamically each call (so layer add/remove
+    // needs no bookkeeping and can't dangle) and consults only ENABLED
+    // (Layers-tab-checked / isVisible()) stores, mirroring ADR-0003 §2's
+    // enabled-layer contract for getDepth. Kept separate from getDepth() because
+    // store values are ellipsoidal heights, not chart-datum depths — distinct
+    // labels until the datum service (#288).
+    float getStoreElevation(QGeoCoordinate const &location) const;
     MissionItem *potentialParentItemFor(std::string const &childType);
 
     Waypoint *addWaypoint(QGeoCoordinate position);
 
     SurveyPattern * createSurveyPattern(MissionItem* parent=nullptr, int row=-1, QString label = "");
     SurveyPattern * addSurveyPattern(QGeoCoordinate position);
-    
+
     SurveyArea * createSurveyArea(MissionItem* parent=nullptr, int row=-1, QString label = "");
     SurveyArea * addSurveyArea(QGeoCoordinate position);
 
@@ -96,13 +106,13 @@ public:
     TrackLine * addTrackLine(QGeoCoordinate position);
 
     Behavior * createBehavior();
-    
+
     Group * createGroup(MissionItem* parent=nullptr, int row=-1, QString label = "");
     Group * addGroup();
 
     Orbit * createOrbit(MissionItem* parent=nullptr, int row=-1, QString label = "");
     Orbit * addOrbit();
-    
+
     MissionItem *itemFromIndex(QModelIndex const &index) const;
 
     Qt::ItemFlags flags(const QModelIndex & index) const override;
@@ -110,7 +120,7 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
     int rowCount(const QModelIndex & parent) const override;
     int columnCount(const QModelIndex & parent) const override;
-    
+
     QModelIndex index(int row, int column, const QModelIndex & parent) const override;
     QModelIndex parent(const QModelIndex & child) const override;
     QModelIndex indexFromItem(MissionItem * item) const;
@@ -120,11 +130,11 @@ public:
     // DisplayRole) but emits no model signal, so the view never refreshes —
     // the rename silently has no visible effect. Route renames through here.
     void renameItem(MissionItem * item, const QString & label);
-    
+
     Qt::DropActions supportedDropActions() const override;
-    
+
     bool removeRows(int row, int count, const QModelIndex & parent) override;
-    
+
     QStringList mimeTypes() const override;
     QMimeData * mimeData(const QModelIndexList & indexes) const override;
     bool canDropMimeData(const QMimeData * data, Qt::DropAction action, int row, int column, const QModelIndex & parent) const override;
@@ -133,20 +143,20 @@ public:
     QString const &filename() const;
     void save(QString const &fname = QString());
     void open(QString const &fname);
-    
+
     void openGeometry(QString const &fname, QString label = "");
-    
+
     void import(QString const &fname);
 
     bool importGeoJson(QString const &fname);
 
     void setCurrent(const QModelIndex &index);
     MissionItem *currentSelected() const;
-    
+
     QSvgRenderer * symbols() const;
-    
+
     qreal mapScale() const;
-    
+
     Platform* activePlatform() const;
 
     QJsonDocument generateMissionPlan(QModelIndex const &index);
@@ -174,7 +184,7 @@ public slots:
     void appendMission(QModelIndex const &index);
     void prependMission(QModelIndex const &index);
     void updateMission(QModelIndex const &index);
-    
+
     void deleteItems(QModelIndexList const &indices);
     void deleteItem(QModelIndex const &index);
     void deleteItem(MissionItem *item);
@@ -209,7 +219,7 @@ private:
     MissionItem * m_currentSelected;
 
     Platform* m_activePlatform = nullptr;
-    
+
     QSvgRenderer* m_symbols;
 
     bool m_contextMode = false;
@@ -232,26 +242,26 @@ private:
     void onChartLayerRemoved(const QModelIndex& parent, int first, int last);
     QString generateUniqueLabel(std::string const &prefix);
 
-    
+
 public:
-    
+
     class RowInserter
     {
     public:
         RowInserter(AutonomousVehicleProject &project, MissionItem *parent, int row=-1);
-        
+
         ~RowInserter();
     private:
         AutonomousVehicleProject &m_project;
     };
 
-private:    
+private:
     friend class RowInserter;
-    
+
     qreal m_map_scale;
-    
+
     // Counter to generate unique labels. Should probably be static, but if only once instance of AutonomousVehicleProject, then doesn't matter.
-    int unique_label_counter; 
+    int unique_label_counter;
 };
 
 #endif // AUTONOMOUSVEHICLEPROJECT_H

--- a/src/camp/projectview.cpp
+++ b/src/camp/projectview.cpp
@@ -209,6 +209,15 @@ void ProjectView::mouseMoveEvent(QMouseEvent *event)
     QGeoCoordinate llMouse = web_mercator::mapToGeo(transformedMouse);
     posText += " WGS84: " + llMouse.toString(QGeoCoordinate::Degrees) + " (" + llMouse.toString(QGeoCoordinate::DegreesMinutesWithHemisphere) + ")";
 
+    // [camp#180] GGGS store layers report ellipsoidal up-positive elevation, not
+    // chart-datum depth. Query stores first (they take precedence) and label the
+    // value distinctly so the operator can tell the two datums apart until the
+    // datum service (#288). Both labels can appear when a store and a depth chart
+    // overlap the cursor.
+    const float elevation = m_project->getStoreElevation(llMouse);
+    if(!std::isnan(elevation))
+        posText += " Elev: " + QString::number(elevation) + " (ellipsoid)";
+
     const float depth = m_project->getDepth(llMouse);
     if(!std::isnan(depth))
         posText += " Depth: " +QString::number(depth);
@@ -359,11 +368,11 @@ void ProjectView::contextMenuEvent(QContextMenuEvent* event)
         menu.addSeparator();
         menu.addAction("(Below moves camera)");
         menu.addSeparator();
-        
-        
+
+
         QAction *lookAtAction = menu.addAction("Look Here");
         connect(lookAtAction, &QAction::triggered, this, &ProjectView::sendLookAt);
-        
+
         QAction *lookAtASVAction = menu.addAction("Look at ASV");
         connect(lookAtASVAction, &QAction::triggered, this, &ProjectView::sendLookAtASV);
 

--- a/src/camp_map/raster/gggs_tile.cpp
+++ b/src/camp_map/raster/gggs_tile.cpp
@@ -1,7 +1,10 @@
 #include "gggs_tile.h"
 
+#include "gggs_tile_util.h"
+
 #include <gdal_priv.h>
 
+#include <QFileInfo>
 #include <QOpenGLTexture>
 #include <algorithm>
 #include <cmath>
@@ -16,6 +19,11 @@ namespace raster
 GggsTile::GggsTile(const QString& path):
   path_(path)
 {
+  // [camp#180] Parse the LOD level once from the basename (immutable for the
+  // tile's lifetime) so getElevation() need not re-run the regex per cursor move.
+  // Independent of the GDAL open below, so it is set even for an invalid tile.
+  level_ = tileLevel(QFileInfo(path).fileName());
+
   if(GDALGetDriverCount() == 0)
     GDALAllRegister();
 

--- a/src/camp_map/raster/gggs_tile.cpp
+++ b/src/camp_map/raster/gggs_tile.cpp
@@ -220,8 +220,11 @@ QOpenGLTexture* GggsTile::texture()
     // was freed here pre-#180 to halve resident memory). sampleAt() indexes this
     // resident buffer for the depth-at-cursor readout, so a point query stays a
     // cheap in-memory lookup with no synchronous GDAL re-open on the GUI thread
-    // (Plan Review #4). The texture still persists for the tile's lifetime (we
-    // never re-upload); the trade-off is a painted tile now holds both copies.
+    // (Plan Review #4). Note the CPU buffer is actually held by EVERY loaded tile
+    // (it is filled in loadPixels() and never freed), not just painted ones — so
+    // the resident-memory footprint scales with the number of LOADED tiles. A
+    // painted tile additionally holds the GL texture created here (kept for the
+    // tile's lifetime; we never re-upload), so it alone carries both copies.
   }
   return texture_.get();
 }

--- a/src/camp_map/raster/gggs_tile.cpp
+++ b/src/camp_map/raster/gggs_tile.cpp
@@ -128,6 +128,34 @@ bool GggsTile::loadPixels()
   return true;
 }
 
+float GggsTile::sampleAt(double lon, double lat) const
+{
+  // [camp#180] ACQUIRE gate, pairing with loadPixels()'s RELEASE store: false
+  // until the worker has published BOTH data_ and the deferred NoData members
+  // (nodata_/has_nodata_), so neither is ever read while unset (Plan Review #1).
+  // A tile whose pixels were dropped (setBand()) also fails this gate.
+  if(!pixelsLoaded() || data_.empty())
+    return std::nanf("");
+
+  // North-up geotransform (geo[2] == geo[4] == 0): invert to a pixel index.
+  // geo[1] > 0 (lon/px), geo[5] < 0 (lat/px). A degenerate zero pixel size can't
+  // index — treat as a miss rather than divide by zero.
+  if(geo_transform_[1] == 0.0 || geo_transform_[5] == 0.0)
+    return std::nanf("");
+  const int col = int(std::floor((lon - geo_transform_[0]) / geo_transform_[1]));
+  const int row = int(std::floor((lat - geo_transform_[3]) / geo_transform_[5]));
+  if(col < 0 || col >= width_ || row < 0 || row >= height_)
+    return std::nanf("");
+
+  const float v = data_[static_cast<size_t>(row) * width_ + col];
+  // [camp#122] Same value filter as loadPixels()'s range loop: exclude non-finite
+  // and the float-compared NoData sentinel so a masked pixel reads as "no value"
+  // rather than a spurious elevation.
+  if(!std::isfinite(v) || (has_nodata_ && v == float(nodata_)))
+    return std::nanf("");
+  return v;
+}
+
 void GggsTile::setBand(int band)
 {
   // [camp#108] Switch which band loadPixels() reads. Out-of-range is a no-op so
@@ -174,10 +202,12 @@ QOpenGLTexture* GggsTile::texture()
     // rationale (Nearest avoids the NoData-sentinel halo the shader's exact-equality
     // discard would otherwise blend across). No upload-time setMinMagFilters() here.
     texture_->setWrapMode(QOpenGLTexture::ClampToEdge);
-    // Free the CPU copy once it's on the GPU — the texture persists for the
-    // tile's lifetime, so we never re-upload (releaseGL = teardown). Halves
-    // resident memory per tile. dataMin/dataMax were captured at load.
-    data_ = std::vector<float>();
+    // [camp#180] The CPU copy is intentionally RETAINED past the GPU upload (it
+    // was freed here pre-#180 to halve resident memory). sampleAt() indexes this
+    // resident buffer for the depth-at-cursor readout, so a point query stays a
+    // cheap in-memory lookup with no synchronous GDAL re-open on the GUI thread
+    // (Plan Review #4). The texture still persists for the tile's lifetime (we
+    // never re-upload); the trade-off is a painted tile now holds both copies.
   }
   return texture_.get();
 }

--- a/src/camp_map/raster/gggs_tile.cpp
+++ b/src/camp_map/raster/gggs_tile.cpp
@@ -150,6 +150,12 @@ float GggsTile::sampleAt(double lon, double lat) const
   // index — treat as a miss rather than divide by zero.
   if(geo_transform_[1] == 0.0 || geo_transform_[5] == 0.0)
     return std::nanf("");
+  // [camp#180] The diagonal-only inversion below assumes no rotation/shear
+  // (geo[2] == geo[4] == 0), which holds for every GGGS tile (north-up WGS84 by
+  // construction — see the ctor's extent math). Guard the assumption rather than
+  // silently return a mis-indexed sample if a sheared tile ever slips through.
+  if(geo_transform_[2] != 0.0 || geo_transform_[4] != 0.0)
+    return std::nanf("");
   const int col = int(std::floor((lon - geo_transform_[0]) / geo_transform_[1]));
   const int row = int(std::floor((lat - geo_transform_[3]) / geo_transform_[5]));
   if(col < 0 || col >= width_ || row < 0 || row >= height_)

--- a/src/camp_map/raster/gggs_tile.h
+++ b/src/camp_map/raster/gggs_tile.h
@@ -82,6 +82,17 @@ public:
   bool hasNoData() const { return has_nodata_; }
   double noData() const { return nodata_; }
 
+  /// [camp#180] Sample the loaded band at a geographic point — the value at
+  /// (@p lon, @p lat) degrees, or NaN if the point is outside the tile, the
+  /// sample is NoData / non-finite, or the pixels are not resident. A pure
+  /// in-memory index into the resident CPU buffer (no GDAL I/O), cheap enough to
+  /// call per cursor move on the GUI thread. Gated on the same pixelsLoaded()
+  /// ACQUIRE the paint path uses; that gate is set by loadPixels() AFTER the
+  /// deferred NoData members are populated, so this never reads nodata_/
+  /// has_nodata_ while unset. Safe against the load worker for the same
+  /// happens-before reason (see pixelsLoaded()).
+  float sampleAt(double lon, double lat) const;
+
   /// Min / max over valid (non-NoData, finite) samples. min_ > max_ if the tile
   /// has no valid samples. Used by the layer to auto-range the grayscale ramp.
   double dataMin() const { return data_min_; }

--- a/src/camp_map/raster/gggs_tile.h
+++ b/src/camp_map/raster/gggs_tile.h
@@ -73,6 +73,13 @@ public:
   int width() const { return width_; }
   int height() const { return height_; }
 
+  /// [camp#180] The tile's LOD level, parsed once from the `<level>_<row>_<col>`
+  /// basename in the constructor (via camp::raster::tileLevel); -1 if the path is
+  /// not a value-tile name. Immutable for the tile's lifetime, so
+  /// GggsTileLayer::getElevation() reads this cached value per cursor move instead
+  /// of re-running the QFileInfo + QRegularExpression parse.
+  int level() const { return level_; }
+
   /// Geographic extent in degrees, pixel-edge aligned (north-up: row 0 = maxLat).
   double minLon() const { return min_lon_; }
   double maxLon() const { return max_lon_; }
@@ -111,6 +118,7 @@ private:
   int height_ = 0;
   int band_count_ = 0;   // [camp#108] GDAL raster-band count (0 until valid)
   int band_ = 1;         // [camp#108] selected 1-indexed band loadPixels() reads
+  int level_ = -1;       // [camp#180] LOD level parsed once from the basename
   double geo_transform_[6] = {0.0};
   double min_lon_ = 0.0, max_lon_ = 0.0, min_lat_ = 0.0, max_lat_ = 0.0;
   bool has_nodata_ = false;

--- a/src/camp_map/raster/gggs_tile_layer.cpp
+++ b/src/camp_map/raster/gggs_tile_layer.cpp
@@ -358,6 +358,8 @@ float GggsTileLayer::getElevation(const QGeoCoordinate& location) const
   // [camp#180] Depth-at-cursor query. Collect the tiles whose geographic extent
   // contains the point, pair each with its tile level, then sample finest-first
   // so the highest-resolution covering tile wins regardless of the rendered LOD.
+  // GggsTile::level() is the cached, parse-once level (no per-move QFileInfo +
+  // QRegularExpression) — keeping this hot GUI-thread path a plain extent test.
   const double lat = location.latitude();
   const double lon = location.longitude();
 
@@ -367,8 +369,7 @@ float GggsTileLayer::getElevation(const QGeoCoordinate& location) const
     if(lat < tile->minLat() || lat > tile->maxLat() ||
        lon < tile->minLon() || lon > tile->maxLon())
       continue;
-    covering.emplace_back(tileLevel(QFileInfo(tile->path()).fileName()),
-                          tile.get());
+    covering.emplace_back(tile->level(), tile.get());
   }
 
   // Descending level: the finest (highest-level) covering tile is queried first

--- a/src/camp_map/raster/gggs_tile_layer.cpp
+++ b/src/camp_map/raster/gggs_tile_layer.cpp
@@ -21,7 +21,9 @@
 #include <QUrl>
 #include <QtConcurrent>
 
+#include <algorithm>
 #include <cmath>
+#include <utility>
 #include <vector>
 
 namespace camp
@@ -349,6 +351,39 @@ QRectF GggsTileLayer::boundingRect() const
   // own space spans (0,0)..(width,height) in Web-Mercator metres. paint() and
   // drawImage() work here (small magnitudes) to keep QPainter precise.
   return QRectF(QPointF(0.0, 0.0), scene_bounds_.size());
+}
+
+float GggsTileLayer::getElevation(const QGeoCoordinate& location) const
+{
+  // [camp#180] Depth-at-cursor query. Collect the tiles whose geographic extent
+  // contains the point, pair each with its tile level, then sample finest-first
+  // so the highest-resolution covering tile wins regardless of the rendered LOD.
+  const double lat = location.latitude();
+  const double lon = location.longitude();
+
+  std::vector<std::pair<int, const GggsTile*>> covering;
+  for(const auto& tile : tiles_)
+  {
+    if(lat < tile->minLat() || lat > tile->maxLat() ||
+       lon < tile->minLon() || lon > tile->maxLon())
+      continue;
+    covering.emplace_back(tileLevel(QFileInfo(tile->path()).fileName()),
+                          tile.get());
+  }
+
+  // Descending level: the finest (highest-level) covering tile is queried first
+  // (inspection > display — camp#103 follow-on). Ties keep their relative order.
+  std::stable_sort(covering.begin(), covering.end(),
+                   [](const auto& a, const auto& b) { return a.first > b.first; });
+
+  for(const auto& [level, tile] : covering)
+  {
+    (void)level;
+    const float value = tile->sampleAt(lon, lat);
+    if(!std::isnan(value))
+      return value;
+  }
+  return std::nanf("");
 }
 
 QStringList GggsTileLayer::bands() const

--- a/src/camp_map/raster/gggs_tile_layer.h
+++ b/src/camp_map/raster/gggs_tile_layer.h
@@ -8,6 +8,7 @@
 #include <marine_colormap/transfer.hpp>
 
 #include <QFutureWatcher>
+#include <QGeoCoordinate>
 #include <QImage>
 #include <QMutex>
 #include <QSize>
@@ -69,6 +70,17 @@ public:
 
   /// True once at least one valid tile loaded.
   bool valid() const { return !tiles_.empty(); }
+
+  /// [camp#180] Elevation at a geographic point from this store's tiles, or NaN
+  /// if no loaded tile covers it (or the covering tiles have no value there).
+  /// Among tiles whose extent contains @p location, the finest (highest tile
+  /// level, parsed from the `<level>_<row>_<col>` basename) is sampled first, so
+  /// inspection prefers the highest-resolution data regardless of the rendered
+  /// LOD (camp#103 follow-on). Values are the raw band samples — ellipsoidal
+  /// up-positive heights for a bathymetry store, NOT chart-datum depths. A pure
+  /// in-memory query (GggsTile::sampleAt over resident pixels); safe to call per
+  /// cursor move on the GUI thread.
+  float getElevation(const QGeoCoordinate& location) const;
 
   /// The layer's Web-Mercator extent (union of tile extents). The item is
   /// setPos()'d at its top-left; exposed for tests.

--- a/src/camp_map/raster/gggs_tile_util.h
+++ b/src/camp_map/raster/gggs_tile_util.h
@@ -32,6 +32,21 @@ inline bool isValueTile(const QString& filename)
   return re.match(filename).hasMatch();
 }
 
+/// [camp#180] Parse the LEVEL (the first digit group) from a value-tile basename
+/// `<level>_<row>_<col>.tif`. Returns -1 if @p filename is not a value tile.
+/// GggsTileLayer::getElevation() uses it to query the finest (highest-level)
+/// covering tile first, independent of the rendered LOD. Match the basename only
+/// (as QDir::entryList / QFileInfo::fileName return), never a full path — a path
+/// separator makes isValueTile() (and so this) return no match.
+inline int tileLevel(const QString& filename)
+{
+  if(!isValueTile(filename))
+    return -1;
+  // isValueTile() guarantees the leading group is all digits, so section() +
+  // toInt() is unambiguous (the tail is stripped at the first '_').
+  return filename.section('_', 0, 0).toInt();
+}
+
 }  // namespace raster
 }  // namespace camp
 

--- a/test/test_gggs_elevation.cpp
+++ b/test/test_gggs_elevation.cpp
@@ -1,0 +1,137 @@
+// [camp#180] Headless tests for GggsTileLayer::getElevation() — the store-layer
+// depth-at-cursor query wired into ProjectView via
+// AutonomousVehicleProject::getStoreElevation().
+//
+// Non-GL by construction (mirrors test_gggs_rescan.cpp): the layer is built and
+// its pixels are loaded via waitForLoad() (pure GDAL RasterIO — no GL context,
+// no paint()). Because waitForLoad() never calls texture(), the tiles' CPU
+// buffers stay resident, which is exactly the state sampleAt() indexes — so
+// getElevation() is exercised end-to-end without a window.
+//
+// Covered: the extent filter (a point outside every tile -> NaN), the
+// descending-level sort (when two tiles overlap the point, the finest / highest
+// level wins regardless of the QDir::Name load order), and the all-NoData case
+// (a covering tile with no valid sample -> NaN).
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include <gdal_priv.h>
+
+#include <QApplication>
+#include <QGeoCoordinate>
+#include <QTemporaryDir>
+
+#include "map/map.h"
+#include "map/layer_list.h"
+#include "raster/gggs_tile_layer.h"
+
+namespace
+{
+
+// Write a north-up Float32 GeoTIFF tile filled with a single @p value (NoData
+// 9999), named @p name (`<level>_<row>_<col>.tif`) with NW corner (@p lon0,
+// @p lat0). A uniform fill makes the sampled value identify which tile answered.
+QString writeUniformTile(const QTemporaryDir& dir, const QString& name,
+                         double lon0, double lat0, float value)
+{
+  if(GDALGetDriverCount() == 0)
+    GDALAllRegister();
+  const int w = 16, h = 16;
+  const double geo[6] = {lon0, 0.0001, 0.0, lat0, 0.0, -0.0001};
+  const QString path = dir.filePath(name);
+  GDALDriver* driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+  EXPECT_NE(driver, nullptr);
+  if(!driver)
+    return QString();
+  GDALDataset* ds = driver->Create(path.toUtf8().constData(), w, h, 1,
+                                   GDT_Float32, nullptr);
+  EXPECT_NE(ds, nullptr);
+  if(!ds)
+    return QString();
+  ds->SetGeoTransform(const_cast<double*>(geo));
+  GDALRasterBand* band = ds->GetRasterBand(1);
+  band->SetNoDataValue(9999.0);
+  std::vector<float> samples(static_cast<size_t>(w) * h, value);
+  const CPLErr err = band->RasterIO(GF_Write, 0, 0, w, h, samples.data(),
+                                    w, h, GDT_Float32, 0, 0);
+  GDALClose(ds);
+  return err == CE_None ? path : QString();
+}
+
+// A geographic point comfortably inside the tile whose NW corner is (lon0, lat0)
+// (the 16x16, 0.0001-deg tiles span lon0..lon0+0.0016, lat0-0.0016..lat0).
+QGeoCoordinate insidePoint(double lon0, double lat0)
+{
+  return QGeoCoordinate(lat0 - 0.0008, lon0 + 0.0008);
+}
+
+}  // namespace
+
+// The finest (highest-level) tile covering the point wins even though QDir::Name
+// loads the coarser "10_..." tile first: without the descending-level sort the
+// walk would return the coarse value.
+TEST(GggsElevationTest, FinestCoveringTileWins)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  // Two tiles at the SAME extent, distinct levels + values. "10_0_0" sorts before
+  // "13_0_0" by name, so load order alone would answer with the coarse value.
+  ASSERT_FALSE(writeUniformTile(dir, "10_0_0.tif", -71.40, 43.00, 100.0f).isEmpty());
+  ASSERT_FALSE(writeUniformTile(dir, "13_0_0.tif", -71.40, 43.00, 200.0f).isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->waitForLoad();
+
+  const float e = layer->getElevation(insidePoint(-71.40, 43.00));
+  EXPECT_FLOAT_EQ(e, 200.0f) << "finest (level 13) tile must win over level 10";
+}
+
+// A point outside every tile's extent -> NaN (the extent filter drops all tiles).
+TEST(GggsElevationTest, OutOfExtentIsNaN)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  ASSERT_FALSE(writeUniformTile(dir, "13_0_0.tif", -71.40, 43.00, 200.0f).isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->waitForLoad();
+
+  // Far from the tile (a whole degree east) -> no covering tile.
+  EXPECT_TRUE(std::isnan(layer->getElevation(QGeoCoordinate(43.00, -70.40))));
+}
+
+// A covering tile whose samples are all NoData yields no value -> NaN.
+TEST(GggsElevationTest, AllNoDataCoveringTileIsNaN)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  // Every sample equals the NoData sentinel (9999) -> masked everywhere.
+  ASSERT_FALSE(writeUniformTile(dir, "13_0_0.tif", -71.40, 43.00, 9999.0f).isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->waitForLoad();
+
+  EXPECT_TRUE(std::isnan(layer->getElevation(insidePoint(-71.40, 43.00))));
+}
+
+int main(int argc, char** argv)
+{
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QApplication app(argc, argv);
+  // [camp#117] A test org/app name keeps Map's ctor QSettings seed out of the
+  // developer's real camp settings.
+  QCoreApplication::setOrganizationName("camp_test");
+  QCoreApplication::setApplicationName("test_gggs_elevation");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_gggs_tile.cpp
+++ b/test/test_gggs_tile.cpp
@@ -446,6 +446,64 @@ TEST(GggsTileUtilTest, IsValueTileNameGrammar)
   EXPECT_TRUE(isValueTile("13_0_0.Tiff"));
 }
 
+// [camp#180] sampleAt() indexes the RESIDENT CPU buffer at a geographic point.
+// Before loadPixels() the pixels (and the deferred NoData members) are not
+// published, so the pixelsLoaded() acquire gate must make sampleAt() return NaN —
+// this is the must-fix guard that a query never reads nodata_/has_nodata_ while
+// unset (Plan Review #1). After loadPixels() a valid pixel returns its value, a
+// NoData pixel and an out-of-extent point return NaN.
+TEST(GggsTileTest, SampleAtResidentBuffer)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const int w = 2, h = 2;
+  // North-up: x0=-71.4, dlon=+0.001; y0=43.0 (north edge), dlat=-0.001. Row 0 is
+  // the north row (lat near 43.0).
+  const double geo[6] = {-71.4, 0.001, 0.0, 43.0, 0.0, -0.001};
+  // Row-major: (r0,c0)=10, (r0,c1)=NoData, (r1,c0)=30, (r1,c1)=40.
+  std::vector<float> samples = {10.0f, 9999.0f, 30.0f, 40.0f};
+  const QString path = writeFloatTile(dir, "13_7_7.tif", w, h, geo, 9999.0, samples);
+  ASSERT_FALSE(path.isEmpty());
+
+  GggsTile tile(path);
+  ASSERT_TRUE(tile.valid());
+
+  // Must-fix: before pixels load, the NoData members are unset — sampleAt() must
+  // NOT read them; the pixelsLoaded() gate makes it return NaN.
+  EXPECT_FALSE(tile.pixelsLoaded());
+  EXPECT_TRUE(std::isnan(tile.sampleAt(-71.3995, 42.9995)));
+
+  ASSERT_TRUE(tile.loadPixels());
+
+  // In-bounds valid pixels: (col 0,row 0) = 10, (col 1,row 1) = 40.
+  EXPECT_FLOAT_EQ(tile.sampleAt(-71.3995, 42.9995), 10.0f);  // pixel (0,0)
+  EXPECT_FLOAT_EQ(tile.sampleAt(-71.3985, 42.9985), 40.0f);  // pixel (1,1)
+
+  // A NoData pixel (col 1,row 0) reads as no value.
+  EXPECT_TRUE(std::isnan(tile.sampleAt(-71.3985, 42.9995)));
+
+  // Out of extent (east of maxLon and north of maxLat) -> NaN.
+  EXPECT_TRUE(std::isnan(tile.sampleAt(-71.0, 42.9995)));
+  EXPECT_TRUE(std::isnan(tile.sampleAt(-71.3995, 44.0)));
+}
+
+// [camp#180] tileLevel() parses the leading LEVEL group from a value-tile
+// basename and rejects non-value names (companions, malformed, wrong extension).
+// getElevation() relies on it to query the finest (highest-level) tile first.
+TEST(GggsTileUtilTest, TileLevelParse)
+{
+  EXPECT_EQ(camp::raster::tileLevel("0_0_0.tif"), 0);
+  EXPECT_EQ(camp::raster::tileLevel("13_10_20.tif"), 13);
+  EXPECT_EQ(camp::raster::tileLevel("7_1_2.tiff"), 7);
+  EXPECT_EQ(camp::raster::tileLevel("13_10_20.TIF"), 13);   // case-insensitive ext
+
+  // Not value tiles -> -1 (companions, too few groups, wrong extension, junk).
+  EXPECT_EQ(camp::raster::tileLevel("13_10_20_time.tif"), -1);
+  EXPECT_EQ(camp::raster::tileLevel("13_0.tif"), -1);
+  EXPECT_EQ(camp::raster::tileLevel("13_0_0.png"), -1);
+  EXPECT_EQ(camp::raster::tileLevel("x13_0_0.tif"), -1);
+}
+
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Wires GGGS store layers into the status-bar depth-at-cursor readout: hovering over an open bathy store (e.g. the S-102 reference store from rolker/unh_marine_autonomy#278) now reports the store's value, where previously only legacy background chart rasters contributed.

Closes #180

## What's here

- `GggsTile::sampleAt()` — resident-buffer point sample (no GDAL open on the cursor path); returns NaN before `loadPixels()` and applies the tile's NoData mask; guards sheared geotransforms (returns NaN rather than a wrong value); cached LOD level replaces per-move basename parsing.
- `GggsTileLayer::getElevation()` — extent filter → finest-covering-tile-wins walk over loaded tiles.
- `getStoreElevation()` joins the depth-provider walk, consulting only Layers-tab-**enabled** layers (ADR-0003 §2); precedence: stores first, then chart rasters, load order within. Deregistration on layer remove and shutdown covered.
- Readout labels the value as the store's native ellipsoidal up-positive height. Datum-referenced display (depth below chart datum) is the follow-on riding rolker/unh_marine_autonomy#288, as scoped in the issue.
- Docs: recorded the pre-existing `getDepth` visibility divergence and the actual CPU-buffer retention behavior in `texture()`.

## Test plan

- New GL-free unit tests: `sampleAt()` resident-buffer semantics (NaN-before-load, NoData mask), `tileLevel()` parse, `getElevation()` extent filter + finest-wins, provider-walk visibility filtering. Full camp suite **194 tests, 0 failures** (12 pre-existing GL skips in-container).
- Known-minor: the sheared-geotransform guard has no dedicated unit test — the input cannot occur by construction for GGGS store tiles (north-up by contract); guard exists as defense-in-depth.

## Review history (local-first)

Issue review → plan → plan review (approve-with-suggestions, all 4 findings folded pre-implementation) → implement → pre-push R1 approved (0 must-fix, Ship: recommended) → operator-requested suggestion pass (4 commits) → R2 approved (0 must-fix, Ship: recommended). Timeline in `.agent/work-plans/issue-180/progress.md`.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
