### PR TITLE
Live coverage robustness: re-add after remove, request resume on enable, tile dimension caps

### DIFF
--- a/.agent/work-plans/issue-168/plan.md
+++ b/.agent/work-plans/issue-168/plan.md
@@ -46,16 +46,19 @@ permanently, and the layer cannot be re-added within the session.
 4. **Update the header comment** (sonar_live_cache_manager.h:36-38) to note that
    removal now clears the entry.
 
-5. **Regression test** (`test_sonar_live_cache_manager_respawn.cpp`): create a
-   `SonarLiveCacheLayer` headlessly (null Node, same harness as
-   `test_sonar_live_eviction.cpp`), maintain a local `std::set<std::string>`,
-   connect its `QObject::destroyed` to erase from that set (the same lambda
-   pattern the fix adds to `updateTopics()`), delete the layer, and assert the
-   set is empty. This tests the exact mechanism the fix relies on without
-   needing the full manager stack (which requires a live `Node` ancestor for
-   `updateTopics()` to proceed). One `ament_add_gtest` block per
-   CMakeLists.txt:925 pattern (same include-dirs, deps, link-libs as
-   `test_sonar_live_eviction`).
+5. **Regression test — white-box on the real manager** (amended per Plan Review
+   round 2, adopted at the plan checkpoint): factor the tracking contract out of
+   `updateTopics()` into a protected `trackSpawnedLayer(const std::string& base,
+   QObject* layer)` (inserts into `sources_` + connects `destroyed` → erase), and
+   add a public const accessor `isSourceTracked(const std::string& base)`. The
+   test (`test_sonar_live_cache_manager_respawn.cpp`) subclasses the manager to
+   promote `trackSpawnedLayer` (`using`-declaration), tracks a plain `QObject`
+   (the contract is QObject-generic), asserts `isSourceTracked()` flips
+   true → (delete layer) → false, and re-tracks to prove respawn. This exercises
+   the manager's REAL set and REAL `connect` wiring — deleting the `connect`
+   line fails the test — without needing the live `Node` ancestor that
+   `updateTopics()` requires. One `ament_add_gtest` block per CMakeLists.txt:925
+   pattern (same include-dirs, deps, link-libs as `test_sonar_live_eviction`).
 
 ### #168 Files to Change
 
@@ -159,6 +162,14 @@ They are deferred to follow-up issues referencing #154/#155/#156.
    `kMaxImageEdge = 4096` is already a private static constexpr on the class
    (sonar_live_cache_layer.h:221). `kMaxBandCount` is a new local constant in
    the `.cpp`.
+
+   **Amended per Plan Review round 2 (adopted at the plan checkpoint)**: also
+   enforce a combined per-message allocation ceiling — per-dimension caps alone
+   still admit `4096×4096×64 bands×4 B ≈ 4 GB`. Add
+   `kMaxTileBytes = 256 MiB` (a full 4096×4096 float tile is 64 MiB/band, so
+   this admits any legitimate ≤4-band full-size tile while bounding the worst
+   case at ~6% of the old ceiling) and reject when
+   `width × height × bands × sizeof(float) > kMaxTileBytes`, same warning path.
 
 2. **Regression test** (extend `test_sonar_live_cache.cpp` or new
    `test_sonar_live_tile_validation.cpp`): enable a headless layer, invoke

--- a/.agent/work-plans/issue-168/plan.md
+++ b/.agent/work-plans/issue-168/plan.md
@@ -1,105 +1,228 @@
-# Plan: SonarLiveCacheManager never clears spawned-sources map on layer removal
+# Plan: Bundle — camp#168 / camp#169 / camp#170 (2026-07-23 field incident)
 
-## Issue
+## Issues
 
-https://github.com/rolker/camp/issues/168
+- https://github.com/rolker/camp/issues/168 — SonarLiveCacheManager never clears spawned-sources map on layer removal
+- https://github.com/rolker/camp/issues/169 — Live coverage requests never resume after restart/re-enable
+- https://github.com/rolker/camp/issues/170 — No cap on incoming coverage-tile dimensions (crash path)
 
-## Context
+**One PR, three atomic commits (user decision 2026-08-05).**
+
+---
+
+## Issue #168 — sources_ not cleared on layer destruction
+
+### Context
 
 `SonarLiveCacheManager::updateTopics()` guards against duplicate-spawn using
-`std::map<std::string, bool> sources_` (sonar_live_cache_manager.h:38). On each
-DDS graph update it checks `if(sources_[base]) continue;` before spawning a
-`SonarLiveCacheLayer` (sonar_live_cache_manager.cpp:64-65, 69-70). When the
-operator removes the layer, `Layer::removeFromMap()` calls `deleteLater()` but
-`sources_` is never updated — no `onRemovedFromMap()` override, no signal
-connection, nothing. After removal every subsequent `updateTopics()` skips the
-source permanently, making it impossible to re-add the live coverage layer within
-a session without a full restart.
+`std::map<std::string, bool> sources_`. After the operator removes a
+`SonarLiveCacheLayer` (`deleteLater()` via `Layer::removeFromMap()`), `sources_`
+is never cleared — the entry stays `true`, `updateTopics()` skips the base
+permanently, and the layer cannot be re-added within the session.
 
-The correct fix is to clear `sources_[base]` when the spawned layer is
-destroyed. The `QObject::destroyed` signal (fired at the start of the `QObject`
-destructor, before any of the Qt child-management or signal/slot bookkeeping) is
-the right hook: it fires whether the layer is removed by the user, by a
-programmatic owner, or on app shutdown — unlike `onRemovedFromMap()`, which the
-base-class `Layer::removeFromMap()` calls but which is skipped on normal app exit
-(layer.cpp:59; camp#90).
+### Approach (#168 commit)
 
-## Approach
+1. **Switch `sources_` from `map<string,bool>` to `set<string>`** — the `bool`
+   value was always `true` and vestigial; `set` expresses the invariant directly.
+   Add `#include <set>` to the header, remove `#include <map>`.
 
-1. **Wire `destroyed` signal at spawn time** — In `updateTopics()`, after spawning
-   the layer, connect its `QObject::destroyed` signal to a lambda (captured by the
-   manager, with `Qt::ConnectionType::DirectConnection` — acceptable because the
-   lambda only calls `std::map::erase`, which is fast and safe on the GUI thread)
-   that erases the base entry from `sources_`.
+2. **Fix the guard** — `if(sources_[base])` → `if(sources_.count(base))`.
+   `operator[]` inserts a default-`false` entry for every scanned topic (side
+   effect); `count()` is read-only. Replace `sources_[base] = true` →
+   `sources_.insert(base)`.
 
-2. **Switch guard to `count()` / `find()`** — The current `if(sources_[base])`
-   uses `operator[]`, which inserts a default `false` entry for every unknown base
-   encountered. Replace with `sources_.count(base)` (no side-effect) so the map
-   stays clean (only live spawned bases present, not also every scanned base).
+3. **Wire the `destroyed` signal at spawn time** — immediately after
+   `sources_.insert(base)`, add:
+   ```cpp
+   // Between deleteLater() and ~QObject the entry stays; the event loop drains
+   // before an operator's re-add, so no spurious re-spawn in that window.
+   connect(layer, &QObject::destroyed, this, [this, base]() { sources_.erase(base); },
+           Qt::DirectConnection);
+   ```
+   `Qt::DirectConnection` is safe: the lambda touches only `std::set::erase`,
+   which is fast and runs on the GUI thread (both `deleteLater()` and
+   `QObject::destroyed` dequeue there).
 
-3. **Add a regression test** — New test `test_sonar_live_cache_manager_respawn.cpp`
-   using the Qt + Map harness (QApplication, `camp::map::Map`, `camp::map::LayerList`)
-   to exercise spawn → remove → spawn on the same source. The test creates a minimal
-   `SonarLiveCacheManager` sub-object, calls `updateTopics()` via a testable seam,
-   removes the spawned layer, and verifies a second `updateTopics()` call re-spawns.
-   If the manager setup cost is too high without a ROS node, scope the test to verify
-   only the `destroyed`-signal erasure in isolation (mock layer, check `sources_` via
-   a test-friend or white-box inspection).
+4. **Update the header comment** (sonar_live_cache_manager.h:36-38) to note that
+   removal now clears the entry.
 
-   **Open question**: whether a lightweight integration test (no ROS node, Qt only)
-   is feasible without significant refactor of `SonarLiveCacheManager`'s constructor.
-   If not, document the manual verification path and file a follow-up (#169-compat test).
+5. **Regression test** (`test_sonar_live_cache_manager_respawn.cpp`): create a
+   `SonarLiveCacheLayer` headlessly (null Node, same harness as
+   `test_sonar_live_eviction.cpp`), maintain a local `std::set<std::string>`,
+   connect its `QObject::destroyed` to erase from that set (the same lambda
+   pattern the fix adds to `updateTopics()`), delete the layer, and assert the
+   set is empty. This tests the exact mechanism the fix relies on without
+   needing the full manager stack (which requires a live `Node` ancestor for
+   `updateTopics()` to proceed). One `ament_add_gtest` block per
+   CMakeLists.txt:925 pattern (same include-dirs, deps, link-libs as
+   `test_sonar_live_eviction`).
 
-## Files to Change
+### #168 Files to Change
 
 | File | Change |
 |------|--------|
-| `src/camp_map/ros/live_coverage/sonar_live_cache_manager.cpp` | In `updateTopics()`: (a) switch `if(sources_[base])` → `if(sources_.count(base))`, and (b) after `sources_[base] = true`, add `connect(layer, &QObject::destroyed, this, [this, base]() { sources_.erase(base); });` |
-| `test/test_sonar_live_cache_manager_respawn.cpp` | New test: spawn a `SonarLiveCacheLayer` for a base, call `removeFromMap()`, verify `sources_` no longer contains the base (or verify a second spawn attempt succeeds) |
-| `CMakeLists.txt` | Add the new test source to the camp_tests target (same pattern as other `test_sonar_live_*.cpp` entries) |
+| `src/camp_map/ros/live_coverage/sonar_live_cache_manager.h` | `map<string,bool>` → `set<string>`; update comment; swap includes |
+| `src/camp_map/ros/live_coverage/sonar_live_cache_manager.cpp` | fix guard (`count`), fix insert, add `connect(destroyed → erase)` |
+| `test/test_sonar_live_cache_manager_respawn.cpp` | new test (headless, null Node) |
+| `CMakeLists.txt` | new `ament_add_gtest` block after `test_sonar_live_eviction` |
+
+---
+
+## Issue #169 — catalog latched while disabled; no reconcile on enable
+
+### Context
+
+`publishRequest()` has exactly one call site: `handleCatalog()`, which
+early-returns when `!enabled_` (sonar_live_cache_layer.cpp:391-395) without
+buffering the message. The catalog subscription is transient-local depth-1
+(created in the constructor, never torn down). If the single latched catalog
+arrives before `QTimer::singleShot(0)` fires the settings-restore enable,
+`handleCatalog` discards it and no subsequent catalog arrives — requests never
+fire. The same gap applies to disable→re-enable within a session
+(`unsubscribeTiles()` tears down `request_pub_`; re-enable never reconciles).
+
+### Approach (#169 commit)
+
+1. **Add `last_catalog_`** — add `std::optional<marine_interfaces::msg::TileCatalog>
+   last_catalog_;` to `SonarLiveCacheLayer`'s private members (sonar_live_cache_layer.h).
+   Include `<optional>` (already present) and `marine_interfaces/msg/tile_catalog.hpp`
+   (already included).
+
+2. **Buffer in `handleCatalog()`** — before the `if(!enabled_)` early-return,
+   always write `last_catalog_ = msg;`. When disabled, return after buffering (not
+   before). No other change to the disabled-path logic.
+
+3. **Replay on enable** — in `enableLiveCoverage()`, after `subscribeTiles()` and
+   before `writeSettings()`, add:
+   ```cpp
+   if(last_catalog_)
+     handleCatalog(*last_catalog_);   // GUI thread, direct call — no marshal needed
+   ```
+   At this point `enabled_` is `true`, so `handleCatalog` will proceed to reconcile
+   and (if `request_pub_` is ready) publish requests.
+
+4. **Regression test** (`test_sonar_live_catalog_resume.cpp`): write N tiles to
+   the layer's cache dir, enable (warm-loads N tiles → `residentTileCount() == N`),
+   disable, invoke `handleCatalog` via `QMetaObject::invokeMethod` (it is a
+   `private slots:` entry — Qt's meta-object system allows this) with an **empty**
+   catalog (prune-all), re-enable, assert `residentTileCount() == 0`. Without the
+   fix the prune-all catalog is discarded; with the fix anti-entropy fires on
+   enable and prunes all N resident tiles. Uses the same headless harness
+   (offscreen QApplication, null Node). One `ament_add_gtest` block.
+
+### #169 Files to Change
+
+| File | Change |
+|------|--------|
+| `src/camp_map/ros/live_coverage/sonar_live_cache_layer.h` | add `last_catalog_` member |
+| `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp` | buffer in `handleCatalog`, replay in `enableLiveCoverage` |
+| `test/test_sonar_live_catalog_resume.cpp` | new headless test |
+| `CMakeLists.txt` | new `ament_add_gtest` block |
+
+---
+
+## Issue #170 — no cap on tile dimensions before allocation (crash path)
+
+### Context
+
+`handleTile()` constructs `SonarLiveTile(index, msg.width, msg.height)` before
+any bounds check (sonar_live_cache_layer.cpp:358-359). `SonarLiveTile::applyPatch`
+then allocates `width * height` floats per band (sonar_live_tile.cpp:105). A
+single oversized or corrupt message is an immediate unbounded allocation on the
+GUI thread. The ADR-0010 eviction budget only applies to tiles *already resident*.
+
+**GUI-thread load items (deferred with rationale):** `evictIfOverBudget()` on
+every patch (O(N tiles × N bands) per call) and `cached_image_` invalidation on
+every patch are acknowledged as aggravating factors during sustained load but are
+performance concerns, not crash-risks. Addressing them requires rate-limiting and
+eviction amortization that are non-trivial and not necessary for the crash fix.
+They are deferred to follow-up issues referencing #154/#155/#156.
+
+### Approach (#170 commit)
+
+1. **Add dimension cap to `handleTile()`** — before the `SonarLiveTile` emplace,
+   validate `msg.width`, `msg.height`, and `msg.bands.size()` against reasonable
+   upper bounds:
+   ```cpp
+   constexpr int kMaxBandCount = 64;
+   if(msg.width <= 0 || msg.height <= 0 ||
+      msg.width > kMaxImageEdge || msg.height > kMaxImageEdge ||
+      static_cast<int>(msg.bands.size()) > kMaxBandCount)
+   {
+     qWarning().noquote() << "[live coverage" << ...
+                          << "] rejected tile with absurd dimensions "
+                          << msg.width << "x" << msg.height
+                          << "bands:" << msg.bands.size();
+     return;
+   }
+   ```
+   `kMaxImageEdge = 4096` is already a private static constexpr on the class
+   (sonar_live_cache_layer.h:221). `kMaxBandCount` is a new local constant in
+   the `.cpp`.
+
+2. **Regression test** (extend `test_sonar_live_cache.cpp` or new
+   `test_sonar_live_tile_validation.cpp`): enable a headless layer, invoke
+   `handleTile` (private slot, via `QMetaObject::invokeMethod`) with
+   `msg.width = 8193` (over the 4096 cap), assert `residentTileCount() == 0`.
+   Then invoke with valid dimensions (e.g., 8×8), assert `residentTileCount() == 1`.
+   Uses the existing `test_sonar_live_cache` harness. One `ament_add_gtest` block
+   if adding a new file, or just new `TEST()` entries if extending the existing one.
+
+### #170 Files to Change
+
+| File | Change |
+|------|--------|
+| `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp` | add dimension/band cap in `handleTile()` |
+| `test/test_sonar_live_cache.cpp` or new `test_sonar_live_tile_validation.cpp` | add rejection and acceptance test cases |
+| `CMakeLists.txt` | add `ament_add_gtest` block if new file |
+
+---
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| Only what's needed | The fix is 2-3 lines in one `.cpp`; no header change, no new abstraction |
-| Improve incrementally | Single atomic fix; does not touch #169 (catalog latch) or #170 (tile dimension cap), which are separate issues |
-| Test what breaks | The spawned-source guard is exactly the kind of in-session state machine that regression tests should cover |
-| A change includes its consequences | The `CMakeLists.txt` update keeps CI green; the test catches future regressions |
+| Only what's needed | Each fix is surgical: 2-6 lines of production code per issue; no new abstraction or new class |
+| Improve incrementally | Three atomic commits on one branch; GUI-thread load items deferred with explicit rationale |
+| Test what breaks | Each fix has a headless regression test targeting the specific failure mode |
+| A change includes its consequences | CMakeLists.txt, header comment, and optional buffered-catalog member all land with the fix |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| ADR-0006 D5 | Yes | Fix preserves the opt-in gate — re-spawned layer still starts inactive and requires operator enable |
-| ADR-0002 | Tangential | Layer destruction still goes through the standard `deleteLater()` path; the new connection fires during that destruction |
-| ADR-0001 | Checked | The `destroyed` signal fires on the GUI thread (via `Qt::DirectConnection`; `deleteLater()` dequeues on the event loop); the lambda touches only `std::map::erase` — no ROS/thread concern |
+| ADR-0001 | Yes | `Qt::DirectConnection` in #168 fix is safe (GUI thread only, fast lambda); `handleCatalog` replay in #169 is a direct call on the GUI thread (post-enable, no marshal needed) |
+| ADR-0006 D2/D4 | Yes (#169, #170) | Catalog buffer is CPU-only (no ROS thread touches it); tile dimension cap is at the node boundary, before allocation |
+| ADR-0006 D5 | Yes (#168) | Re-spawned layer still starts inactive (opt-in gate preserved) |
+| ADR-0010 | Tangential (#170) | Eviction budget applies post-allocation; the cap prevents the unbounded pre-allocation |
 
 ## Consequences
 
-| If we change... | Also update... | Included in plan? |
+| If we change... | Also update... | Included? |
 |---|---|---|
-| `updateTopics()` spawn guard | `onRemovedFromMap()` in `SonarLiveCacheLayer` (not needed — destroyed signal is broader and already correct) | N/A — not required |
-| spawn→remove→spawn path | Manual verification in the field (BizzyBoat / gabby) | No — integration test covers it in CI |
+| `sources_` type in manager header | Replace `<map>` with `<set>` include | Yes |
+| `handleCatalog` adds buffering | `enableLiveCoverage` must replay buffer | Yes |
+| Tile dimension cap | Any future code that bypasses `handleTile` | N/A — no such path exists |
 
 ## Documentation & Instruction Impact
 
-- **Stale docs**: None — the class-level Doxygen comment in sonar_live_cache_manager.h
-  already says "deduped by base namespace"; no doc implies the dedup is permanent.
-- **Agent-instruction candidates**: The `QObject::destroyed` pattern (connect at spawn,
-  erase at destruction) is a clean solution for manager-tracks-children problems. Could be
-  added as a note to `.agent/knowledge/` if similar managers emerge — but premature now
-  with only one instance.
+- **Stale docs**: The class-level comment on `sonar_live_cache_manager.h:36-38`
+  documents the dedup behavior without mentioning removal—update it in the #168
+  commit. No other docs reference the spawned-source map or catalog latch behavior.
+- **Agent-instruction candidates**: The `QObject::destroyed` pattern for
+  manager-tracks-children problems is worth a knowledge note if similar managers
+  emerge; premature now (single instance). The catalog-buffer-and-replay pattern
+  (always buffer transient-local subscriptions in case of opt-in-gate timing races)
+  is a candidate for `.agent/knowledge/` — proposed for operator consideration.
 
 ## Open Questions
 
-- Can `test_sonar_live_cache_manager_respawn.cpp` run headless (no ROS node, Qt only)?
-  The test needs to drive `updateTopics()` without a live `TopicsManager`; this may
-  require either a test-seam method on `SonarLiveCacheManager` or direct construction
-  of a `SonarLiveCacheLayer` to verify the `destroyed`-signal erasure in isolation.
+- None — all three test strategies are concrete (destroyed-signal mock set for #168;
+  `QMetaObject::invokeMethod` + `residentTileCount()` for #169 prune-all;
+  oversized-tile rejection via `residentTileCount()` for #170).
 
 ## Estimated Scope
 
-Single PR. The fix itself is 2-3 lines; the test is the main effort. Issues #169 and
-#170 share the same field incident but are separate structural bugs addressed in
-separate commits on the same PR branch (per user decision 2026-08-05).
+Single PR (`Closes #168 / Closes #169 / Closes #170`), three atomic commits.
+Production-code changes: ~10 lines total across the three fixes. Test files: three
+new headless test files plus CMakeLists additions.

--- a/.agent/work-plans/issue-168/plan.md
+++ b/.agent/work-plans/issue-168/plan.md
@@ -1,0 +1,105 @@
+# Plan: SonarLiveCacheManager never clears spawned-sources map on layer removal
+
+## Issue
+
+https://github.com/rolker/camp/issues/168
+
+## Context
+
+`SonarLiveCacheManager::updateTopics()` guards against duplicate-spawn using
+`std::map<std::string, bool> sources_` (sonar_live_cache_manager.h:38). On each
+DDS graph update it checks `if(sources_[base]) continue;` before spawning a
+`SonarLiveCacheLayer` (sonar_live_cache_manager.cpp:64-65, 69-70). When the
+operator removes the layer, `Layer::removeFromMap()` calls `deleteLater()` but
+`sources_` is never updated — no `onRemovedFromMap()` override, no signal
+connection, nothing. After removal every subsequent `updateTopics()` skips the
+source permanently, making it impossible to re-add the live coverage layer within
+a session without a full restart.
+
+The correct fix is to clear `sources_[base]` when the spawned layer is
+destroyed. The `QObject::destroyed` signal (fired at the start of the `QObject`
+destructor, before any of the Qt child-management or signal/slot bookkeeping) is
+the right hook: it fires whether the layer is removed by the user, by a
+programmatic owner, or on app shutdown — unlike `onRemovedFromMap()`, which the
+base-class `Layer::removeFromMap()` calls but which is skipped on normal app exit
+(layer.cpp:59; camp#90).
+
+## Approach
+
+1. **Wire `destroyed` signal at spawn time** — In `updateTopics()`, after spawning
+   the layer, connect its `QObject::destroyed` signal to a lambda (captured by the
+   manager, with `Qt::ConnectionType::DirectConnection` — acceptable because the
+   lambda only calls `std::map::erase`, which is fast and safe on the GUI thread)
+   that erases the base entry from `sources_`.
+
+2. **Switch guard to `count()` / `find()`** — The current `if(sources_[base])`
+   uses `operator[]`, which inserts a default `false` entry for every unknown base
+   encountered. Replace with `sources_.count(base)` (no side-effect) so the map
+   stays clean (only live spawned bases present, not also every scanned base).
+
+3. **Add a regression test** — New test `test_sonar_live_cache_manager_respawn.cpp`
+   using the Qt + Map harness (QApplication, `camp::map::Map`, `camp::map::LayerList`)
+   to exercise spawn → remove → spawn on the same source. The test creates a minimal
+   `SonarLiveCacheManager` sub-object, calls `updateTopics()` via a testable seam,
+   removes the spawned layer, and verifies a second `updateTopics()` call re-spawns.
+   If the manager setup cost is too high without a ROS node, scope the test to verify
+   only the `destroyed`-signal erasure in isolation (mock layer, check `sources_` via
+   a test-friend or white-box inspection).
+
+   **Open question**: whether a lightweight integration test (no ROS node, Qt only)
+   is feasible without significant refactor of `SonarLiveCacheManager`'s constructor.
+   If not, document the manual verification path and file a follow-up (#169-compat test).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/camp_map/ros/live_coverage/sonar_live_cache_manager.cpp` | In `updateTopics()`: (a) switch `if(sources_[base])` → `if(sources_.count(base))`, and (b) after `sources_[base] = true`, add `connect(layer, &QObject::destroyed, this, [this, base]() { sources_.erase(base); });` |
+| `test/test_sonar_live_cache_manager_respawn.cpp` | New test: spawn a `SonarLiveCacheLayer` for a base, call `removeFromMap()`, verify `sources_` no longer contains the base (or verify a second spawn attempt succeeds) |
+| `CMakeLists.txt` | Add the new test source to the camp_tests target (same pattern as other `test_sonar_live_*.cpp` entries) |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Only what's needed | The fix is 2-3 lines in one `.cpp`; no header change, no new abstraction |
+| Improve incrementally | Single atomic fix; does not touch #169 (catalog latch) or #170 (tile dimension cap), which are separate issues |
+| Test what breaks | The spawned-source guard is exactly the kind of in-session state machine that regression tests should cover |
+| A change includes its consequences | The `CMakeLists.txt` update keeps CI green; the test catches future regressions |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0006 D5 | Yes | Fix preserves the opt-in gate — re-spawned layer still starts inactive and requires operator enable |
+| ADR-0002 | Tangential | Layer destruction still goes through the standard `deleteLater()` path; the new connection fires during that destruction |
+| ADR-0001 | Checked | The `destroyed` signal fires on the GUI thread (via `Qt::DirectConnection`; `deleteLater()` dequeues on the event loop); the lambda touches only `std::map::erase` — no ROS/thread concern |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `updateTopics()` spawn guard | `onRemovedFromMap()` in `SonarLiveCacheLayer` (not needed — destroyed signal is broader and already correct) | N/A — not required |
+| spawn→remove→spawn path | Manual verification in the field (BizzyBoat / gabby) | No — integration test covers it in CI |
+
+## Documentation & Instruction Impact
+
+- **Stale docs**: None — the class-level Doxygen comment in sonar_live_cache_manager.h
+  already says "deduped by base namespace"; no doc implies the dedup is permanent.
+- **Agent-instruction candidates**: The `QObject::destroyed` pattern (connect at spawn,
+  erase at destruction) is a clean solution for manager-tracks-children problems. Could be
+  added as a note to `.agent/knowledge/` if similar managers emerge — but premature now
+  with only one instance.
+
+## Open Questions
+
+- Can `test_sonar_live_cache_manager_respawn.cpp` run headless (no ROS node, Qt only)?
+  The test needs to drive `updateTopics()` without a live `TopicsManager`; this may
+  require either a test-seam method on `SonarLiveCacheManager` or direct construction
+  of a `SonarLiveCacheLayer` to verify the `destroyed`-signal erasure in isolation.
+
+## Estimated Scope
+
+Single PR. The fix itself is 2-3 lines; the test is the main effort. Issues #169 and
+#170 share the same field incident but are separate structural bugs addressed in
+separate commits on the same PR branch (per user decision 2026-08-05).

--- a/.agent/work-plans/issue-168/progress.md
+++ b/.agent/work-plans/issue-168/progress.md
@@ -15,3 +15,24 @@ issue: 168
 
 ### Open questions
 - [ ] Can `test_sonar_live_cache_manager_respawn.cpp` run headless (no ROS node, Qt only)? May need a test-seam or direct layer instantiation to verify the `destroyed`-signal erasure in isolation.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-08-05 17:50 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-168/plan.md` at `19ba194`
+**PR**: PR-less (dispatched via review-plan skill on the local worktree; `gh` unauthenticated in this environment)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix) Commit to a concrete regression-test strategy — the plan leaves test feasibility as an Open Question with a "document manual + file follow-up" fallback, which would downgrade the "Test what breaks" deliverable. The fix lives in `SonarLiveCacheManager`, whose `updateTopics()` early-returns without a live `Node` ancestor + real publishers, so the existing null-Node layer harness (`test_sonar_live_eviction.cpp`) does NOT transfer directly. Feasible options: (a) add a public accessor (`sourceCount()` / `isSourceTracked(base)`) plus a test seam to spawn without DDS; (b) integration test with `rclcpp` publishers on `<base>/coverage_tiles`; (c) friend/white-box on `sources_`. Pick one before implementation. — `plan.md:46-51, 94-99`
+- [ ] (suggestion) After switching the guard to `sources_.count(base)`, the `bool` value in `std::map<std::string, bool>` is always `true` and vestigial — `std::set<std::string>` expresses intent (Only what's needed). Update the member + its comment in `sonar_live_cache_manager.h:36-38` if adopting. — `plan.md:36-38`
+- [ ] (suggestion) CMakeLists step says "add the new test source to the camp_tests target" — there is no single aggregate test target; each test is its own `ament_add_gtest` block. Follow the `test_sonar_live_eviction` block (CMakeLists.txt:925) for include-dirs / ament deps / link-libs. — `plan.md:59`
+- [ ] (suggestion) Documentation & Instruction Impact claims "None", but the header comment at `sonar_live_cache_manager.h:36-38` documents the map's lifecycle ("a topic reappearing doesn't spawn a duplicate") without noting that removal now clears the entry — update that inline comment alongside the fix. — `plan.md:87-88`
+- [ ] (suggestion) Minor timing note: between `removeFromMap()` (which only schedules `deleteLater()`) and the actual `~QObject` firing `destroyed`, `sources_` still holds `base`; an `updateTopics()` that races that window won't re-spawn. Harmless for the operator remove→re-add flow (seconds apart, event loop drains first) — worth a one-line comment, not a redesign. — `plan.md:29-33`
+
+### Notes
+- Root cause and fix are correct and idiomatic. Verified against source: `Layer::removeFromMap()` (map/layer.cpp:54-71) reparents to null, removes from scene, and `deleteLater()`s — so `QObject::destroyed` reliably fires on removal AND shutdown, unlike `onRemovedFromMap()` (skipped on quit). The layer's Qt parent is the `LayerList`, not the manager, so lifetimes are independent and there is no double-free. The 3-arg `connect(layer, &QObject::destroyed, this, lambda)` correctly uses the manager as receiver context, so a manager destroyed first auto-disconnects — shutdown-order safe. All cited ADRs exist (0001, 0002, 0003, 0006).
+- `review-issue` was not run for #168 (no review-issue comment / no `## Issue Review` entry) — noted, not penalized (optional step).
+- **Independence**: this is a fresh-context, independent review (host-dispatched sub-agent, Opus) of a Sonnet-authored plan. The skill's self-review heuristic (match on `**By**` agent-name prefix) would false-positive here because all Claude Code agents share the `Claude Code Agent` identity string; the differing model line is the true independence signal. No self-review annotation applied.

--- a/.agent/work-plans/issue-168/progress.md
+++ b/.agent/work-plans/issue-168/progress.md
@@ -55,3 +55,23 @@ issue: 168
 
 ### Open questions
 - [ ] No open questions — plan is review-plan-ready.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-08-05 18:19 +00:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-168/plan.md` at `0f81a67`
+**PR**: PR-less (dispatched via review-plan skill on the local worktree; `gh` unauthenticated in this environment)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) #168 test validates the Qt `destroyed`-signal pattern via a *local* mock `std::set` + its own lambda — it does NOT exercise `SonarLiveCacheManager::sources_` nor the manager's real `connect(...)` wiring. Deleting the manager's `connect(layer, &QObject::destroyed, …)` line would not fail this test (~zero regression protection for the actual fix). Prior review's must-fix option (a) was "public accessor + test seam"; extension chose the weaker mock. Consider a thin white-box accessor (`bool isSourceTracked(base) const`) so the test asserts against the manager's set after a real remove. Defensible tradeoff — `updateTopics()` requires a live `Node` ancestor + real publishers for a true end-to-end respawn test. — `plan.md:49-58`
+- [ ] (suggestion) #170 cap: `msg.width`/`msg.height` are `uint16` (confirmed in `SonarVisualizationTile.msg`), so `msg.width <= 0` is effectively `== 0` (harmless, promotes to signed int). Residual: even at the 4096 cap, `4096×4096×64 bands×4B ≈ 4 GB` remains a large single allocation. Cap correctly eliminates the unbounded uint16-max crash path; a combined `width*height*bands` ceiling would harden further if cheap. Not blocking. — `plan.md:146-157`
+
+### Notes
+- Root causes and fixes verified correct and idiomatic against source. #168: `<map>` include (manager.h:6) and `sources_[base]` guard (manager.cpp:64,70) confirmed; `new SonarLiveCacheLayer(...)` return currently discarded — impl must capture the pointer for the `connect`. #169: catalog subscription is created once in the ctor and never torn down, so re-enable does NOT re-deliver the transient-local latched catalog — the buffered replay is exactly the needed reconcile trigger; `enableLiveCoverage` order (warmLoad→subscribeTiles→writeSettings, cpp:235-238) means `request_pub_` is live when the replay's `publishRequest` fires. #170: `kMaxImageEdge=4096` (layer.h:221) and the pre-construction validation site in `handleTile` (cpp:358-359) confirmed; node-boundary cap is the correct location.
+- Scope: 3 issues / 1 PR / 3 atomic commits per explicit user decision (2026-08-05). Upper-bound but cohesive — all three are the same `live_coverage` field-incident subsystem. ~10 lines production across `sonar_live_cache_manager.{h,cpp}` + `sonar_live_cache_layer.{h,cpp}` plus 3 new headless test files + CMakeLists blocks.
+- ADRs referenced (0001, 0006, 0010) all exist under `docs/decisions/`. Headless test harness (offscreen QApplication + Map + null Node) confirmed in `test_sonar_live_eviction.cpp` — supports the #169/#170 layer-level test plans; `residentTileCount()` is public (layer.h:85).
+- `review-issue` was not run for #168/#169/#170 (no `## Issue Review` entry / no comment) — noted, not penalized (optional step).
+- **Independence**: fresh-context, independent review (host-dispatched Opus sub-agent) of a Sonnet-authored plan. The skill's self-review heuristic (match on `**By**` agent-name prefix) false-positives here because all Claude Code agents share the `Claude Code Agent` identity string; the differing model line (Opus vs Sonnet) is the true independence signal. No self-review annotation applied.

--- a/.agent/work-plans/issue-168/progress.md
+++ b/.agent/work-plans/issue-168/progress.md
@@ -75,3 +75,22 @@ issue: 168
 - ADRs referenced (0001, 0006, 0010) all exist under `docs/decisions/`. Headless test harness (offscreen QApplication + Map + null Node) confirmed in `test_sonar_live_eviction.cpp` — supports the #169/#170 layer-level test plans; `residentTileCount()` is public (layer.h:85).
 - `review-issue` was not run for #168/#169/#170 (no `## Issue Review` entry / no comment) — noted, not penalized (optional step).
 - **Independence**: fresh-context, independent review (host-dispatched Opus sub-agent) of a Sonnet-authored plan. The skill's self-review heuristic (match on `**By**` agent-name prefix) false-positives here because all Claude Code agents share the `Claude Code Agent` identity string; the differing model line (Opus vs Sonnet) is the true independence signal. No self-review annotation applied.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-08-05 19:01 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-168 at `ee21fd0`
+**Mode**: pre-push
+**Depth**: Deep (reason: field-incident crash-path fix + Qt object-lifecycle/concurrency in cross-cutting live_coverage subsystem)
+**Must-fix**: 0 | **Suggestions**: 4
+**Round**: 1 | **Ship**: recommended — no must-fix; two independent adversarial passes confirmed all three fixes correct
+
+### Findings
+- [ ] (suggestion) #170 ingest cap reuses render-clamp constant kMaxImageEdge (4096) as tile-ingest ceiling; edge>4096 producer would hit a silent reject/re-request loop — consider kMaxIngestEdge or a documenting comment — `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp:363`
+- [ ] (suggestion) Catalog-resume test comment misstates prune mechanism: tiles seeded at reconciler version 0 (markHave(index,0)), not stamp.sec=100; the 100-vs-200 margin doesn't exist — `test/test_sonar_live_catalog_resume.cpp:137`
+- [ ] (suggestion) enableLiveCoverage replay re-requests the full held set every enable (v0 seeding); rapid disable/enable emits a full-catalog TileRequest burst per cycle (by-design ADR-0006 D3) — worth a one-line note — `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp:243`
+- [ ] (suggestion) #170 byte ceiling multiplies by msg.bands.size() but applyPatch allocates per unique band name; duplicate-named bands over-counted (conservative, safe direction) — `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp:361`
+- [ ] (note) C++ test suite not built/run locally (offline; heavy ROS/Qt build) — CI colcon+gtest is the gate. Static analysis: cppcheck aborts on Qt slots macro; cmake-lint/yamllint enforced by pre-commit. Local/Copilot adversarial unavailable (no Ollama, off by default).

--- a/.agent/work-plans/issue-168/progress.md
+++ b/.agent/work-plans/issue-168/progress.md
@@ -36,3 +36,22 @@ issue: 168
 - Root cause and fix are correct and idiomatic. Verified against source: `Layer::removeFromMap()` (map/layer.cpp:54-71) reparents to null, removes from scene, and `deleteLater()`s — so `QObject::destroyed` reliably fires on removal AND shutdown, unlike `onRemovedFromMap()` (skipped on quit). The layer's Qt parent is the `LayerList`, not the manager, so lifetimes are independent and there is no double-free. The 3-arg `connect(layer, &QObject::destroyed, this, lambda)` correctly uses the manager as receiver context, so a manager destroyed first auto-disconnects — shutdown-order safe. All cited ADRs exist (0001, 0002, 0003, 0006).
 - `review-issue` was not run for #168 (no review-issue comment / no `## Issue Review` entry) — noted, not penalized (optional step).
 - **Independence**: this is a fresh-context, independent review (host-dispatched sub-agent, Opus) of a Sonnet-authored plan. The skill's self-review heuristic (match on `**By**` agent-name prefix) would false-positive here because all Claude Code agents share the `Claude Code Agent` identity string; the differing model line is the true independence signal. No self-review annotation applied.
+
+## Plan Authored (bundle extension)
+**Status**: complete
+**When**: 2026-08-05 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-168/plan.md` at `0f81a67`
+**Branch**: feature/issue-168 at `0f81a67`
+**Phases**: single (three atomic commits on one PR)
+
+### Summary of changes from prior plan
+- Extended plan to cover camp#169 and camp#170 as a bundle (user decision 2026-08-05)
+- Resolved Plan Review must-fix: committed to option (a) test strategy for #168 — test the `destroyed`-signal erasure via a local mock `std::set`, headless, null Node, bypassing the full manager stack
+- Adopted all Plan Review suggestions: `std::set` instead of `map<string,bool>`, per-test `ament_add_gtest` block pattern, header comment update, one-line deleteLater-window comment
+- Added full context/approach/files/consequences/test sections for #169 (catalog-buffer-and-replay) and #170 (dimension cap before allocation)
+- #170 GUI-thread load items (eviction amortization, render rate-limit) explicitly deferred with rationale
+
+### Open questions
+- [ ] No open questions — plan is review-plan-ready.

--- a/.agent/work-plans/issue-168/progress.md
+++ b/.agent/work-plans/issue-168/progress.md
@@ -1,0 +1,17 @@
+---
+issue: 168
+---
+
+# Issue #168 — Live coverage layer cannot be re-added after remove
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-08-05 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-168/plan.md` at `19ba194`
+**Branch**: feature/issue-168 at `19ba194`
+**Phases**: single
+
+### Open questions
+- [ ] Can `test_sonar_live_cache_manager_respawn.cpp` run headless (no ROS node, Qt only)? May need a test-seam or direct layer instantiation to verify the `destroyed`-signal erasure in isolation.

--- a/.agent/work-plans/issue-168/progress.md
+++ b/.agent/work-plans/issue-168/progress.md
@@ -94,3 +94,19 @@ issue: 168
 - [ ] (suggestion) enableLiveCoverage replay re-requests the full held set every enable (v0 seeding); rapid disable/enable emits a full-catalog TileRequest burst per cycle (by-design ADR-0006 D3) — worth a one-line note — `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp:243`
 - [ ] (suggestion) #170 byte ceiling multiplies by msg.bands.size() but applyPatch allocates per unique band name; duplicate-named bands over-counted (conservative, safe direction) — `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp:361`
 - [ ] (note) C++ test suite not built/run locally (offline; heavy ROS/Qt build) — CI colcon+gtest is the gate. Static analysis: cppcheck aborts on Qt slots macro; cmake-lint/yamllint enforced by pre-commit. Local/Copilot adversarial unavailable (no Ollama, off by default).
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-08-05 15:55 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+
+**PR**: #185 at `16e6e53`
+**Sources**: 3 (Copilot R1 APPROVED @ `16e6e53`, Local Review (Pre-Push) R1, CI rollup)
+**Cross-source confirmations**: 0
+**CI**: all-pass
+
+### Findings
+- [ ] (trivial, Copilot ×2 same root) `makeManager()` helper EXPECTs non-null `topLevelLayers()` then dereferences anyway (non-void helper can't ASSERT); null would segfault instead of failing cleanly. Guard-return nullptr in the helper + `ASSERT_NE(manager, nullptr)` at both call sites — `test/test_sonar_live_cache_manager_respawn.cpp:44,57,78`
+
+### False positives
+- (none — Copilot approved; the pre-push review's 4 suggestions were already applied at this head)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -972,6 +972,32 @@ if(BUILD_TESTING)
     Qt5::Positioning
     ${GDAL_LIBRARY}
   )
+
+  # [camp#169] Latched catalog buffered across a disabled window; reconcile
+  # (and requests) fire on every enable. Same offscreen harness.
+  ament_add_gtest(test_sonar_live_catalog_resume
+    test/test_sonar_live_catalog_resume.cpp
+  )
+  target_include_directories(test_sonar_live_catalog_resume PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp_map
+  )
+  ament_target_dependencies(test_sonar_live_catalog_resume
+    geometry_msgs
+    marine_autonomy
+    marine_colormap
+    marine_interfaces
+    marine_tiled_raster_store
+    rclcpp
+    tf2_ros
+  )
+  target_link_libraries(test_sonar_live_catalog_resume
+    camp_map_ros
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
+  )
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -998,6 +998,32 @@ if(BUILD_TESTING)
     Qt5::Positioning
     ${GDAL_LIBRARY}
   )
+
+  # [camp#170] Tile dimension/byte validation before allocation (crash guard).
+  # Same offscreen harness.
+  ament_add_gtest(test_sonar_live_tile_validation
+    test/test_sonar_live_tile_validation.cpp
+  )
+  target_include_directories(test_sonar_live_tile_validation PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp_map
+  )
+  ament_target_dependencies(test_sonar_live_tile_validation
+    geometry_msgs
+    marine_autonomy
+    marine_colormap
+    marine_interfaces
+    marine_tiled_raster_store
+    rclcpp
+    tf2_ros
+  )
+  target_link_libraries(test_sonar_live_tile_validation
+    camp_map_ros
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
+  )
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -945,6 +945,33 @@ if(BUILD_TESTING)
     Qt5::Positioning
     ${GDAL_LIBRARY}
   )
+
+  # [camp#168] Spawned-source tracking clears on layer destruction so the live
+  # coverage layer can be re-added after remove. White-box on the manager's
+  # tracking seam; same offscreen harness (GL-free / ROS-free).
+  ament_add_gtest(test_sonar_live_cache_manager_respawn
+    test/test_sonar_live_cache_manager_respawn.cpp
+  )
+  target_include_directories(test_sonar_live_cache_manager_respawn PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp_map
+  )
+  ament_target_dependencies(test_sonar_live_cache_manager_respawn
+    geometry_msgs
+    marine_autonomy
+    marine_colormap
+    marine_interfaces
+    marine_tiled_raster_store
+    rclcpp
+    tf2_ros
+  )
+  target_link_libraries(test_sonar_live_cache_manager_respawn
+    camp_map_ros
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
+  )
 endif()
 
 

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
@@ -235,6 +235,13 @@ void SonarLiveCacheLayer::enableLiveCoverage()
   // GUI-thread warm-load can't race a callback (ADR-0006 D3/D4).
   warmLoad();
   subscribeTiles();
+  // [camp#169] Replay the buffered catalog so reconcile (and the resulting tile
+  // requests) fire on every enable — the latched sample may have arrived while
+  // disabled (startup settings-restore race) or the request publisher may have
+  // been torn down by a disable since the last reconcile. Direct call on the
+  // GUI thread; enabled_ is already true so handleCatalog() proceeds.
+  if(last_catalog_)
+    handleCatalog(*last_catalog_);
   writeSettings();
   updateDisplay();
   cached_image_ = QImage();
@@ -388,6 +395,12 @@ void SonarLiveCacheLayer::handleCatalog(const marine_interfaces::msg::TileCatalo
   // Learn the level even while inactive (used for availability + later warm-load).
   if(!level_ && !msg.entries.empty())
     level_ = msg.entries.front().index.level;
+
+  // [camp#169] Always buffer, even while disabled: the transient-local depth-1
+  // subscription delivers its latched sample exactly once — discarding it here
+  // while disabled means no reconcile ever fires (the boat's catalog is stable,
+  // so nothing re-delivers it). enableLiveCoverage() replays this buffer.
+  last_catalog_ = msg;
 
   if(!enabled_)
   {

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
@@ -348,6 +348,29 @@ void SonarLiveCacheLayer::handleTile(const marine_interfaces::msg::SonarVisualiz
 {
   if(!enabled_)
     return;
+
+  // [camp#170] Validate dimensions BEFORE any allocation or state mutation: a
+  // single oversized/corrupt message would otherwise allocate
+  // width*height*bands floats on the GUI thread on receipt (the 2026-07-23
+  // operator-station crash) — the ADR-0010 eviction budget only accounts for
+  // tiles after they are resident. Per-edge cap plus a combined byte ceiling:
+  // per-edge alone still admits 4096x4096 x 64 bands x 4B ~= 4 GiB. 256 MiB
+  // admits any legitimate <=4-band full-size tile (64 MiB/band at 4096^2).
+  constexpr std::size_t kMaxBandCount = 64;
+  constexpr std::size_t kMaxTileBytes = std::size_t(256) * 1024 * 1024;
+  const std::size_t tile_bytes = std::size_t(msg.width) * msg.height *
+                                 msg.bands.size() * sizeof(float);
+  if(msg.width == 0 || msg.height == 0 ||
+     msg.width > kMaxImageEdge || msg.height > kMaxImageEdge ||
+     msg.bands.size() > kMaxBandCount || tile_bytes > kMaxTileBytes)
+  {
+    qWarning().noquote() << "[live coverage" << QString::fromStdString(base_namespace_)
+                         << "] rejected tile with absurd dimensions"
+                         << msg.width << "x" << msg.height
+                         << "bands:" << msg.bands.size();
+    return;
+  }
+
   const gggs::GridIndex index = gridIndexFromTileIndex(msg.index);
   if(!index.valid())
     return;

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
@@ -239,7 +239,10 @@ void SonarLiveCacheLayer::enableLiveCoverage()
   // requests) fire on every enable — the latched sample may have arrived while
   // disabled (startup settings-restore race) or the request publisher may have
   // been torn down by a disable since the last reconcile. Direct call on the
-  // GUI thread; enabled_ is already true so handleCatalog() proceeds.
+  // GUI thread; enabled_ is already true so handleCatalog() proceeds. Warm-load
+  // seeds tiles at reconciler version 0, so each enable re-requests the full
+  // catalog set — a deliberate full-heal burst per enable (ADR-0006 D3), not
+  // an incremental delta.
   if(last_catalog_)
     handleCatalog(*last_catalog_);
   writeSettings();
@@ -356,6 +359,11 @@ void SonarLiveCacheLayer::handleTile(const marine_interfaces::msg::SonarVisualiz
   // tiles after they are resident. Per-edge cap plus a combined byte ceiling:
   // per-edge alone still admits 4096x4096 x 64 bands x 4B ~= 4 GiB. 256 MiB
   // admits any legitimate <=4-band full-size tile (64 MiB/band at 4096^2).
+  // kMaxImageEdge doubles as the ingest ceiling (it is the render clamp): a
+  // producer emitting larger tiles would loop reject -> catalog re-request, so
+  // raising producer tile size means raising the clamp too. The byte ceiling
+  // counts msg.bands.size() even though applyPatch allocates per unique band
+  // name — duplicate-named bands over-count, which errs on rejection (safe).
   constexpr std::size_t kMaxBandCount = 64;
   constexpr std::size_t kMaxTileBytes = std::size_t(256) * 1024 * 1024;
   const std::size_t tile_bytes = std::size_t(msg.width) * msg.height *

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
@@ -235,6 +235,15 @@ private:
   // Needed to recover a GridIndex from a cached GeoTIFF on warm-load.
   std::optional<std::uint8_t> level_;
 
+  // [camp#169] Last catalog seen, buffered even while disabled. The catalog
+  // subscription is transient-local depth-1: if the single latched sample is
+  // delivered while enabled_ is false it would otherwise be discarded, and —
+  // the boat's catalog being stable — never re-delivered, so requests would
+  // never resume until a restart (the 2026-07-23 field incident's timing
+  // race). enableLiveCoverage() replays this buffer through handleCatalog()
+  // so reconcile/request fire on every enable.
+  std::optional<marine_interfaces::msg::TileCatalog> last_catalog_;
+
   // [camp#134] The shared GL raster renderer (its own offscreen context + the
   // unified shader + colormap LUT). Replaces the shader/program/LUT/FBO this layer
   // used to duplicate from GggsTileLayer. Default ramp Grayscale (renderer default).

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_manager.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_manager.cpp
@@ -61,14 +61,33 @@ void SonarLiveCacheManager::updateTopics()
       continue;
     const std::string base = full.substr(0, full.size() - suffix.size());
 
-    if(sources_[base])
+    if(sources_.count(base))
       continue;   // already spawned a layer for this source
     auto layers = topLevelLayers();
     if(!layers)
       continue;
-    new SonarLiveCacheLayer(layers, node_item, QString::fromStdString(base));
-    sources_[base] = true;
+    auto layer = new SonarLiveCacheLayer(layers, node_item, QString::fromStdString(base));
+    trackSpawnedLayer(base, layer);
   }
+}
+
+bool SonarLiveCacheManager::isSourceTracked(const std::string& base) const
+{
+  return sources_.count(base) > 0;
+}
+
+void SonarLiveCacheManager::trackSpawnedLayer(const std::string& base, QObject* layer)
+{
+  sources_.insert(base);
+  // Clear the entry when the layer dies so the next updateTopics() can respawn
+  // it (camp#168 — the 2026-07-23 field incident: remove made the live coverage
+  // layer un-re-addable for the rest of the session). Between the operator's
+  // remove (deleteLater()) and ~QObject firing `destroyed` the entry lingers;
+  // the event loop drains before any human re-add, so no spurious skip in
+  // practice. DirectConnection is safe: both deleteLater() destruction and this
+  // erase run on the GUI thread and the lambda touches only the set.
+  connect(layer, &QObject::destroyed, this,
+          [this, base]() { sources_.erase(base); }, Qt::DirectConnection);
 }
 
 }  // namespace live_coverage

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_manager.h
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_manager.h
@@ -3,7 +3,7 @@
 
 #include "../../tools/layer_manager.h"
 
-#include <map>
+#include <set>
 #include <string>
 
 namespace camp
@@ -29,13 +29,27 @@ class SonarLiveCacheManager: public tools::LayerManager
 public:
   SonarLiveCacheManager(MapTool* parent);
 
+  /// True while a layer for `base` is tracked (spawned and not yet destroyed).
+  /// Introspection + test seam (camp#168).
+  bool isSourceTracked(const std::string& base) const;
+
 public slots:
   void updateTopics();
 
+protected:
+  /// Register a spawned layer for `base`: insert into `sources_` and arrange
+  /// for the entry to clear when the layer is destroyed, so the source can be
+  /// re-added after an operator removes the layer (camp#168). Factored from
+  /// `updateTopics()` so the tracking contract is testable without the live
+  /// `Node` ancestor that topic discovery requires.
+  void trackSpawnedLayer(const std::string& base, QObject* layer);
+
 private:
-  // base namespace -> spawned, so a topic reappearing (DDS re-discovery) doesn't
-  // spawn a duplicate; the existing layer's subscriptions reconnect on their own.
-  std::map<std::string, bool> sources_;
+  // Base namespaces with a live spawned layer, so a topic reappearing (DDS
+  // re-discovery) doesn't spawn a duplicate. The entry is erased when the
+  // layer is destroyed (operator remove -> deleteLater, or shutdown), so the
+  // next updateTopics() can respawn it (camp#168).
+  std::set<std::string> sources_;
 };
 
 }  // namespace live_coverage

--- a/test/test_sonar_live_cache_manager_respawn.cpp
+++ b/test/test_sonar_live_cache_manager_respawn.cpp
@@ -1,0 +1,105 @@
+// [camp#168] Headless white-box test for SonarLiveCacheManager's spawned-source
+// tracking. The 2026-07-23 field incident: removing the live coverage layer left
+// its entry in `sources_` forever, so updateTopics() never respawned it and only
+// a full camp restart brought it back. The fix clears the entry when the layer
+// is destroyed. This test exercises the manager's REAL set and REAL
+// `connect(destroyed -> erase)` wiring via the protected trackSpawnedLayer()
+// seam (updateTopics() itself needs a live ROS Node ancestor, out of scope for a
+// headless test) — deleting the connect line in trackSpawnedLayer() fails this
+// test. Offscreen QApplication + Map harness as test_sonar_live_eviction;
+// GL-free, ROS-free.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QObject>
+
+#include "map/map.h"
+#include "map/layer_list.h"
+#include "tools/layer_manager.h"
+#include "ros/live_coverage/sonar_live_cache_manager.h"
+
+using camp::map::Map;
+using camp::ros::live_coverage::SonarLiveCacheManager;
+
+namespace
+{
+
+// Promote the protected tracking seam for white-box testing.
+class TestManager: public SonarLiveCacheManager
+{
+public:
+  using SonarLiveCacheManager::SonarLiveCacheManager;
+  using SonarLiveCacheManager::trackSpawnedLayer;
+};
+
+// Build the minimal MapItem ancestry the manager requires (MapItem asserts a
+// non-null parent): Map -> LayerList -> host LayerManager -> manager.
+TestManager* makeManager(Map& map)
+{
+  auto layers = map.topLevelLayers();
+  EXPECT_NE(layers, nullptr);
+  auto host = new camp::tools::LayerManager(layers, "test_host_tool");
+  return new TestManager(host);
+}
+
+}  // namespace
+
+TEST(SonarLiveCacheManagerRespawn, DirectDeleteClearsTrackingAndAllowsRetrack)
+{
+  Map map;
+  TestManager* manager = makeManager(map);
+
+  const std::string base = "/cube_bathymetry";
+  EXPECT_FALSE(manager->isSourceTracked(base));
+
+  // The tracking contract is QObject-generic; a plain QObject stands in for the
+  // spawned SonarLiveCacheLayer.
+  auto layer = new QObject();
+  manager->trackSpawnedLayer(base, layer);
+  EXPECT_TRUE(manager->isSourceTracked(base));
+
+  delete layer;  // ~QObject fires `destroyed` synchronously
+  EXPECT_FALSE(manager->isSourceTracked(base));
+
+  // Re-add after removal — the exact flow that failed in the field.
+  auto layer2 = new QObject();
+  manager->trackSpawnedLayer(base, layer2);
+  EXPECT_TRUE(manager->isSourceTracked(base));
+  delete layer2;
+  EXPECT_FALSE(manager->isSourceTracked(base));
+}
+
+TEST(SonarLiveCacheManagerRespawn, DeleteLaterClearsTrackingOnceEventLoopDrains)
+{
+  Map map;
+  TestManager* manager = makeManager(map);
+
+  const std::string base = "/cube_bathymetry";
+  auto layer = new QObject();
+  manager->trackSpawnedLayer(base, layer);
+  EXPECT_TRUE(manager->isSourceTracked(base));
+
+  // The operator-remove path: Layer::removeFromMap() schedules deleteLater().
+  // The entry legitimately lingers until the event loop drains the deferred
+  // delete — then it must be gone.
+  layer->deleteLater();
+  EXPECT_TRUE(manager->isSourceTracked(base));
+  QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+  EXPECT_FALSE(manager->isSourceTracked(base));
+}
+
+int main(int argc, char** argv)
+{
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QApplication app(argc, argv);
+  // [camp#117] Map's ctor writes the BackgroundTileLayers seed into QSettings;
+  // a test org/app name keeps that out of the developer's real camp settings.
+  QCoreApplication::setOrganizationName("camp_test");
+  QCoreApplication::setApplicationName("test_sonar_live_cache_manager_respawn");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_sonar_live_cache_manager_respawn.cpp
+++ b/test/test_sonar_live_cache_manager_respawn.cpp
@@ -37,11 +37,16 @@ public:
 };
 
 // Build the minimal MapItem ancestry the manager requires (MapItem asserts a
-// non-null parent): Map -> LayerList -> host LayerManager -> manager.
+// non-null parent): Map -> LayerList -> host LayerManager -> manager. Returns
+// nullptr (rather than crashing on a null LayerList) so call sites can
+// ASSERT_NE and fail with a message — this helper is non-void, so it cannot
+// use ASSERT_* itself.
 TestManager* makeManager(Map& map)
 {
   auto layers = map.topLevelLayers();
   EXPECT_NE(layers, nullptr);
+  if(!layers)
+    return nullptr;
   auto host = new camp::tools::LayerManager(layers, "test_host_tool");
   return new TestManager(host);
 }
@@ -52,6 +57,7 @@ TEST(SonarLiveCacheManagerRespawn, DirectDeleteClearsTrackingAndAllowsRetrack)
 {
   Map map;
   TestManager* manager = makeManager(map);
+  ASSERT_NE(manager, nullptr);
 
   const std::string base = "/cube_bathymetry";
   EXPECT_FALSE(manager->isSourceTracked(base));
@@ -77,6 +83,7 @@ TEST(SonarLiveCacheManagerRespawn, DeleteLaterClearsTrackingOnceEventLoopDrains)
 {
   Map map;
   TestManager* manager = makeManager(map);
+  ASSERT_NE(manager, nullptr);
 
   const std::string base = "/cube_bathymetry";
   auto layer = new QObject();

--- a/test/test_sonar_live_catalog_resume.cpp
+++ b/test/test_sonar_live_catalog_resume.cpp
@@ -1,0 +1,163 @@
+// [camp#169] Headless regression test: the latched catalog must survive a
+// disabled window and drive a reconcile on (re-)enable. The catalog
+// subscription is transient-local depth-1 — its single latched sample is
+// delivered exactly once. Before the fix, handleCatalog() discarded it while
+// `enabled_` was false and enableLiveCoverage() never reconciled, so whether
+// requests ever fired after a camp restart was a startup timing race
+// (2026-07-23 field incident: live coverage stale all session, zero
+// publishers on coverage_requests).
+//
+// Scenario: warm-load N cached tiles, deliver an EMPTY catalog (prune-all)
+// while disabled, re-enable. With the fix, the buffered catalog replays on
+// enable and anti-entropy prunes all N resident tiles; without it, the catalog
+// is discarded and the N stale tiles stay resident forever.
+//
+// handleCatalog is a private slot: invoked by name via QMetaObject
+// (DirectConnection — no metatype registration needed), mirroring how the ROS
+// callback marshals onto the GUI thread. Offscreen QApplication + Map harness
+// as test_sonar_live_eviction; GL-free, ROS-free (null Node).
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include <QApplication>
+#include <QDir>
+#include <QMetaObject>
+#include <QSettings>
+#include <QTemporaryDir>
+#include <QUrl>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_interfaces/msg/sonar_visualization_tile.hpp"
+#include "marine_interfaces/msg/tile_catalog.hpp"
+#include "marine_interfaces/msg/visualization_band.hpp"
+
+#include "map/map.h"
+#include "map/layer_list.h"
+#include "ros/live_coverage/sonar_live_cache_layer.h"
+#include "ros/live_coverage/sonar_live_tile.h"
+
+namespace mi = marine_interfaces::msg;
+using camp::map::Map;
+using camp::ros::live_coverage::SonarLiveCacheLayer;
+using camp::ros::live_coverage::SonarLiveTile;
+using camp::ros::live_coverage::tileIndexFromGridIndex;
+
+namespace
+{
+
+constexpr int kLevel = 10;
+constexpr int kEdge = 8;
+
+QString sanitizeNamespace(const QString& ns)
+{
+  return QString::fromLatin1(QUrl::toPercentEncoding(ns));
+}
+
+// A uniform full-tile INT16 "depth" patch (value = base * 0.01) for @p grid.
+mi::SonarVisualizationTile makeUniformDepth(const gggs::GridIndex& grid, std::int16_t base)
+{
+  mi::SonarVisualizationTile msg;
+  msg.header.stamp.sec = 100;
+  msg.header.frame_id = "gggs";
+  msg.index = tileIndexFromGridIndex(grid);
+  msg.width = kEdge;
+  msg.height = kEdge;
+  msg.window_col = 0;
+  msg.window_row = 0;
+  msg.window_width = kEdge;
+  msg.window_height = kEdge;
+
+  mi::VisualizationBand band;
+  band.name = "depth";
+  band.dtype = mi::VisualizationBand::INT16;
+  band.scale = 0.01;
+  band.offset = 0.0;
+  band.nodata = -32768.0;
+  for(int i = 0; i < kEdge * kEdge; ++i)
+  {
+    band.data.push_back(static_cast<std::uint8_t>(base & 0xff));
+    band.data.push_back(static_cast<std::uint8_t>((base >> 8) & 0xff));
+  }
+  msg.bands.push_back(band);
+  return msg;
+}
+
+bool deliverCatalog(SonarLiveCacheLayer* layer, const mi::TileCatalog& catalog)
+{
+  // By-name direct invocation reaches the private slot exactly as the ROS
+  // callback's GUI-thread marshal does.
+  return QMetaObject::invokeMethod(layer, "handleCatalog", Qt::DirectConnection,
+                                   Q_ARG(marine_interfaces::msg::TileCatalog, catalog));
+}
+
+}  // namespace
+
+TEST(SonarLiveCatalogResume, CatalogBufferedWhileDisabledReconcilesOnEnable)
+{
+  QSettings().clear();
+  QTemporaryDir cache;
+  ASSERT_TRUE(cache.isValid());
+
+  const QString ns = "/catalog_resume_test";
+  constexpr std::size_t kTiles = 3;
+  // Generous budget: eviction must not interfere with this test.
+  const std::size_t per_tile = static_cast<std::size_t>(kEdge) * kEdge * sizeof(float);
+  QSettings().setValue("LiveTileCache/cache_dir", cache.path());
+  QSettings().setValue("LiveTileCache/max_vram_bytes", qulonglong(100 * per_tile));
+
+  const QString tile_dir = QDir(cache.path()).filePath(sanitizeNamespace(ns));
+  ASSERT_TRUE(QDir().mkpath(tile_dir));
+  const gggs::Level level(kLevel);
+  for(std::size_t i = 0; i < kTiles; ++i)
+  {
+    const gggs::GridIndex grid = level.gridIndex(43.0 + 0.02 * i, -70.5);
+    ASSERT_TRUE(grid.valid());
+    SonarLiveTile tile(grid, kEdge, kEdge);
+    tile.applyPatch(makeUniformDepth(grid, static_cast<std::int16_t>(300 + i)));
+    const QString path =
+      QDir(tile_dir).filePath(QString("%1_%2_%3.tif")
+                                .arg(static_cast<int>(grid.level()))
+                                .arg(grid.row())
+                                .arg(grid.column()));
+    ASSERT_TRUE(tile.writeToGeoTiff(path.toStdString()));
+  }
+
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  auto* layer = new SonarLiveCacheLayer(layers, nullptr, ns);
+
+  layer->enableLiveCoverage();
+  ASSERT_EQ(layer->residentTileCount(), kTiles);   // warm-load seeded the cache
+
+  layer->disableLiveCoverage();
+
+  // The latched catalog lands while disabled. Empty catalog = the boat holds
+  // nothing = prune-all on the next reconcile. Its generation time must be
+  // NEWER than the held tiles' version (stamp.sec=100): the reconciler's
+  // timestamp gate (ADR-0008 D4b) refuses to prune tiles fresher than the
+  // catalog, so a zero-stamped catalog would prune nothing.
+  mi::TileCatalog empty_catalog;
+  empty_catalog.header.stamp.sec = 200;
+  ASSERT_TRUE(deliverCatalog(layer, empty_catalog));
+  // Buffered, not acted on: still resident while disabled.
+  EXPECT_EQ(layer->residentTileCount(), kTiles);
+
+  // Re-enable: the buffered catalog must replay and anti-entropy must prune
+  // all resident tiles. Without the fix the catalog was discarded above and
+  // this stays at kTiles forever.
+  layer->enableLiveCoverage();
+  EXPECT_EQ(layer->residentTileCount(), std::size_t(0));
+}
+
+int main(int argc, char** argv)
+{
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QApplication app(argc, argv);
+  QCoreApplication::setOrganizationName("camp_test");
+  QCoreApplication::setApplicationName("test_sonar_live_catalog_resume");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_sonar_live_catalog_resume.cpp
+++ b/test/test_sonar_live_catalog_resume.cpp
@@ -136,9 +136,11 @@ TEST(SonarLiveCatalogResume, CatalogBufferedWhileDisabledReconcilesOnEnable)
 
   // The latched catalog lands while disabled. Empty catalog = the boat holds
   // nothing = prune-all on the next reconcile. Its generation time must be
-  // NEWER than the held tiles' version (stamp.sec=100): the reconciler's
-  // timestamp gate (ADR-0008 D4b) refuses to prune tiles fresher than the
-  // catalog, so a zero-stamped catalog would prune nothing.
+  // NONZERO: warm-loaded tiles are seeded at reconciler version 0 (markHave
+  // can't recover the original stamp from a cached GeoTIFF), and the
+  // reconciler's timestamp gate (ADR-0008 D4b) prunes only tiles with
+  // version < generation_time — a zero-stamped catalog prunes nothing
+  // (0 < 0 is false).
   mi::TileCatalog empty_catalog;
   empty_catalog.header.stamp.sec = 200;
   ASSERT_TRUE(deliverCatalog(layer, empty_catalog));

--- a/test/test_sonar_live_tile_validation.cpp
+++ b/test/test_sonar_live_tile_validation.cpp
@@ -1,0 +1,153 @@
+// [camp#170] Headless regression test: incoming coverage-tile dimensions are
+// validated BEFORE allocation. During the 2026-07-23 deployment camp crashed
+// at the operator station under sustained tile load; the most direct path is
+// that applyPatch allocates width*height floats per band straight from the
+// message fields — a single oversized or corrupt message is an unbounded
+// GUI-thread allocation on receipt (the ADR-0010 eviction budget only counts
+// tiles after residency). handleTile must reject absurd width/height/band
+// counts (and a combined byte ceiling) with a warning, and still accept
+// legitimate tiles. handleTile is a private slot: invoked by name via
+// QMetaObject (DirectConnection), mirroring the ROS callback's GUI-thread
+// marshal. Offscreen QApplication + Map harness; GL-free, ROS-free.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include <QApplication>
+#include <QDir>
+#include <QMetaObject>
+#include <QSettings>
+#include <QTemporaryDir>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_interfaces/msg/sonar_visualization_tile.hpp"
+#include "marine_interfaces/msg/visualization_band.hpp"
+
+#include "map/map.h"
+#include "map/layer_list.h"
+#include "ros/live_coverage/sonar_live_cache_layer.h"
+#include "ros/live_coverage/sonar_live_tile.h"
+
+namespace mi = marine_interfaces::msg;
+using camp::map::Map;
+using camp::ros::live_coverage::SonarLiveCacheLayer;
+using camp::ros::live_coverage::tileIndexFromGridIndex;
+
+namespace
+{
+
+constexpr int kLevel = 10;
+constexpr int kEdge = 8;
+
+// A minimal full-tile INT16 depth patch for @p grid with explicit dimensions.
+// Band data is sized for kEdge*kEdge regardless of the claimed width/height —
+// for rejection cases the message must be cheap to build (the whole point is
+// that the layer must reject BEFORE trusting the claimed dimensions).
+mi::SonarVisualizationTile makeTile(const gggs::GridIndex& grid,
+                                    std::uint16_t width, std::uint16_t height,
+                                    std::size_t band_count = 1)
+{
+  mi::SonarVisualizationTile msg;
+  msg.header.stamp.sec = 100;
+  msg.header.frame_id = "gggs";
+  msg.index = tileIndexFromGridIndex(grid);
+  msg.width = width;
+  msg.height = height;
+  msg.window_col = 0;
+  msg.window_row = 0;
+  msg.window_width = width;
+  msg.window_height = height;
+
+  for(std::size_t b = 0; b < band_count; ++b)
+  {
+    mi::VisualizationBand band;
+    band.name = b == 0 ? "depth" : ("band" + std::to_string(b));
+    band.dtype = mi::VisualizationBand::INT16;
+    band.scale = 0.01;
+    band.offset = 0.0;
+    band.nodata = -32768.0;
+    for(int i = 0; i < kEdge * kEdge; ++i)
+    {
+      band.data.push_back(static_cast<std::uint8_t>(0x2c));
+      band.data.push_back(static_cast<std::uint8_t>(0x01));
+    }
+    msg.bands.push_back(band);
+  }
+  return msg;
+}
+
+bool deliverTile(SonarLiveCacheLayer* layer, const mi::SonarVisualizationTile& msg)
+{
+  return QMetaObject::invokeMethod(layer, "handleTile", Qt::DirectConnection,
+                                   Q_ARG(marine_interfaces::msg::SonarVisualizationTile, msg));
+}
+
+class SonarLiveTileValidation: public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    QSettings().clear();
+    ASSERT_TRUE(cache_.isValid());
+    QSettings().setValue("LiveTileCache/cache_dir", cache_.path());
+    map_ = std::make_unique<Map>();
+    auto layers = map_->topLevelLayers();
+    ASSERT_NE(layers, nullptr);
+    layer_ = new SonarLiveCacheLayer(layers, nullptr, "/tile_validation_test");
+    layer_->enableLiveCoverage();
+    grid_ = gggs::Level(kLevel).gridIndex(43.0, -70.5);
+    ASSERT_TRUE(grid_.valid());
+  }
+
+  QTemporaryDir cache_;
+  std::unique_ptr<Map> map_;
+  SonarLiveCacheLayer* layer_ = nullptr;
+  gggs::GridIndex grid_;
+};
+
+}  // namespace
+
+TEST_F(SonarLiveTileValidation, RejectsOversizedEdge)
+{
+  // 8192 > kMaxImageEdge (4096): rejected before any allocation.
+  ASSERT_TRUE(deliverTile(layer_, makeTile(grid_, 8192, kEdge)));
+  EXPECT_EQ(layer_->residentTileCount(), std::size_t(0));
+  ASSERT_TRUE(deliverTile(layer_, makeTile(grid_, kEdge, 8192)));
+  EXPECT_EQ(layer_->residentTileCount(), std::size_t(0));
+}
+
+TEST_F(SonarLiveTileValidation, RejectsZeroDimensionsAndAbsurdBandCount)
+{
+  ASSERT_TRUE(deliverTile(layer_, makeTile(grid_, 0, kEdge)));
+  EXPECT_EQ(layer_->residentTileCount(), std::size_t(0));
+  ASSERT_TRUE(deliverTile(layer_, makeTile(grid_, kEdge, 0)));
+  EXPECT_EQ(layer_->residentTileCount(), std::size_t(0));
+  // 65 bands > kMaxBandCount (64).
+  ASSERT_TRUE(deliverTile(layer_, makeTile(grid_, kEdge, kEdge, 65)));
+  EXPECT_EQ(layer_->residentTileCount(), std::size_t(0));
+}
+
+TEST_F(SonarLiveTileValidation, RejectsCombinedByteCeiling)
+{
+  // Each edge within the 4096 cap and bands within the 64 cap, but combined
+  // 4096*4096*16*4B = 1 GiB > the 256 MiB ceiling.
+  ASSERT_TRUE(deliverTile(layer_, makeTile(grid_, 4096, 4096, 16)));
+  EXPECT_EQ(layer_->residentTileCount(), std::size_t(0));
+}
+
+TEST_F(SonarLiveTileValidation, AcceptsLegitimateTile)
+{
+  ASSERT_TRUE(deliverTile(layer_, makeTile(grid_, kEdge, kEdge)));
+  EXPECT_EQ(layer_->residentTileCount(), std::size_t(1));
+}
+
+int main(int argc, char** argv)
+{
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QApplication app(argc, argv);
+  QCoreApplication::setOrganizationName("camp_test");
+  QCoreApplication::setApplicationName("test_sonar_live_tile_validation");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Closes #168
Closes #169
Closes #170

## What

Live-coverage robustness bundle from the [2026-07-23 BizzyBoat deployment](https://github.com/rolker/unh_echoboats_project11/issues/386) incident — three structural fixes, one atomic commit each:

- **#168 — layer can be re-added after remove** (`2544c56`): `SonarLiveCacheManager` now tracks spawned sources in a `std::set` and erases the entry from the layer's `QObject::destroyed` signal (factored into a `trackSpawnedLayer()` seam with an `isSourceTracked()` accessor). Previously the write-only map made a removed layer un-respawnable until camp restart.
- **#169 — requests resume on every enable** (`09e7443`): every catalog is buffered in `last_catalog_` even while disabled (the transient-local depth-1 subscription delivers its latched sample exactly once), and `enableLiveCoverage()` replays it after warm-load/subscribe — so anti-entropy reconcile + tile requests fire on startup-race and in-session re-enable alike.
- **#170 — tile dimensions validated before allocation** (`ee21fd0`): `handleTile` rejects (with a warning) zero/oversized edges (>4096), >64 bands, or >256 MiB combined footprint before any allocation or state mutation — closing the unbounded-allocation crash path. GUI-thread load bounding (re-render rate-limit, eviction amortization) deferred to the #154/#155/#156 umbrella per the plan.

## Test plan

- Full camp suite green: 220 tests, 0 failures (1 pre-existing skip).
- Three new headless test files (offscreen QApplication, ROS-free): manager respawn (direct-delete + `deleteLater` paths, white-box on the real tracking set), catalog resume (prune-all catalog delivered while disabled takes effect on re-enable — **negative-verified to fail without the fix**), tile validation (per-edge / band-count / byte-ceiling rejection + acceptance).
- Pre-push review round 1: approved, `Ship: recommended` — two independent adversarial passes confirmed all three fixes; 4 comment-precision suggestions applied (`16e6e53`).
- Field verification (operator remove→re-add, restart-resume, sustained tile load) is the next deployment's checklist.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
