### PR TITLE
Field import: camp (2026-08-20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,6 +476,35 @@ if(BUILD_TESTING)
     Qt5::Widgets
   )
 
+  # AIS unknown speed/course must not render as a number (uninitialised cog,
+  # and int() of NaN, both surfaced as huge values in the hover label)
+  ament_add_gtest(test_ais_contact_state
+    test/test_ais_contact_state.cpp
+    src/camp/ais/ais_contact.cpp
+    src/camp/ship_track.cpp
+    src/camp/geographicsitem.cpp
+    src/camp/georeferenced.cpp
+    src/camp/ros/ros_object.cpp
+    src/camp_map/map_view/web_mercator.cpp
+  )
+  target_include_directories(test_ais_contact_state PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp_map
+  )
+  ament_target_dependencies(test_ais_contact_state
+    rclcpp
+    marine_ais_msgs
+    tf2
+    tf2_geometry_msgs
+    geometry_msgs
+  )
+  target_link_libraries(test_ais_contact_state
+    Qt5::Core
+    Qt5::Widgets
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
+  )
+
   # earth<-frame transform cache / staleness decision (#59 — TF-gap flicker fix)
   ament_add_gtest(test_transform_cache
     test/test_transform_cache.cpp

--- a/docs/camp_user_manual.md
+++ b/docs/camp_user_manual.md
@@ -31,9 +31,10 @@ Start CAMP from the operator station:
 ros2 launch camp camp_launch.py
 ```
 
-- CAMP **auto-loads a default background chart** (the `background_chart` launch
-  argument; currently NOAA chart 13283). To use a different chart, pass
-  `background_chart:=<path-to-.KAP>`.
+- CAMP starts with its **OpenStreetMap backdrop**; no chart is loaded for you.
+  Open one with *Open Background* from the map context menu. Charts are app
+  state — CAMP remembers what you opened and restores it next start, and
+  removing a chart layer makes that stick too.
 - CAMP is typically started as part of the operator launcher (see the boat's
   operator manual, *Starting the stack*), so you don't usually run it by hand.
 

--- a/launch/camp_launch.py
+++ b/launch/camp_launch.py
@@ -1,22 +1,17 @@
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
-def generate_launch_description():
-  background_chart = LaunchConfiguration('background_chart')
-  background_chart_arg = DeclareLaunchArgument(
-    "background_chart",
-      default_value=PathJoinSubstitution([
-          FindPackageShare('camp'),
-            'workspace/13283/13283_2.KAP'
-      ])
-  )
 
+def generate_launch_description():
+  # Workspace directory only. CAMP is not given a background raster at launch:
+  # it draws an OpenStreetMap backdrop of its own, and any charts the operator
+  # opens are app state that CAMP persists and restores by itself. Forcing one
+  # here also made it stick -- the command-line chart is loaded through
+  # openBackground(), which persists it, so it came back on subsequent starts
+  # even once the argument was removed.
   return LaunchDescription([
-    background_chart_arg,
     Node(
       package='camp',
       executable='CCOMAutonomousMissionPlanner',
@@ -25,8 +20,7 @@ def generate_launch_description():
         PathJoinSubstitution([
           FindPackageShare('camp'),
           'workspace/'
-        ]),
-        background_chart
+        ])
       ],
       emulate_tty=True
     )

--- a/src/camp/ais/ais_contact.cpp
+++ b/src/camp/ais/ais_contact.cpp
@@ -37,7 +37,12 @@ AISContactState::AISContactState(const marine_ais_msgs::msg::AISContact& message
   sog = motion.length();
   if (motion.length() > 0.0)
   {
-    cog = -motion.angle(tf2::Vector3(0.0, 1.0, 0.0))*180/M_PI;
+    // Bearing from north, clockwise positive, from the ENU motion vector
+    // (x east, y north — the parser's convention). Vector3::angle() is
+    // unsigned (acos of the dot product), so the previous -angle() form
+    // mirrored every eastward course (true 090 rendered as 270) in the
+    // label and the prediction vector.
+    cog = atan2(motion.x(), motion.y())*180/M_PI;
     if (cog < 0.0)
      cog += 360.0;
   }
@@ -146,7 +151,7 @@ void AISContact::updateLabel()
   }
   setLabel(label);
 }
-  
+
 
 
 void AISContact::updateProjectedPoints()
@@ -178,7 +183,7 @@ void AISContact::paint(QPainter* painter, const QStyleOptionGraphicsItem* option
   painter->drawPath(shape());
 
   p.setColor(QColor(128, 128, 128, 128));
-  
+
   painter->setPen(p);
   painter->drawPath(predictionShape());
 
@@ -239,6 +244,11 @@ QPainterPath AISContact::predictionShape() const
       state++;
     if(state != m_states.rend())
     {
+      // No prediction without a speed AND course: NaN (unavailable) would
+      // otherwise reach atDistanceAndAzimuth and only disappear by the
+      // accident of release-Qt dropping non-finite path points.
+      if(std::isnan(state->second.sog) || std::isnan(state->second.cog))
+        return ret;
       ret.moveTo(state->second.location.pos);
       QGeoCoordinate futureLocation = state->second.location.location.atDistanceAndAzimuth(state->second.sog*300, state->second.cog);
       auto timeSinceReport = m_displayTime - state->first;

--- a/src/camp/ais/ais_contact.cpp
+++ b/src/camp/ais/ais_contact.cpp
@@ -129,8 +129,20 @@ void AISContact::updateLabel()
 
   if(!m_states.empty())
   {
-    label += "\nsog: " + QString::number(int(m_states.rbegin()->second.sog*10)/10.0) + " m/s";
-    label += "\ncog: " + QString::number(int(m_states.rbegin()->second.cog));
+    // NaN means the value is genuinely unavailable -- either AIS reported its
+    // not-available sentinel, or the contact is not moving so no course can be
+    // derived. Say so rather than printing a number. The int() casts these
+    // replace were also undefined behaviour on NaN, which is how an absent
+    // value reached the label as a huge one.
+    const auto& state = m_states.rbegin()->second;
+    if(std::isnan(state.sog))
+      label += "\nsog: n/a";
+    else
+      label += "\nsog: " + QString::number(state.sog, 'f', 1) + " m/s";
+    if(std::isnan(state.cog))
+      label += "\ncog: n/a";
+    else
+      label += "\ncog: " + QString::number(static_cast<int>(state.cog));
   }
   setLabel(label);
 }

--- a/src/camp/ais/ais_contact.h
+++ b/src/camp/ais/ais_contact.h
@@ -2,6 +2,7 @@
 #define CAMP_AIS_CONTACT_H
 
 #include <QObject>
+#include <cmath>
 #include "../ship_track.h"
 #include "marine_ais_msgs/msg/ais_contact.hpp"
 #include "../locationposition.h"
@@ -26,9 +27,16 @@ struct AISContactState
   AISContactState(const marine_ais_msgs::msg::AISContact& message);
   rclcpp::Time timestamp;
   LocationPosition location;
-  double heading;
-  float cog;
-  float sog;
+  // Initialised to NaN, the "unavailable" value the rest of the AIS path
+  // already uses. None of these is guaranteed to be assigned: a contact that
+  // is not moving never computes a course, and AIS reports SOG/COG as
+  // unavailable often enough (the parser writes NaN into the twist) that the
+  // motion vector is frequently NaN, which fails the > 0.0 test the same way.
+  // Left uninitialised, the label rendered whatever was on the stack as a
+  // course over ground.
+  double heading = std::nan("");
+  float cog = std::nan("");
+  float sog = std::nan("");
 };
 
 struct AISReport: public QObject, AISContactDetails, AISContactState

--- a/src/camp/ais/ais_contact.h
+++ b/src/camp/ais/ais_contact.h
@@ -13,12 +13,17 @@ struct AISContactDetails
 {
   AISContactDetails();
   AISContactDetails(const marine_ais_msgs::msg::AISContact& message);
-  uint32_t mmsi;
+  uint32_t mmsi = 0;
   std::string name;
-  float dimension_to_stbd; 
-  float dimension_to_port;
-  float dimension_to_bow;
-  float dimension_to_stern;
+  // Zero is AIS's "dimension not available", and is what shape() already
+  // tests to fall back from a ship outline to a triangle. Initialising to it
+  // means a details object built before any report describes an unknown-size
+  // vessel rather than one whose dimensions are whatever was on the stack --
+  // those feed drawShipOutline directly.
+  float dimension_to_stbd = 0.0f;
+  float dimension_to_port = 0.0f;
+  float dimension_to_bow = 0.0f;
+  float dimension_to_stern = 0.0f;
 };
 
 struct AISContactState

--- a/src/camp/main.cpp
+++ b/src/camp/main.cpp
@@ -22,12 +22,12 @@ int main(int argc, char *argv[])
     w.setStyleSheet("QSplitter::handle{background: #8080A0;}");
     w.show();
 
-    auto args = rclcpp::remove_ros_arguments(argc, argv);    
-    
+    auto args = rclcpp::remove_ros_arguments(argc, argv);
+
     for(std::size_t i = 1; i < args.size(); i++)
     {
         QString arg(args[i].c_str());
-        if(arg.isEmpty())  // empty arg (e.g. an empty background_chart) -> ignore
+        if(arg.isEmpty())  // empty arg (e.g. an empty launch substitution) -> ignore
             continue;
         if(arg.endsWith(".json", Qt::CaseInsensitive))
             //w.open(arg);

--- a/src/camp/platform_manager/platform.cpp
+++ b/src/camp/platform_manager/platform.cpp
@@ -13,12 +13,14 @@ Platform::Platform(QWidget* parent, QGraphicsItem *parentItem):
   m_ui(new Ui::Platform)
 {
   m_ui->setupUi(this);
-  // Order: helm, running-task tree, mission command buttons. Give the tree all
-  // the vertical stretch so the helm panel and the (now header-less) button row
-  // stay at their natural, compact height instead of each taking a third.
+  // The splitter holds only the two panes worth resizing: the helm panel and
+  // the running-task tree. The tree takes all the spare height so the helm
+  // panel stays at its natural, compact size. The mission command buttons sit
+  // below the splitter in the parent layout (platform.ui) rather than inside
+  // it -- a button row has nothing to reveal by growing, and a handle above it
+  // could only shrink or collapse the buttons out of reach.
   m_ui->splitter->setStretchFactor(0, 0);  // helmManager
   m_ui->splitter->setStretchFactor(1, 1);  // runningTasksView
-  m_ui->splitter->setStretchFactor(2, 0);  // missionManager (buttons)
   setAcceptHoverEvents(true);
   setZValue(6.0);
   connect(this, &Platform::pathUpdated, this, &Platform::updatePath, Qt::QueuedConnection);

--- a/src/camp/platform_manager/platform.ui
+++ b/src/camp/platform_manager/platform.ui
@@ -13,16 +13,24 @@
   <property name="windowTitle">
    <string>Platform</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <!-- Stretch 1,0,0: the splitter absorbs all spare height; the mission
+       command buttons and the SOG readout keep their natural size. -->
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,0">
    <item>
+    <!-- Only the two resizable panes belong in the splitter. missionManager
+         is a single row of buttons with nothing to reveal by growing, so
+         putting it here would add a second handle that can only make the
+         layout worse (and collapse the buttons out of sight). -->
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <widget class="HelmManager" name="helmManager" native="true"/>
      <widget class="RunningTasksView" name="runningTasksView" native="true"/>
-     <widget class="MissionManager" name="missionManager" native="true"/>
     </widget>
+   </item>
+   <item>
+    <widget class="MissionManager" name="missionManager" native="true"/>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/test/test_ais_contact_state.cpp
+++ b/test/test_ais_contact_state.cpp
@@ -73,6 +73,8 @@ TEST(AISContactState, MovingContactYieldsSpeedAndCourse)
   AISContactState state(contactWithVelocity(3.0, 4.0));
   EXPECT_FLOAT_EQ(5.0f, state.sog);
   ASSERT_FALSE(std::isnan(state.cog));
-  EXPECT_GE(state.cog, 0.0f);
-  EXPECT_LT(state.cog, 360.0f);
+  // ENU (east=3, north=4) is a true course of atan2(3,4) = 036.87 degrees.
+  // Pinned: a range-only assertion would accept the mirrored 323.13 the old
+  // -angle() form produced.
+  EXPECT_NEAR(36.8699f, state.cog, 0.01f);
 }

--- a/test/test_ais_contact_state.cpp
+++ b/test/test_ais_contact_state.cpp
@@ -29,6 +29,19 @@ marine_ais_msgs::msg::AISContact contactWithVelocity(double x, double y)
 
 }  // namespace
 
+TEST(AISContactDetails, DefaultConstructedDimensionsAreUnknownNotGarbage)
+{
+  // Zero is AIS's "not available" for dimensions, and what AISContact::shape()
+  // tests to choose a triangle over a ship outline. Uninitialised members
+  // would feed drawShipOutline whatever was on the stack.
+  AISContactDetails details;
+  EXPECT_EQ(0u, details.mmsi);
+  EXPECT_FLOAT_EQ(0.0f, details.dimension_to_bow);
+  EXPECT_FLOAT_EQ(0.0f, details.dimension_to_stern);
+  EXPECT_FLOAT_EQ(0.0f, details.dimension_to_port);
+  EXPECT_FLOAT_EQ(0.0f, details.dimension_to_stbd);
+}
+
 TEST(AISContactState, DefaultConstructedValuesAreUnknownNotGarbage)
 {
   AISContactState state;

--- a/test/test_ais_contact_state.cpp
+++ b/test/test_ais_contact_state.cpp
@@ -1,0 +1,65 @@
+// AISContactState must never present an unknown speed or course as a number.
+//
+// AIS reports SOG/COG as unavailable often enough that this is the common case,
+// not an edge case: the parser writes NaN into the twist, and a contact that is
+// not moving has no derivable course at all. Both used to reach the hover label
+// as very large numbers -- cog because it was an uninitialised member that the
+// constructor only assigns when the contact is moving, and sog because casting
+// NaN to int is undefined behaviour.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+#include "ais/ais_contact.h"
+
+namespace
+{
+
+marine_ais_msgs::msg::AISContact contactWithVelocity(double x, double y)
+{
+  marine_ais_msgs::msg::AISContact message;
+  message.pose.position.latitude = 43.05;
+  message.pose.position.longitude = -70.72;
+  message.twist.twist.linear.x = x;
+  message.twist.twist.linear.y = y;
+  return message;
+}
+
+}  // namespace
+
+TEST(AISContactState, DefaultConstructedValuesAreUnknownNotGarbage)
+{
+  AISContactState state;
+  EXPECT_TRUE(std::isnan(state.sog));
+  EXPECT_TRUE(std::isnan(state.cog));
+  EXPECT_TRUE(std::isnan(state.heading));
+}
+
+TEST(AISContactState, UnavailableVelocityStaysUnknown)
+{
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  AISContactState state(contactWithVelocity(nan, nan));
+  EXPECT_TRUE(std::isnan(state.sog));
+  EXPECT_TRUE(std::isnan(state.cog)) << "NaN velocity must not leave cog unset";
+}
+
+TEST(AISContactState, StationaryContactHasNoCourse)
+{
+  // A stopped vessel reports a real SOG of zero, but no meaningful course.
+  // The constructor cannot compute one, so cog must remain unknown rather
+  // than retaining whatever was in the member beforehand.
+  AISContactState state(contactWithVelocity(0.0, 0.0));
+  EXPECT_FLOAT_EQ(0.0f, state.sog);
+  EXPECT_TRUE(std::isnan(state.cog));
+}
+
+TEST(AISContactState, MovingContactYieldsSpeedAndCourse)
+{
+  AISContactState state(contactWithVelocity(3.0, 4.0));
+  EXPECT_FLOAT_EQ(5.0f, state.sog);
+  ASSERT_FALSE(std::isnan(state.cog));
+  EXPECT_GE(state.cog, 0.0f);
+  EXPECT_LT(state.cog, 360.0f);
+}


### PR DESCRIPTION
Closes #192.

Field import from gitcloud (4 commits, agents on gabby/pandy): AIS unknown-value rendering + member-initialisation UB fixes (with new registered gtest), no-background-chart-at-startup launch change, and the mission-command splitter fix. Pre-review clean — see #192 for the full assessment.

**Diverged branch note**: cut from `gitcloud/jazzy`; jazzy has 23 newer local commits (today's merges), so this PR's merge commit performs the reconciliation. Field SHAs preserved (no cherry-pick) so gitcloud stays reconcilable without force-push.

Pairs with the `unh_marine_autonomy` operator_ui import (forced background raster dropped there).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
