### PR TITLE
GggsTileLayer: viewport-scoped retention + residency budget (uma-ADR-0013 D4)

### DIFF
--- a/.agent/work-plans/issue-195/plan.md
+++ b/.agent/work-plans/issue-195/plan.md
@@ -4,6 +4,12 @@
 
 https://github.com/rolker/camp/issues/195
 
+**Revised 2026-08-21** after the plan review (`progress.md` § Plan Review,
+`66c5f76`, 14 findings) and the operator decisions taken on it. The revision is
+recorded inline throughout; the four decisions are summarised in
+"Decisions applied to this revision" below so the delta from `b70311f` stays
+readable.
+
 ## Context
 
 Verified against the code: `GggsTileLayer` has exactly one release path —
@@ -24,166 +30,257 @@ Two in-repo precedents bracket the fix:
 with `last_access_seq` LRU fallback, `foldIntoParent()`, `kApexProtectLevel`,
 `kReloadHysteresisFactor`), and `MapTiles::evictIfNeeded()` (camp#98 — a
 **count** cap of `max(256, 4 × visible_count)`, deferred + debounced off
-`paint()`, protecting the live visible set).
+`paint()`, protecting the live visible set, with the eviction pass recomputing
+the protected set **live** rather than trusting the one captured at schedule
+time). `test/test_map_tiles_eviction.cpp` is the in-repo count-budget test
+precedent; `cube_bathymetry`'s `test_tile_eviction_rss.cpp` is the out-of-repo
+one.
+
+## Decisions applied to this revision
+
+1. **Budget is a `QSettings` byte target, default 512 MiB**, converted to a tile
+   count from the *observed* tile size. `width_`/`height_` come from GDAL
+   (`gggs_tile.cpp:70-71,96-97`), so 960×960 is a store convention, not a
+   guarantee, and a hardcoded count would silently mis-size on any other store.
+   The key mirrors `LiveTileCache/max_vram_bytes` (`sonar_live_cache_layer.cpp:150-163`),
+   including `0 = disabled`.
+   *Rationale for 512 MiB beside the live cache's own 512 MiB*: the camp#153 OOM
+   precedent is **salmon**'s hardware, and **the Shoals operator station is
+   pandy, not salmon**. A 512 MiB display working set alongside the live cache's
+   512 MiB is acceptable on pandy; the settings key exists precisely so the
+   number can be tuned on the host during the rebuild day rather than requiring
+   a rebuild.
+2. **The cap is floored at the protected (current-frame) set.** A ceiling that
+   can fall below the working set is D4's "thrashes by construction" (review
+   finding 6). The floor is paired with a **non-silent over-budget status**, so
+   D4's "never fail silently" holds without the degrade lever.
+3. **The `pressure_bias_` / degrade-under-pressure lever is deferred entirely**
+   to **camp#197** (review finding 9: as specified it oscillates with a period
+   equal to its cool-down). camp#155/#156 are named there as the measured-pressure
+   input.
+4. **The `deriveViewportClip()` signature change is dropped** (review finding 8).
+   `clip.scene.center()` is already computed every `paint()`, and with CAMP's
+   single MapView it *is* the painting view's centre. Painting-view recovery
+   stays camp#150's.
 
 ## Approach
 
-Governed by `uma-ADR-0013` D4. Design decisions, with the reasoning the issue
-asked to be checked rather than assumed:
+Governed by `uma-ADR-0013` D4.
 
 1. **No fold-to-parent — plain drop-and-re-read.** `SonarLiveCacheLayer` folds
    because its tiles arrive once over ROS and must survive eviction; a GGGS
    tile's source of truth is the file on disk. `resetPixels()` + `releaseGL()`
-   already is a complete release, and the existing demand-driven loader already
-   reloads on pan-back (`hasUnloadedVisibleTiles()` + the
-   moved-since-last-kick re-kick in `paint():996-1000`) — **the reload path is
-   free**. Building a CAMP-side pyramid would also manufacture a derived
-   product for `chart`/`reference`, which `uma-ADR-0010` D9 deliberately gives
-   no overviews.
+   already is a complete release, and the existing demand-driven loader reloads
+   on pan-back (`hasUnloadedVisibleTiles()` + the moved-since-last-kick re-kick
+   in `paint():996-1000`) — **the reload path is free for every tile at a level
+   ≤ the selection**. Building a CAMP-side pyramid would also manufacture a
+   derived product for `chart`/`reference`, which `uma-ADR-0010` D9 deliberately
+   gives no overviews.
    *Cost:* an evicted area **blanks** until the reload lands, rather than
-   degrading. Bought back cheaply by the apex-protect analogue in step 3.
+   degrading — bought back by the coarsest-level exemption in step 4, and, in
+   the ladder case, by the fact that every level ≤ the selection is resident, so
+   a panned-away area retains coarse coverage.
+   *Exception (review finding 4):* a **hole-covering** tile at a level **finer**
+   than the selection is NOT reloadable — `loadTilesWorker()` skips
+   `tile->level() > level` (`:527`). See step 5.
 
 2. **Structural current-frame protection** (`raster/tile_residency.h`, new,
-   header-only + GL-free). A `TileResidency` type owns two `std::list<size_t>`
-   partitions and an index of iterators: `beginFrame()` splices the whole
-   protected list into the evictable list (O(1)); `protect(i)` splices one
-   entry back (O(1)); `candidates()` returns **only** the evictable partition.
-   The eviction routine has no access to the protected partition, so "cannot
-   evict what this frame selected" is a property of the type, not an `if` a
-   future edit can drop — D4's requirement, via the sentinel-splice pattern,
-   without an intrusive list inside `tiles_`. Standalone-testable.
+   header-only, Qt- and GL-free). `TileResidency` owns two `std::list<size_t>`
+   partitions plus an index of iterators and a per-index frame epoch:
+   `beginFrame()` splices the whole protected list into the evictable list and
+   bumps the epoch (O(1)); `protect(i)` splices one entry back (O(1), idempotent
+   within a frame); `candidates()` returns **only** the evictable partition. The
+   eviction routine has no access to the protected partition, so "cannot evict
+   what this frame selected" is a property of the type, not an `if` a future
+   edit can drop — D4's sentinel-node requirement. Standalone-testable.
 
-3. **Count budget, adaptive cap.** Tiles are a fixed 960×960, so count is a
-   faithful RAM proxy (D4 blesses it; `cube_bathymetry`'s
-   `test_tile_eviction_rss.cpp` uses the same proxy). Cap =
-   `clamp(kMultiplier × protected_count, kMinCap, kMaxCap)` — MapTiles' form,
-   which makes "budget ≥ current-frame working set" true *by construction*
-   (D4). Proposed defaults `kMultiplier = 3`, `kMinCap = 32`,
-   `kMaxCap = 64` (≈450 MiB worst case at 7.03 MiB/tile), overridable via
-   `QSettings GggsTileLayers/max_resident_tiles` (`0` disables → pre-#195
-   behaviour, mirroring `LiveTileCache/max_vram_bytes`). Tiles at the
-   **coarsest available level** are never evicted (the `kApexProtectLevel`
-   analogue): on a nested `overviews/` ladder that guarantees a zoom-out floor;
-   on a single-level store it is a no-op and blanking stands (documented).
+3. **Protection comes from the loader predicate, not the draw list**
+   (review finding 1 — must-fix). `itemsIntersecting()` is short-circuited by
+   `cached_image_` on a static frame (`paint():1009-1015`), so a draw-list-sourced
+   `protect()` would protect **nothing** on exactly the frames eviction runs on,
+   and the live visible set would become evictable. The predicate is the
+   loader's own: *tile intersects `clip.scene`* **and** *level ≤ `selected_level_`*
+   (plus the hole-coverage extension of step 5), evaluated over `tiles_`
+   irrespective of load state — a not-yet-loaded selected tile is part of the
+   working set the cap must accommodate. `loadFailed()` tiles are excluded (they
+   never become resident, so they must not inflate the floor).
+   **Placement** (review finding 2 — must-fix): `beginFrame()`/`protect()` run
+   in `paint()` immediately after the LOD selection and **before** the
+   `data_min_ > data_max_` early return at `:1002`. The `tiles_.empty()` return
+   at `:942` is vacuous (nothing to protect or evict). The eviction pass
+   **re-runs** the same predicate live before choosing candidates, MapTiles-style,
+   so a tile that re-entered the view between scheduling and running is never
+   evicted — and so protection cannot go stale across the debounce.
 
-4. **Hybrid ordering, camp#150-safe.** Order candidates farthest-first by
-   distance to the **nearest** recorded view centre, `last_visible_gen_` LRU
-   as the fallback (headless / no view). Do **not** inherit
-   `views().first()`: `paint()` receives the painting viewport as its `QWidget*
-   widget` argument, so `deriveViewportClip()` gains an optional `widget`
-   parameter and recovers the painting view via
-   `qobject_cast<QGraphicsView*>(widget->parentWidget())`, falling back to
-   `views().first()` exactly as today. Protection and view centres accumulate
-   per `paint()` call; eviction is deferred through a queued, debounced
-   `evictIfOverBudget()` (MapTiles pattern) so one pass sees the **union** of
-   every view that painted. Single-view behaviour is unchanged; camp#150 does
-   not invalidate the result.
+4. **Byte budget → count cap, floored at the working set.**
+   `GggsTileLayers/max_resident_bytes`, default 512 MiB, `0` disables (pre-#195
+   behaviour). Per-tile resident bytes are observed from the tile-set
+   (`width × height × 4`, doubled when a GL texture may also be held), so the
+   count adapts to whatever GDAL reports. Then
+   `cap = max(budget_bytes / per_tile_bytes, protected_count)` — the floor is
+   what makes "budget ≥ current-frame working set" true by construction (D4);
+   `protected_count > budget_tiles` sets the **over-budget status** instead of
+   thrashing (decision 2). Eviction runs down to
+   `max(protected_count, 0.75 × cap)` (the `kReloadHysteresisFactor` analogue)
+   so the next frame cannot immediately re-trigger.
+   **Coarsest-level exemption, bounded** (review finding 11): tiles at
+   `available_levels_.front()` are exempt as the zoom-out floor — but only when
+   the ladder has more than one level (on a single-level store every tile would
+   otherwise be exempt and the budget would be a no-op), and only for the
+   `kCoarsestExemptCap` nearest such tiles; the surplus, which is what grows with
+   the area panned, becomes a **last-resort** candidate rather than an exemption.
+   `available_levels_` is rebuilt by `rescan()`, so the exemption is evaluated
+   per pass, never cached.
 
-5. **Hysteresis and volume caps.** Once triggered, evict down to
-   `kEvictHysteresisFactor = 0.75 × cap` so the next frame cannot re-trigger
-   (the `kReloadHysteresisFactor` analogue). The loader's existing
-   moved-since-last-kick guard covers re-kick storms; add a per-kick bound so
-   `loadTilesWorker()` stops after `cap` tiles — its pass is already
-   ascending-by-level, so a truncated kick yields coarse coverage first.
+5. **camp#194 hole coverage is preserved, and its reload gap is handled
+   explicitly** (review finding 4 — must-fix). The predicate "this finer tile
+   intersects a `loadFailed()` tile at a level ≤ the selection" is extracted into
+   one helper shared by `tilesReady()`'s release loop and the budget pass, so the
+   two rules cannot drift. A hole-coverer **in the current viewport** is
+   protected like any selected tile — it is the only usable coverage there.
+   A hole-coverer **outside** the viewport is a *last-resort* candidate: evicted
+   only when nothing else can be, because it genuinely cannot reload
+   (`loadTilesWorker()` skips levels > the selection). When one is dropped the
+   layer says so in its status ("coverage over failed tile(s) released — use
+   Rescan"), so the loss is visible and the operator has the recovery action.
+   *Alternative considered and rejected:* extending the loader ceiling to admit
+   finer tiles over a failed footprint would make them reloadable, but a failed
+   **coarse** tile spans an enormous footprint, so this would pull in every fine
+   tile in the viewport at low zoom — reintroducing the store-bounded load
+   `camp-ADR-0013` exists to avoid, and inflating the protected floor with it.
 
-6. **Degrade, don't thrash; never silently.** When the protected set alone
-   exceeds `kMaxCap`, eviction cannot help — so relax the quality target:
-   `pressure_bias_` steps the `selectLodLevel()` pick `bias` entries coarser in
-   `available_levels_`, one-way ratchet with an N-frame cool-down before
-   relaxing, and `setStatus("(reduced detail — tile budget)")`. Where no
-   coarser level exists the bias is a no-op and the status says the layer is
-   over budget instead. This closes D4's loop rather than reporting a number
-   nobody acts on.
+6. **Eviction is deferred, debounced, and re-arms when the worker is busy**
+   (review finding 3 — must-fix). `paint()` only *schedules*
+   `evictIfOverBudget()` (queued invocation, `eviction_pending_` debounce);
+   releasing tiles inside `paint()` would mutate the set the render pass reads.
+   The slot must not mutate tiles the loader worker is iterating, so it checks
+   `future_watcher_.isRunning()` — and when it finds the worker busy it
+   **re-arms** on a short timer with `eviction_pending_` still set, instead of
+   dropping the request. Without the re-arm the budget would almost never fire
+   during a continuous pan, because every pan step re-kicks the loader — the
+   exact scenario the budget exists for. Abort+join (what `loadTiles()` does)
+   is rejected here: it would stall the GUI thread mid-pan for a whole tile read.
 
-7. **Preserve camp#194's hole-coverage rule.** `tilesReady()` retains finer
-   tiles that intersect a `loadFailed()` tile at a level ≤ the selection —
-   the only usable coverage over that hole. Those tiles must be `protect()`ed
-   in the new pass too, or the budget path silently undoes that guarantee.
+7. **Hybrid eviction ordering with a staleness term** (review finding 12).
+   Candidates are ordered by, in priority: *last-resort tier* (out-of-view
+   hole-coverers and surplus-coarsest last), then *staleness* (a tile not seen
+   in the last `kRecentGenerations` paints goes first), then *farthest from the
+   viewport centre*, then LRU generation. The staleness tier is what keeps
+   distance from being primary — D4's stated objection is that distance-only
+   "discards history along a path being traversed", and a tile seen a few frames
+   ago along a pan track sorts behind one that has not been seen at all.
+   The viewport centre is `load_viewport_.center()` — `clip.scene`'s centre,
+   recorded by `paint()` (decision 4). A null viewport (headless) leaves pure
+   LRU, exactly as `SonarLiveCacheLayer` degrades.
 
-8. **Extract `releaseTile()`.** The `releaseGL()`/`resetPixels()` pairing plus
-   the `makeCurrent()`-or-skip dance in `tilesReady()` becomes one helper both
-   release paths call. Both keep the GUI-thread assert and the
-   `!future_watcher_.isRunning()` gate (they mutate tiles the worker iterates).
+8. **One status composer** (review finding 5 — must-fix). `tilesReady()`
+   currently rewrites `setStatus()` unconditionally (`:732-739`, clearing to
+   `""`), which would wipe any over-budget message written from `paint()`.
+   All status writes move into `updateStatus()`, which composes from state —
+   no tiles / loading / no data / failed-tile count / over budget / hole coverage
+   released — and every writer calls it instead of `setStatus()`.
+
+9. **No per-kick loader volume cap** (review finding 7 — must-fix; the original
+   plan's step 5 is withdrawn). The re-kick guard requires `selected_level_` or
+   `load_viewport_` to change (`:996-999`), so a truncated kick with a stationary
+   operator would never complete and `tilesReady()` would settle with a cleared
+   status over a permanently incomplete picture. The kick set is already
+   viewport-bounded — it *is* the protected set — so the cap bought nothing.
+
+10. **Extract `releaseTiles()`.** The `releaseGL()`/`resetPixels()` pairing plus
+    the `makeCurrent()`-or-skip dance in `tilesReady()` becomes one helper both
+    release paths call, so the pairing invariant (`gggs_tile.h`: a CPU-only clear
+    leaves a stale texture shadowing any re-load) is enforced in one place.
 
 ## Test Strategy
 
 | Test | Asserts |
 |---|---|
-| `test/test_tile_residency.cpp` (new, pure) | `beginFrame()`/`protect()`/`candidates()` invariants: a protected index never appears in `candidates()`; splice is O(1)-shaped; re-protect is idempotent |
-| `test/test_gggs_eviction.cpp` (new, headless, GL-free) | Synthetic tile dir + `setLodForTest()` walked across a strip far wider than the cap: resident count stays ≤ cap while visited count grows (the `test_tile_eviction_rss.cpp` bounded-count shape); no tile in the current `load_viewport_` is ever evicted; coarsest level survives; pan-back reloads the dropped tile (`pixelsLoadedCount()`); evict↔reload ping-pong does not occur across repeated A→B→A pans; a `loadFailed()`-covering finer tile is retained; `max_resident_tiles = 0` reproduces pre-#195 residency |
-| `test/test_gggs_render.cpp` (extend) | Degrade path: with a cap below the visible set, the selection steps coarser and `status()` is non-empty |
+| `test/test_tile_residency.cpp` (new, pure) | `beginFrame()`/`protect()`/`candidates()` invariants: a protected index never appears in `candidates()`; re-protect within a frame is idempotent; `beginFrame()` returns the whole protected partition to the candidates; `sync()` admits tiles appended by `rescan()` |
+| `test/test_gggs_eviction.cpp` (new, headless, GL-free) | Synthetic single-level strip walked far wider than the cap: resident count stays ≤ cap while visited count grows (the `test_map_tiles_eviction.cpp` / `test_tile_eviction_rss.cpp` bounded-count shape); no tile intersecting the current `load_viewport_` is ever evicted; pan-back reloads a dropped tile (`pixelsLoadedCount()`); a ladder's coarsest level survives a pan that evicts the fine level, and the exemption is bounded; a `loadFailed()`-covering finer tile in view is retained; over-budget (working set alone above the byte target) floors the cap and reports a non-empty status rather than evicting the visible set; `max_resident_bytes = 0` reproduces pre-#195 residency |
+| `test/test_gggs_elevation.cpp` (extend — review finding 14) | `getElevation()` over an **evicted** (panned-away) area returns NaN while the in-viewport readout still answers — the consequence the plan's own table names |
 
-Precedents: `test_sonar_live_eviction.cpp`, `test_sonar_live_reload.cpp`.
-Register both new suites in `CMakeLists.txt` beside `test_gggs_rescan`.
+Headless coverage is the CPU half of the release only: with no GL context
+`releaseGL()` is a no-op and the texture half of the 7.03 MiB is untested
+(review finding 14). Recorded as a known coverage gap in `camp-ADR-0014`
+rather than papered over.
+
+The A→B→A ping-pong assertion from the original plan is **withdrawn** (review
+finding 12): with a cap below `|A ∪ B|` ping-pong is guaranteed, so the
+assertion was either unachievable or vacuous. The reload behaviour is covered by
+the pan-back assertion instead, at a cap that admits the working set.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `src/camp_map/raster/tile_residency.h` | **New.** Splice-partition residency helper (protected / evictable), header-only, GL- and Qt-light |
-| `src/camp_map/raster/gggs_tile_layer.h` | Budget + residency + pressure-bias members; `evictIfOverBudget()` slot, `releaseTile()`, test seams (`residentTileCount()`, `setResidentBudgetForTest()`) |
-| `src/camp_map/raster/gggs_tile_layer.cpp` | `paint()`: `beginFrame()`/`protect()`/record view centre/schedule eviction; pressure-bias LOD step; `evictIfOverBudget()`; `releaseTile()` extraction; loader per-kick cap; status reporting; ctor reads `QSettings` |
-| `src/camp_map/raster/viewport_clip.h` | Optional `QWidget* widget` → prefer the painting view, `views().first()` fallback |
-| `src/camp_map/raster/raster_layer.cpp`, `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp` | Pass `widget` to `deriveViewportClip()` (call sites only) |
+| `src/camp_map/raster/tile_residency.h` | **New.** Splice-partition residency helper (protected / evictable), header-only, Qt- and GL-free |
+| `src/camp_map/raster/gggs_tile_layer.h` | Budget + residency members; `evictIfOverBudget()` slot; `refreshProtection()`, `releaseTiles()`, `updateStatus()`, hole-coverage helper; test seams (`residentTileCount()`, `setResidentBudgetBytesForTest()`, `refreshResidencyForTest()`) |
+| `src/camp_map/raster/gggs_tile_layer.cpp` | `paint()`: protect + record the view centre + schedule eviction; `evictIfOverBudget()` with re-arm; `releaseTiles()`/`updateStatus()` extraction; ctor reads `QSettings` |
 | `test/test_tile_residency.cpp`, `test/test_gggs_eviction.cpp` | **New** (see Test Strategy) |
-| `test/test_gggs_render.cpp` | Degrade-path case |
+| `test/test_gggs_elevation.cpp` | Readout over an evicted area |
 | `CMakeLists.txt` | Register the two new gtest suites |
 | `docs/decisions/0014-gggs-viewport-scoped-residency.md` | **New camp ADR** — the decision, cross-referencing `uma-ADR-0013` D4 and `camp-ADR-0010` |
-| `docs/decisions/0013-lod-level-selection-demand-driven-load.md` | Amend: "levels ≤ the selection are never released" is no longer true; point at ADR-0014 |
+| `docs/decisions/0013-lod-level-selection-demand-driven-load.md` | Amend four stale places: the Residency bullet (`:81-84`), the Release bullet (`:132-138`), the residency-bound/camp#195 paragraph (`:147-165`), and the camp#195 pointers at `:97` and `:131` — the overdraw + composite-depth-cap mitigations re-route to **camp#198** |
+
+Not changed (was in the `b70311f` plan): `viewport_clip.h`,
+`raster_layer.cpp`, `sonar_live_cache_layer.cpp` — decision 4 dropped the
+`deriveViewportClip()` signature change.
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| Test what breaks | The failure is an OOM after prolonged panning — asserted as a bounded resident count under a synthetic pan walk, the portable proxy `cube_bathymetry` already uses |
-| A change includes its consequences | ADR-0013's residency paragraph, `getElevation()` semantics, and the shared `deriveViewportClip()` signature are all in-plan, not follow-ups |
-| Capture decisions, not just implementations | New camp ADR-0014 records the fold-vs-drop and count-vs-bytes reasoning; without it the next agent re-derives it |
-| Only what's needed | No fold-to-parent, no ResourceMonitor dependency, no prefetch (`uma-ADR-0013` D6 explicitly wants measurement first) |
-| Improve incrementally | A fixed sane default now; the measured budget arrives via #155/#156 through the same `QSettings` seam |
+| Test what breaks | The failure is an OOM after prolonged panning — asserted as a bounded resident count under a synthetic pan walk, the portable proxy both `test_map_tiles_eviction.cpp` and cube's `test_tile_eviction_rss.cpp` already use |
+| A change includes its consequences | All four stale `camp-ADR-0013` passages are amended in this PR, `getElevation()` over an evicted area gets a test, and the two follow-ups the ADR pointed at camp#195 for get real issues (camp#197, camp#198) rather than a dangling pointer |
+| Capture decisions, not just implementations | `camp-ADR-0014` records fold-vs-drop, bytes-vs-count, the hole-coverage last-resort rule, and the deferred τ lever; without it the next agent re-derives them |
+| Only what's needed | No fold-to-parent, no ResourceMonitor dependency, no prefetch (`uma-ADR-0013` D6 wants measurement first), no τ lever (camp#197), no `deriveViewportClip()` churn (camp#150) |
+| Improve incrementally | A sane default now; the measured budget arrives via camp#155/#156 through the same `QSettings` seam |
 | Enforcement over documentation | Current-frame protection is enforced by `TileResidency`'s type boundary, not by a comment |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| `uma-ADR-0013` D4 | Yes | Budget + structural current-frame protection + hybrid ordering + degrade-not-thrash, all implemented; count units explicitly blessed for fixed 960×960 tiles |
+| `uma-ADR-0013` D4 | Yes | Budget + structural current-frame protection + hybrid ordering implemented; the quality-relaxation lever is deferred to camp#197 with the cap floor + over-budget status standing in for "never fail silently" |
 | `uma-ADR-0013` D5 | Yes | Ascending (zoom-out) backdrop retention is untouched; eviction never targets the current frame, so "the picture never gets worse" holds except across a true pan-away |
 | `uma-ADR-0013` D6 | No | No prefetch — the ADR requires latency measurement first |
-| `uma-ADR-0013` D8 | No | `getElevation()` is a display readout, not a safety query; `shallowestReliable()` is not in this layer |
-| `uma-ADR-0010` D9 | Yes (respected) | No CAMP-side pyramid is manufactured for `chart`/`reference`; the coarse-zoom blank stays a store-side question |
-| `camp-ADR-0010` | Yes | Same forces, different layer; divergences (drop vs fold, count vs bytes) are recorded in the new ADR-0014 |
-| `camp-ADR-0011` | Yes | `deriveViewportClip()` gains a parameter; the render convention itself is unchanged |
-| `camp-ADR-0013` | Yes | Amended — the "levels ≤ selection are never released" residency rule is superseded |
+| `uma-ADR-0013` D8 | No | `getElevation()` is a display readout, not a safety query |
+| `uma-ADR-0010` D9 | Yes (respected) | No CAMP-side pyramid is manufactured for `chart`/`reference` |
+| `camp-ADR-0010` | Yes | Same forces, different layer; divergences (drop vs fold) are recorded in `camp-ADR-0014` |
+| `camp-ADR-0011` | Yes (untouched) | `deriveViewportClip()` is unchanged (decision 4) |
+| `camp-ADR-0013` | Yes | Amended in four places — the "levels ≤ selection are never released" residency rule is superseded and the camp#195 pointers are re-routed |
 
 ## Consequences
 
 | If we change... | Also update... | Included in plan? |
 |---|---|---|
-| The residency rule | `docs/decisions/0013-...md` + new ADR-0014 | Yes |
-| `deriveViewportClip()` signature | `RasterLayer`, `SonarLiveCacheLayer` call sites | Yes |
-| Tile residency | `getElevation()` returns NaN over evicted (off-screen) area | Yes — noted in ADR-0014; the cursor is always in-viewport, so protected |
-| Tile residency | Auto-range: deliberately **not** recomputed on evict (the fold is widening-only), so the colormap does not flicker as tiles come and go | Yes — stated in ADR-0014 |
-| Per-layer budget | N GGGS layers multiply the process footprint | No — process-wide accounting is #155/#156; ADR-0014 records the gap |
-| Per-frame overdraw (issue comment) | Composite-depth capping / occlusion skip | No — separate axis; the budget bounds it only indirectly. Follow-up issue |
+| The residency rule | `docs/decisions/0013-...md` (4 passages) + new `camp-ADR-0014` | Yes |
+| Tile residency | `getElevation()` returns NaN over an evicted (off-screen) area | Yes — tested, and recorded in `camp-ADR-0014`; the cursor is always in-viewport, so its tile is protected |
+| Tile residency | Auto-range: deliberately **not** recomputed on evict (the fold is widening-only), so the colormap does not flicker as tiles come and go | Yes — stated in `camp-ADR-0014` |
+| Per-layer budget | N GGGS layers multiply the process footprint | No — process-wide accounting is camp#155/#156; `camp-ADR-0014` records the gap |
+| Per-frame overdraw | Composite-depth capping / occlusion skip | No — camp#198, and `camp-ADR-0013`'s pointers are re-routed there |
+| Quality under pressure | The D4 τ lever | No — camp#197 |
 
 ## Documentation & Instruction Impact
 
-- **Stale docs** (must land in this PR): `docs/decisions/0013-lod-level-selection-demand-driven-load.md` (residency rule superseded); new `docs/decisions/0014-gggs-viewport-scoped-residency.md`; `.agents/README.md` — add the residency budget to the GGGS-layer notes if that section names the load model.
+- **Stale docs** (land in this PR):
+  `docs/decisions/0013-lod-level-selection-demand-driven-load.md` (four
+  passages); new `docs/decisions/0014-gggs-viewport-scoped-residency.md`.
+  `.agents/README.md` was checked — its GGGS-layer notes do not restate the
+  residency rule, so no edit is owed there.
 - **Agent-instruction candidates** (proposals only): none new — the reusable
   lesson ("a viewport-filtered *loader* is not a residency bound") belongs in
-  ADR-0014, which is repo-tracked and discoverable.
+  `camp-ADR-0014`, which is repo-tracked and discoverable.
 
 ## Open Questions
 
-- Confirm the cap defaults (`kMultiplier = 3`, `kMinCap = 32`, `kMaxCap = 64`
-  ≈ 450 MiB worst case) and the settings key `GggsTileLayers/max_resident_tiles`.
-- Confirm the degrade lever (step 6) belongs in this PR rather than as a
-  follow-up — it is the part most likely to oscillate in the field.
-- Confirm the `deriveViewportClip()` `widget` parameter (touching two other
-  layers' call sites) is acceptable scope here, versus a separate camp#150 PR.
+All three of the `b70311f` plan's open questions are answered by the operator
+decisions above (byte budget + settings key; τ lever deferred to camp#197;
+`deriveViewportClip()` unchanged). None remain open.
 
 ## Estimated Scope
 
-Single PR, ~5 atomic commits: (1) `TileResidency` + its test, (2)
-`deriveViewportClip` painting-view recovery + call sites, (3) `releaseTile()`
-extraction, (4) budget/eviction/hysteresis + test, (5) degrade lever + ADRs.
+Single PR, ~6 atomic commits: (1) plan revision, (2) `TileResidency` + its test,
+(3) `releaseTiles()` + `updateStatus()` extraction, (4) budget/eviction +
+tests, (5) ADR-0014 + ADR-0013 amendments, (6) progress entry.

--- a/.agent/work-plans/issue-195/plan.md
+++ b/.agent/work-plans/issue-195/plan.md
@@ -53,7 +53,8 @@ one.
 2. **The cap is floored at the protected (current-frame) set.** A ceiling that
    can fall below the working set is D4's "thrashes by construction" (review
    finding 6). The floor is paired with a **non-silent over-budget status**, so
-   D4's "never fail silently" holds without the degrade lever.
+   camp#195's "Report the degraded state; never fail silently" holds without
+   the degrade lever.
 3. **The `pressure_bias_` / degrade-under-pressure lever is deferred entirely**
    to **camp#197** (review finding 9: as specified it oscillates with a period
    equal to its cool-down). camp#155/#156 are named there as the measured-pressure
@@ -197,7 +198,7 @@ Governed by `uma-ADR-0013` D4.
 | Test | Asserts |
 |---|---|
 | `test/test_tile_residency.cpp` (new, pure) | `beginFrame()`/`protect()`/`candidates()` invariants: a protected index never appears in `candidates()`; re-protect within a frame is idempotent; `beginFrame()` returns the whole protected partition to the candidates; `sync()` admits tiles appended by `rescan()` |
-| `test/test_gggs_eviction.cpp` (new, headless, GL-free) | Synthetic single-level strip walked far wider than the cap: resident count stays ≤ cap while visited count grows (the `test_map_tiles_eviction.cpp` / `test_tile_eviction_rss.cpp` bounded-count shape); no tile intersecting the current `load_viewport_` is ever evicted; pan-back reloads a dropped tile (`pixelsLoadedCount()`); a ladder's coarsest level survives a pan that evicts the fine level, and the exemption is bounded; a `loadFailed()`-covering finer tile in view is retained; over-budget (working set alone above the byte target) floors the cap and reports a non-empty status rather than evicting the visible set; `max_resident_bytes = 0` reproduces pre-#195 residency |
+| `test/test_gggs_eviction.cpp` (new, headless, GL-free) | Synthetic single-level strip walked far wider than the cap: resident count stays ≤ cap while visited count grows (the `test_map_tiles_eviction.cpp` / `test_tile_eviction_rss.cpp` bounded-count shape); no tile intersecting the current `load_viewport_` is ever evicted; pan-back reloads a dropped tile; a ladder's coarsest level survives a pan that evicts the fine level; a `loadFailed()`-covering finer tile in view is retained; over-budget (working set alone above the byte target) floors the cap and reports a non-empty status rather than evicting the visible set; `max_resident_bytes = 0` reproduces pre-#195 residency. **Added after the local review**: the coarsest exemption is bounded *by the cap* (an exemption that can outgrow the eviction target makes the victim loop unable to reach it); the zoom-out backdrop under the viewport is protected; the released-coverage report clears on `rescan()`; and the **deferred** path — protect-and-schedule, then `processEvents()` — converges, covering the debounce and the queued hop rather than only the synchronous test shortcut |
 | `test/test_gggs_elevation.cpp` (extend — review finding 14) | `getElevation()` over an **evicted** (panned-away) area returns NaN while the in-viewport readout still answers — the consequence the plan's own table names |
 
 Headless coverage is the CPU half of the release only: with no GL context
@@ -209,6 +210,43 @@ The A→B→A ping-pong assertion from the original plan is **withdrawn** (revie
 finding 12): with a cap below `|A ∪ B|` ping-pong is guaranteed, so the
 assertion was either unachievable or vacuous. The reload behaviour is covered by
 the pan-back assertion instead, at a cap that admits the working set.
+
+## Corrections from the local review (pre-push)
+
+The `/review-code` round on the implementation found seven issues that changed
+the landed design; recorded here so the plan matches what shipped:
+
+1. **Protection is the loader predicate *plus* the in-view resident backdrop.**
+   `itemsIntersecting()` draws the whole resident set with no level filter, so
+   during a zoom-out the in-view tiles *finer* than the selection are the entire
+   visible picture — and they cannot reload. Protecting only the loader's set
+   would have let the budget undo camp#103/#194's no-blank-frame guarantee.
+2. **The coarsest exemption is bounded by the cap** (`min(64, cap / 4)`), not by
+   a flat 64: at the 512 MiB / 960×960 default the flat cap (64) exceeds the
+   eviction target (~57), and since exempt tiles still count toward residency
+   the victim loop could never reach the target — it would shed every ordinary
+   candidate every pass.
+3. **`tilesReady()` drains a pending eviction.** The timer re-arm alone is a
+   blind resample: during a sustained pan the loader-idle window is about one
+   event-loop turn, so a 100 ms retry lands in it only by luck. `tilesReady()`
+   is the deterministic rendezvous — GUI thread, right after the worker's join,
+   before any `paint()` can re-kick.
+4. **A refused GL release is reported.** `RasterGlRenderer` latches a
+   `makeCurrent()` failure without destroying the context, so "release nothing"
+   can be permanent and the budget would silently cease to exist.
+5. **The released-hole-coverage report is live, not latched** (cleared by
+   `rescan()`, shown only while a tile is still failed), and it names the
+   recovery actions that actually work — zoom in, or Rescan to repair the failed
+   tile. Rescan alone does not reload an evicted finer tile.
+6. **A malformed `max_resident_bytes` no longer disables the budget silently**
+   (`toULongLong()` returns 0 — the disable sentinel — for any unparsable
+   value); it warns and falls back to the default.
+7. Smaller: generation `0` (never seen) now classifies as *stale* rather than
+   "recent"; `budgetTiles() == 0` clears the published budget state;
+   `QMetaObject::invokeMethod` uses the compile-checked pointer-to-member
+   overload; `perTileResidentBytes()` is memoized off the paint path; and
+   "loading…" is a status *part* rather than an early return that would hide the
+   residency reports for the whole duration of a pan.
 
 ## Files to Change
 
@@ -242,7 +280,7 @@ Not changed (was in the `b70311f` plan): `viewport_clip.h`,
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| `uma-ADR-0013` D4 | Yes | Budget + structural current-frame protection + hybrid ordering implemented; the quality-relaxation lever is deferred to camp#197 with the cap floor + over-budget status standing in for "never fail silently" |
+| `uma-ADR-0013` D4 | Yes | Budget + structural current-frame protection + hybrid ordering implemented; the quality-relaxation lever is deferred to camp#197 with the cap floor + over-budget status standing in for the issue's "never fail silently" requirement |
 | `uma-ADR-0013` D5 | Yes | Ascending (zoom-out) backdrop retention is untouched; eviction never targets the current frame, so "the picture never gets worse" holds except across a true pan-away |
 | `uma-ADR-0013` D6 | No | No prefetch — the ADR requires latency measurement first |
 | `uma-ADR-0013` D8 | No | `getElevation()` is a display readout, not a safety query |

--- a/.agent/work-plans/issue-195/plan.md
+++ b/.agent/work-plans/issue-195/plan.md
@@ -1,0 +1,189 @@
+# Plan: GggsTileLayer — viewport-scoped retention and residency budget
+
+## Issue
+
+https://github.com/rolker/camp/issues/195
+
+## Context
+
+Verified against the code: `GggsTileLayer` has exactly one release path —
+`tilesReady()`'s loop that drops tiles at levels **finer** than
+`selected_level_` once the selection's visible set has settled
+(`gggs_tile_layer.cpp:641-716`). Nothing frees a tile because the view panned
+away. `loadTilesWorker()` is viewport-filtered on the way *in*
+(`:527-531`), so residency equals the union of every viewport ever visited.
+
+Per-tile cost is high because `GggsTile::texture()` deliberately **retains** the
+CPU buffer past the GPU upload (camp#180 cursor readout, `gggs_tile.cpp`): a
+painted 960×960 tile holds 3.52 MiB of `std::vector<float>` **plus** a 3.52 MiB
+R32F texture ≈ **7.03 MiB**. A hundred panned-over tiles is ~700 MiB — the same
+shape that OOM'd salmon in camp#153 and produced `camp-ADR-0010`.
+
+Two in-repo precedents bracket the fix:
+`SonarLiveCacheLayer::evictIfOverBudget()` (byte budget, farthest-from-centre
+with `last_access_seq` LRU fallback, `foldIntoParent()`, `kApexProtectLevel`,
+`kReloadHysteresisFactor`), and `MapTiles::evictIfNeeded()` (camp#98 — a
+**count** cap of `max(256, 4 × visible_count)`, deferred + debounced off
+`paint()`, protecting the live visible set).
+
+## Approach
+
+Governed by `uma-ADR-0013` D4. Design decisions, with the reasoning the issue
+asked to be checked rather than assumed:
+
+1. **No fold-to-parent — plain drop-and-re-read.** `SonarLiveCacheLayer` folds
+   because its tiles arrive once over ROS and must survive eviction; a GGGS
+   tile's source of truth is the file on disk. `resetPixels()` + `releaseGL()`
+   already is a complete release, and the existing demand-driven loader already
+   reloads on pan-back (`hasUnloadedVisibleTiles()` + the
+   moved-since-last-kick re-kick in `paint():996-1000`) — **the reload path is
+   free**. Building a CAMP-side pyramid would also manufacture a derived
+   product for `chart`/`reference`, which `uma-ADR-0010` D9 deliberately gives
+   no overviews.
+   *Cost:* an evicted area **blanks** until the reload lands, rather than
+   degrading. Bought back cheaply by the apex-protect analogue in step 3.
+
+2. **Structural current-frame protection** (`raster/tile_residency.h`, new,
+   header-only + GL-free). A `TileResidency` type owns two `std::list<size_t>`
+   partitions and an index of iterators: `beginFrame()` splices the whole
+   protected list into the evictable list (O(1)); `protect(i)` splices one
+   entry back (O(1)); `candidates()` returns **only** the evictable partition.
+   The eviction routine has no access to the protected partition, so "cannot
+   evict what this frame selected" is a property of the type, not an `if` a
+   future edit can drop — D4's requirement, via the sentinel-splice pattern,
+   without an intrusive list inside `tiles_`. Standalone-testable.
+
+3. **Count budget, adaptive cap.** Tiles are a fixed 960×960, so count is a
+   faithful RAM proxy (D4 blesses it; `cube_bathymetry`'s
+   `test_tile_eviction_rss.cpp` uses the same proxy). Cap =
+   `clamp(kMultiplier × protected_count, kMinCap, kMaxCap)` — MapTiles' form,
+   which makes "budget ≥ current-frame working set" true *by construction*
+   (D4). Proposed defaults `kMultiplier = 3`, `kMinCap = 32`,
+   `kMaxCap = 64` (≈450 MiB worst case at 7.03 MiB/tile), overridable via
+   `QSettings GggsTileLayers/max_resident_tiles` (`0` disables → pre-#195
+   behaviour, mirroring `LiveTileCache/max_vram_bytes`). Tiles at the
+   **coarsest available level** are never evicted (the `kApexProtectLevel`
+   analogue): on a nested `overviews/` ladder that guarantees a zoom-out floor;
+   on a single-level store it is a no-op and blanking stands (documented).
+
+4. **Hybrid ordering, camp#150-safe.** Order candidates farthest-first by
+   distance to the **nearest** recorded view centre, `last_visible_gen_` LRU
+   as the fallback (headless / no view). Do **not** inherit
+   `views().first()`: `paint()` receives the painting viewport as its `QWidget*
+   widget` argument, so `deriveViewportClip()` gains an optional `widget`
+   parameter and recovers the painting view via
+   `qobject_cast<QGraphicsView*>(widget->parentWidget())`, falling back to
+   `views().first()` exactly as today. Protection and view centres accumulate
+   per `paint()` call; eviction is deferred through a queued, debounced
+   `evictIfOverBudget()` (MapTiles pattern) so one pass sees the **union** of
+   every view that painted. Single-view behaviour is unchanged; camp#150 does
+   not invalidate the result.
+
+5. **Hysteresis and volume caps.** Once triggered, evict down to
+   `kEvictHysteresisFactor = 0.75 × cap` so the next frame cannot re-trigger
+   (the `kReloadHysteresisFactor` analogue). The loader's existing
+   moved-since-last-kick guard covers re-kick storms; add a per-kick bound so
+   `loadTilesWorker()` stops after `cap` tiles — its pass is already
+   ascending-by-level, so a truncated kick yields coarse coverage first.
+
+6. **Degrade, don't thrash; never silently.** When the protected set alone
+   exceeds `kMaxCap`, eviction cannot help — so relax the quality target:
+   `pressure_bias_` steps the `selectLodLevel()` pick `bias` entries coarser in
+   `available_levels_`, one-way ratchet with an N-frame cool-down before
+   relaxing, and `setStatus("(reduced detail — tile budget)")`. Where no
+   coarser level exists the bias is a no-op and the status says the layer is
+   over budget instead. This closes D4's loop rather than reporting a number
+   nobody acts on.
+
+7. **Preserve camp#194's hole-coverage rule.** `tilesReady()` retains finer
+   tiles that intersect a `loadFailed()` tile at a level ≤ the selection —
+   the only usable coverage over that hole. Those tiles must be `protect()`ed
+   in the new pass too, or the budget path silently undoes that guarantee.
+
+8. **Extract `releaseTile()`.** The `releaseGL()`/`resetPixels()` pairing plus
+   the `makeCurrent()`-or-skip dance in `tilesReady()` becomes one helper both
+   release paths call. Both keep the GUI-thread assert and the
+   `!future_watcher_.isRunning()` gate (they mutate tiles the worker iterates).
+
+## Test Strategy
+
+| Test | Asserts |
+|---|---|
+| `test/test_tile_residency.cpp` (new, pure) | `beginFrame()`/`protect()`/`candidates()` invariants: a protected index never appears in `candidates()`; splice is O(1)-shaped; re-protect is idempotent |
+| `test/test_gggs_eviction.cpp` (new, headless, GL-free) | Synthetic tile dir + `setLodForTest()` walked across a strip far wider than the cap: resident count stays ≤ cap while visited count grows (the `test_tile_eviction_rss.cpp` bounded-count shape); no tile in the current `load_viewport_` is ever evicted; coarsest level survives; pan-back reloads the dropped tile (`pixelsLoadedCount()`); evict↔reload ping-pong does not occur across repeated A→B→A pans; a `loadFailed()`-covering finer tile is retained; `max_resident_tiles = 0` reproduces pre-#195 residency |
+| `test/test_gggs_render.cpp` (extend) | Degrade path: with a cap below the visible set, the selection steps coarser and `status()` is non-empty |
+
+Precedents: `test_sonar_live_eviction.cpp`, `test_sonar_live_reload.cpp`.
+Register both new suites in `CMakeLists.txt` beside `test_gggs_rescan`.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/camp_map/raster/tile_residency.h` | **New.** Splice-partition residency helper (protected / evictable), header-only, GL- and Qt-light |
+| `src/camp_map/raster/gggs_tile_layer.h` | Budget + residency + pressure-bias members; `evictIfOverBudget()` slot, `releaseTile()`, test seams (`residentTileCount()`, `setResidentBudgetForTest()`) |
+| `src/camp_map/raster/gggs_tile_layer.cpp` | `paint()`: `beginFrame()`/`protect()`/record view centre/schedule eviction; pressure-bias LOD step; `evictIfOverBudget()`; `releaseTile()` extraction; loader per-kick cap; status reporting; ctor reads `QSettings` |
+| `src/camp_map/raster/viewport_clip.h` | Optional `QWidget* widget` → prefer the painting view, `views().first()` fallback |
+| `src/camp_map/raster/raster_layer.cpp`, `src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp` | Pass `widget` to `deriveViewportClip()` (call sites only) |
+| `test/test_tile_residency.cpp`, `test/test_gggs_eviction.cpp` | **New** (see Test Strategy) |
+| `test/test_gggs_render.cpp` | Degrade-path case |
+| `CMakeLists.txt` | Register the two new gtest suites |
+| `docs/decisions/0014-gggs-viewport-scoped-residency.md` | **New camp ADR** — the decision, cross-referencing `uma-ADR-0013` D4 and `camp-ADR-0010` |
+| `docs/decisions/0013-lod-level-selection-demand-driven-load.md` | Amend: "levels ≤ the selection are never released" is no longer true; point at ADR-0014 |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Test what breaks | The failure is an OOM after prolonged panning — asserted as a bounded resident count under a synthetic pan walk, the portable proxy `cube_bathymetry` already uses |
+| A change includes its consequences | ADR-0013's residency paragraph, `getElevation()` semantics, and the shared `deriveViewportClip()` signature are all in-plan, not follow-ups |
+| Capture decisions, not just implementations | New camp ADR-0014 records the fold-vs-drop and count-vs-bytes reasoning; without it the next agent re-derives it |
+| Only what's needed | No fold-to-parent, no ResourceMonitor dependency, no prefetch (`uma-ADR-0013` D6 explicitly wants measurement first) |
+| Improve incrementally | A fixed sane default now; the measured budget arrives via #155/#156 through the same `QSettings` seam |
+| Enforcement over documentation | Current-frame protection is enforced by `TileResidency`'s type boundary, not by a comment |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| `uma-ADR-0013` D4 | Yes | Budget + structural current-frame protection + hybrid ordering + degrade-not-thrash, all implemented; count units explicitly blessed for fixed 960×960 tiles |
+| `uma-ADR-0013` D5 | Yes | Ascending (zoom-out) backdrop retention is untouched; eviction never targets the current frame, so "the picture never gets worse" holds except across a true pan-away |
+| `uma-ADR-0013` D6 | No | No prefetch — the ADR requires latency measurement first |
+| `uma-ADR-0013` D8 | No | `getElevation()` is a display readout, not a safety query; `shallowestReliable()` is not in this layer |
+| `uma-ADR-0010` D9 | Yes (respected) | No CAMP-side pyramid is manufactured for `chart`/`reference`; the coarse-zoom blank stays a store-side question |
+| `camp-ADR-0010` | Yes | Same forces, different layer; divergences (drop vs fold, count vs bytes) are recorded in the new ADR-0014 |
+| `camp-ADR-0011` | Yes | `deriveViewportClip()` gains a parameter; the render convention itself is unchanged |
+| `camp-ADR-0013` | Yes | Amended — the "levels ≤ selection are never released" residency rule is superseded |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| The residency rule | `docs/decisions/0013-...md` + new ADR-0014 | Yes |
+| `deriveViewportClip()` signature | `RasterLayer`, `SonarLiveCacheLayer` call sites | Yes |
+| Tile residency | `getElevation()` returns NaN over evicted (off-screen) area | Yes — noted in ADR-0014; the cursor is always in-viewport, so protected |
+| Tile residency | Auto-range: deliberately **not** recomputed on evict (the fold is widening-only), so the colormap does not flicker as tiles come and go | Yes — stated in ADR-0014 |
+| Per-layer budget | N GGGS layers multiply the process footprint | No — process-wide accounting is #155/#156; ADR-0014 records the gap |
+| Per-frame overdraw (issue comment) | Composite-depth capping / occlusion skip | No — separate axis; the budget bounds it only indirectly. Follow-up issue |
+
+## Documentation & Instruction Impact
+
+- **Stale docs** (must land in this PR): `docs/decisions/0013-lod-level-selection-demand-driven-load.md` (residency rule superseded); new `docs/decisions/0014-gggs-viewport-scoped-residency.md`; `.agents/README.md` — add the residency budget to the GGGS-layer notes if that section names the load model.
+- **Agent-instruction candidates** (proposals only): none new — the reusable
+  lesson ("a viewport-filtered *loader* is not a residency bound") belongs in
+  ADR-0014, which is repo-tracked and discoverable.
+
+## Open Questions
+
+- Confirm the cap defaults (`kMultiplier = 3`, `kMinCap = 32`, `kMaxCap = 64`
+  ≈ 450 MiB worst case) and the settings key `GggsTileLayers/max_resident_tiles`.
+- Confirm the degrade lever (step 6) belongs in this PR rather than as a
+  follow-up — it is the part most likely to oscillate in the field.
+- Confirm the `deriveViewportClip()` `widget` parameter (touching two other
+  layers' call sites) is acceptable scope here, versus a separate camp#150 PR.
+
+## Estimated Scope
+
+Single PR, ~5 atomic commits: (1) `TileResidency` + its test, (2)
+`deriveViewportClip` painting-view recovery + call sites, (3) `releaseTile()`
+extraction, (4) budget/eviction/hysteresis + test, (5) degrade lever + ADRs.

--- a/.agent/work-plans/issue-195/progress.md
+++ b/.agent/work-plans/issue-195/progress.md
@@ -117,3 +117,48 @@ and 10 (cap defaults — re-derive from a byte target).
 
 ### Clean
 Static analysis (cppcheck) reported nothing on the changed lines. Both adversarial passes independently cleared the worker/GUI-thread ordering contract, the destruction-with-pending-invocation path, re-entrancy, the repaint loop, and `TileResidency` itself (epoch arithmetic, iterator stability, the append-only precondition). Plan drift: none — every planned file changed, nothing outside the plan, and all seven plan-review must-fixes verified present in code.
+
+## Implementation
+**Status**: complete
+**When**: 2026-08-21 16:05 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-195 at `74149dc` (not pushed — no PR opened)
+**Plan**: `.agent/work-plans/issue-195/plan.md`, revised in `90b3d52` and kept in sync through `21751c2`
+**Build**: `./ui_ws/build.sh camp` clean | **Tests**: `./ui_ws/test.sh camp` — 263 tests, 0 failures, 1 skipped (the pre-existing GL-gated skip)
+
+### What landed
+`GggsTileLayer` gets viewport-scoped retention with a residency budget —
+`uma-ADR-0013` D4 for this layer. Six atomic commits:
+
+1. `90b3d52` plan revision (the 14 plan-review findings + the four operator decisions)
+2. `4e025c0` `TileResidency` — the splice-partition that makes current-frame protection structural, plus its unit test
+3. `d2ca9b6` extract `releaseTiles()` and unify every status write into `updateStatus()`
+4. `98e1981` the budget, protection, deferred eviction, hybrid ordering + `test_gggs_eviction.cpp` and the elevation-readout case
+5. `6b05355` `camp-ADR-0014`, and `camp-ADR-0013` amended in its four stale places
+6. `21751c2` the pre-push review's five must-fixes and twelve suggestions
+
+### Operator decisions, as implemented
+- **Budget**: `QSettings GggsTileLayers/max_resident_bytes`, 512 MiB default, `0` disables; the tile count is derived from the **observed** per-tile cost, not a hardcoded 960x960. The pandy-not-salmon rationale is recorded in `camp-ADR-0014` D1 and the plan.
+- **Cap floored at the protected set**, paired with a non-silent over-budget status.
+- **Degrade-under-pressure lever deferred** — filed as [camp#197](https://github.com/rolker/camp/issues/197) with the oscillation argument and camp#155 as the measured-pressure input.
+- **`deriveViewportClip()` untouched**; the eviction centre is `load_viewport_.center()`.
+
+### Follow-ups filed
+- [camp#197](https://github.com/rolker/camp/issues/197) — the D4 tau lever (quality relaxation under pressure)
+- [camp#198](https://github.com/rolker/camp/issues/198) — compositing overdraw / composite-depth cap, incl. the QA depth-1 opt-in. `camp-ADR-0013`'s two render-time pointers were re-routed here so neither points at a decided issue.
+
+### Deliberately not done
+- No fold-to-parent (tiles are file-backed; the demand-driven loader reloads on pan-back)
+- No per-kick loader volume cap (withdrawn — the kick set is already viewport-bounded and truncation would settle on a permanently incomplete picture)
+- The coverage half of the old camp#195 family (a region whose only native level is finer than the selection) is still open — a budget bounds what is kept, it does not decide to load finer data. Stated as such in `camp-ADR-0013` and in the code comments that used to point at camp#195.
+
+### Known gaps (recorded in `camp-ADR-0014`, not papered over)
+- Headless tests exercise only the CPU half of `releaseTiles()`; the GL-texture half — the larger part of the ~7 MiB per tile — has no automated coverage.
+- The budget is per layer; process-wide accounting is camp#155/#156.
+- `paint()` now pays two O(tiles) sweeps it previously short-circuited past on cached frames. Accepted, stated, and named as the first thing to profile if pan latency regresses.
+- A refused GL release is reported but not worked around; freeing the CPU half in that state would be safe but needs a renderer accessor that does not exist yet.
+
+### Next step
+Not pushed, per the dispatch. `git push -u origin feature/issue-195` and open a PR
+(`Closes #195`) when the operator is ready; `triage-reviews` follows.

--- a/.agent/work-plans/issue-195/progress.md
+++ b/.agent/work-plans/issue-195/progress.md
@@ -1,0 +1,46 @@
+---
+issue: 195
+---
+
+# Issue #195 — GggsTileLayer: no viewport-scoped retention or residency budget — panning accumulates tiles without bound (camp#153 precedent)
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-08-21 15:02 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-195/plan.md` at `b70311f`
+**Branch**: feature/issue-195 at `b70311f`
+**Phases**: single (one PR, ~5 atomic commits)
+
+### Design decisions taken (host constraints evaluated, not inherited)
+- **Fold-to-parent rejected.** GGGS tiles are file-backed; `resetPixels()` +
+  `releaseGL()` is already a complete release and the existing demand-driven
+  loader re-reads on pan-back, so the reload path is free. `SonarLiveCacheLayer`
+  folds only because its data arrives once over ROS. A CAMP-side pyramid would
+  also manufacture a derived product `uma-ADR-0010` D9 deliberately withholds
+  from `chart`/`reference`. Cost — an evicted area blanks rather than degrades —
+  is bought back by never evicting the coarsest available level.
+- **Count budget**, adaptive cap `clamp(3 × protected_count, 32, 64)` (MapTiles /
+  camp#98 form), which makes "budget ≥ current-frame set" true by construction.
+  Fixed 960×960 tiles cost ~7.03 MiB each (CPU buffer retained past GPU upload
+  per camp#180), so 64 ≈ 450 MiB.
+- **`views().first()` designed around, not inherited.** `paint()` already
+  receives the painting viewport widget; `deriveViewportClip()` gains an optional
+  `widget` param and recovers the painting view, falling back to `views().first()`.
+  Protection accumulates per `paint()`; eviction is deferred + debounced so one
+  pass sees the union of all views (camp#150-safe).
+- **Structural protection** via a new `TileResidency` splice-partition type
+  (two `std::list`s, O(1) per frame/touch) whose eviction API cannot reach the
+  protected partition — D4's sentinel-node guarantee without an intrusive list.
+- **Hysteresis**: evict to `0.75 × cap`, plus a per-kick loader volume cap.
+- **Degrade lever** included: `pressure_bias_` steps the LOD selection coarser
+  when the protected set alone exceeds the cap, with a cool-down and a visible
+  status; a no-op with a visible status where no coarser level exists.
+- **camp#194 hole-coverage rule preserved**: finer tiles covering a
+  `loadFailed()` tile are protected from budget eviction too.
+
+### Open questions
+- [ ] Confirm cap defaults (`kMultiplier=3`, `kMinCap=32`, `kMaxCap=64` ≈ 450 MiB) and the `GggsTileLayers/max_resident_tiles` settings key.
+- [ ] Confirm the degrade lever belongs in this PR rather than a follow-up — it is the part most likely to oscillate in the field.
+- [ ] Confirm the `deriveViewportClip()` `widget` parameter (touching `RasterLayer` and `SonarLiveCacheLayer` call sites) is acceptable scope here versus a separate camp#150 PR.

--- a/.agent/work-plans/issue-195/progress.md
+++ b/.agent/work-plans/issue-195/progress.md
@@ -44,3 +44,37 @@ issue: 195
 - [ ] Confirm cap defaults (`kMultiplier=3`, `kMinCap=32`, `kMaxCap=64` ≈ 450 MiB) and the `GggsTileLayers/max_resident_tiles` settings key.
 - [ ] Confirm the degrade lever belongs in this PR rather than a follow-up — it is the part most likely to oscillate in the field.
 - [ ] Confirm the `deriveViewportClip()` `widget` parameter (touching `RasterLayer` and `SonarLiveCacheLayer` call sites) is acceptable scope here versus a separate camp#150 PR.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-08-21 15:04 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-195/plan.md` at `b70311f`
+**PR**: PR-less (`--issue` mode; branch `feature/issue-195`)
+**Verdict**: changes-requested
+
+Design direction is sound and well-grounded in the code — the D4 mapping,
+the `TileResidency` splice-partition, hysteresis, and the fold-to-parent
+rejection all hold up. Seven must-fix items are implementation traps or D4
+gaps that are cheap now and silent later; the rest are scoping/robustness
+suggestions. Answers to the plan's three Open Questions are in findings
+6 (degrade lever — defer), 8 (`deriveViewportClip` — drop from this PR),
+and 10 (cap defaults — re-derive from a byte target).
+
+### Findings
+- [ ] (must-fix) Protection must be driven by the loader predicate (tiles ∩ `clip.scene` at level ≤ selection), NOT the `itemsIntersecting()` draw list — `cached_image_` short-circuits the collect on static frames, so a draw-list-sourced `protect()` would protect nothing and the live visible set becomes evictable — `plan.md:78`
+- [ ] (must-fix) `beginFrame()`/`protect()` must sit immediately after `deriveViewportClip()` and before `paint()`'s early returns (`tiles_.empty()`, `data_min_ > data_max_`, `gggs_tile_layer.cpp:942,1002`); an early return between them leaves the whole set spliced into the evictable partition — `plan.md:78`
+- [ ] (must-fix) Eviction gated on `!future_watcher_.isRunning()` will almost never fire during a continuous pan (every pan step re-kicks the loader) — the exact scenario the budget exists for. The debounce must re-arm when it finds the worker busy (or abort+join like `loadTiles()` does) — `plan.md:106`
+- [ ] (must-fix) camp#194 interaction: an evicted hole-covering finer tile can NEVER reload — `loadTilesWorker()` skips `tile->level() > level` (`gggs_tile_layer.cpp:527`), so the "reload path is free" premise fails for exactly that class. Either protect hole-coverers regardless of viewport, or extend the loader ceiling to admit finer tiles over a failed footprint; state which. Factor the hole predicate into one helper shared by `tilesReady()` and the budget pass so the two rules cannot drift — `plan.md:98`
+- [ ] (must-fix) `tilesReady()` unconditionally rewrites `setStatus()` (`:732-739`, clears to `""` when no failures), so any degrade / over-budget status set from `paint()` is silently wiped. Unify all status writes into one composer — `plan.md:94`
+- [ ] (must-fix) `clamp(3 × protected, 32, 64)` does not make "budget ≥ current-frame working set" true by construction: `kMaxCap` is a hard ceiling, so `protected > 64` yields budget < working set — D4's "thrashes by construction". Either floor the cap at `protected` (+ headroom), or make the τ lever mandatory; the plan must say which — `plan.md:61-63`
+- [ ] (must-fix) Per-kick loader cap creates a settled-but-incomplete picture: the re-kick guard needs `selected_level_`/`load_viewport_` to change (`:996-999`), so a truncated kick with the operator stationary never completes and `tilesReady()` clears the status to `""`. Drop the per-kick cap (the kick set is already viewport-bounded = the protected set) or force a re-kick plus a visible status on truncation — `plan.md:85-87`
+- [ ] (suggestion) Open Question 3 — drop the `deriveViewportClip()` `widget` parameter from this PR. The eviction metric needs a view centre, and `clip.scene.center()` is already computed per `paint()`; with CAMP's single MapView it is exactly the painting view's centre. Leave the painting-view recovery to camp#150 — `plan.md:71-77,126-127`
+- [ ] (suggestion) Open Question 2 — defer the `pressure_bias_` lever to a follow-up issue. As specified it oscillates deterministically: trigger `protected > kMaxCap` → degrade → `protected' ≈ protected/4` → cool-down relaxes → re-trigger, period = cool-down. A stable relax needs the *predicted* protected count at the finer level (countable from `tiles_ ∩ clip`) under a hysteresis factor, not a frame cool-down. Deferring is safe because the unbounded-pan accumulation (the actual OOM) is fully fixed by the budget; the lever only addresses "one viewport is itself over budget". Pair the deferral with finding 6's cap floor plus a non-silent over-budget status so D4's "never fail silently" still holds in this PR — `plan.md:89-96`
+- [ ] (suggestion) Open Question 1 — re-derive the cap from a byte target. `width_`/`height_` come from GDAL (`gggs_tile.cpp:70-71,96-97`); 960×960 is a store convention, not an invariant. Convert a byte budget (`GggsTileLayers/max_resident_bytes`) to a count using observed tile bytes — keeps D4's blessed count mechanics, removes the fixed-size assumption, and makes the number comparable to the co-resident `LiveTileCache/max_vram_bytes` (512 MiB default). 450 MiB on top of that, on the station camp#153 already OOM'd, needs an explicit headroom argument — `plan.md:61-66,178-179`
+- [ ] (suggestion) Bound the coarsest-level exemption (its resident set grows with area panned) and note `available_levels_` is dynamic across `rescan()`. Also state and test the real degrade-not-blank mechanism: because every level ≤ selection loads, a panned-away area retains coarse coverage — assert a non-empty render over an evicted area, not merely "coarsest level survives" — `plan.md:66-67,113`
+- [ ] (suggestion) The A→B→A ping-pong assertion is unachievable or vacuous as written — with cap < |A ∪ B| and distance-primary ordering, ping-pong is guaranteed. Specify the cap relative to |A ∪ B| and assert a bounded reload count. Relatedly, distance-primary ordering is what D4 criticises ("distance-only discards history along a path being traversed"); add a staleness term or record why not — `plan.md:78-80,113`
+- [ ] (suggestion) The `camp-ADR-0013` amendment is broader than one sentence: the Residency bullet (`:81-84`), the Release bullet (`:132-138`), the Residency-bound/camp#195 paragraph (`:147-165`), and the camp#195 pointers at `:97` and `:131` all go stale. The overdraw mitigation the ADR routes to camp#195 must be re-routed to the new follow-up issue, or the ADR will point at a closed issue — `plan.md:132`
+- [ ] (suggestion) `camp-ADR-0014` is warranted (not overkill): a new residency policy with deliberate divergences from `camp-ADR-0010` (drop vs fold, count vs bytes) plus the repo-local D4 compliance record. Record there that τ-raising weakens `camp-ADR-0013`'s "`getElevation()` samples finest-covering-tile-first" mitigation (`:124-126`) — `plan.md:131`
+- [ ] (suggestion) File targeting: add `test/test_gggs_elevation.cpp` (readout over an evicted area) — the consequences table names `getElevation()` but no test covers it. Cite the in-repo `test/test_map_tiles_eviction.cpp` as the count-budget precedent alongside cube's `test_tile_eviction_rss.cpp`. Note that headless tests exercise only the CPU half of `releaseTile()` — the GL texture free (the larger half of the 7.03 MiB) stays uncovered — `plan.md:113,119-131`

--- a/.agent/work-plans/issue-195/progress.md
+++ b/.agent/work-plans/issue-195/progress.md
@@ -78,3 +78,42 @@ and 10 (cap defaults — re-derive from a byte target).
 - [ ] (suggestion) The `camp-ADR-0013` amendment is broader than one sentence: the Residency bullet (`:81-84`), the Release bullet (`:132-138`), the Residency-bound/camp#195 paragraph (`:147-165`), and the camp#195 pointers at `:97` and `:131` all go stale. The overdraw mitigation the ADR routes to camp#195 must be re-routed to the new follow-up issue, or the ADR will point at a closed issue — `plan.md:132`
 - [ ] (suggestion) `camp-ADR-0014` is warranted (not overkill): a new residency policy with deliberate divergences from `camp-ADR-0010` (drop vs fold, count vs bytes) plus the repo-local D4 compliance record. Record there that τ-raising weakens `camp-ADR-0013`'s "`getElevation()` samples finest-covering-tile-first" mitigation (`:124-126`) — `plan.md:131`
 - [ ] (suggestion) File targeting: add `test/test_gggs_elevation.cpp` (readout over an evicted area) — the consequences table names `getElevation()` but no test covers it. Cite the in-repo `test/test_map_tiles_eviction.cpp` as the count-budget precedent alongside cube's `test_tile_eviction_rss.cpp`. Note that headless tests exercise only the CPU half of `releaseTile()` — the GL texture free (the larger half of the 7.03 MiB) stays uncovered — `plan.md:113,119-131`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-08-21 16:00 -04:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested (all findings addressed in `21751c2`)
+
+**Branch**: feature/issue-195 at `6b05355` (reviewed) → `21751c2` (fixed)
+**Mode**: pre-push
+**Depth**: Deep (reason: new ADR + ~2000-line diff across a render hot path)
+**Specialists**: static analysis (cppcheck); Claude Adversarial Lens A (logic) + Lens B (systemic/safety); governance + plan drift. Copilot off (default). Local model off (`--no-local`).
+**Must-fix**: 5 | **Suggestions**: 12
+**Round**: 1 | **Ship**: recommended — every must-fix is fixed and re-tested; 263 tests green
+
+### Findings
+- [x] (must-fix) Zoom-out backdrop drawn but not protected: in-view tiles finer than the selection are the whole visible picture mid-transition and cannot reload, so the budget could undo camp#103/#194's no-blank-frame guarantee — `gggs_tile_layer.cpp:refreshProtection`
+- [x] (must-fix) Coarsest exemption (flat 64) can exceed the eviction target (~57 at the 512 MiB/960x960 default), so the victim loop can never reach it and sheds every ordinary candidate every pass — `gggs_tile_layer.cpp:evictIfOverBudget`
+- [x] (must-fix) Timer re-arm is a blind resample: the loader-idle window during a sustained pan is ~one event-loop turn, so the budget can be starved for seconds. `tilesReady()` now drains a pending pass — `gggs_tile_layer.cpp:tilesReady`
+- [x] (must-fix) A latched GL `makeCurrent()` failure permanently disables eviction with no report — now surfaced as "tile budget NOT enforced" — `gggs_tile_layer.cpp:evictIfOverBudget`
+- [x] (must-fix) `hole_coverage_released_` was a one-way latch surviving the recovery it advertised, and named Rescan alone (which does not reload an evicted finer tile) — `gggs_tile_layer.cpp:updateStatus`, `rescan`
+- [x] (suggestion) Malformed `GggsTileLayers/max_resident_bytes` parses to 0 = the disable sentinel, silently restoring pre-#195 behaviour — warn + fall back — `gggs_tile_layer.cpp` ctor
+- [x] (suggestion) Generation 0 (never seen) classified "recent" for the first 120 paints, inverting the staleness key — `gggs_tile_layer.cpp:evictIfOverBudget`
+- [x] (suggestion) `budgetTiles() == 0` early return left `over_budget_` stale — `gggs_tile_layer.cpp:evictIfOverBudget`
+- [x] (suggestion) String-based `QMetaObject::invokeMethod` — a rename would silently stop the budget; use the pointer-to-member overload — `gggs_tile_layer.cpp:scheduleEvictionIfNeeded`
+- [x] (suggestion) `perTileResidentBytes()` recomputed O(n) every frame — memoized against `tiles_.size()` — `gggs_tile_layer.cpp`
+- [x] (suggestion) `updateStatus()`'s `loading_` early return hid the residency reports for the whole duration of a pan — "loading..." is now a part — `gggs_tile_layer.cpp:updateStatus`
+- [x] (suggestion) Quotation "never fail silently" misattributed to `uma-ADR-0013` D4; it is camp#195's own ask (D4 says "degrades visibly and predictably rather than churning") — `gggs_tile_layer.cpp`, `0014-*.md`, `plan.md`
+- [x] (suggestion) ADR-0014's null-viewport "pure LRU" claim, its stated per-frame cost, and its `uma-ADR-0010` D9 store-class claim were imprecise — corrected against the code and D9's text
+- [x] (suggestion) `camp-ADR-0013`'s `getElevation()` "finest-covering-tile-first" fidelity mitigation is now residency-conditioned and was left unqualified — amended
+- [x] (suggestion) `camp-ADR-0010` had no back-reference to the sibling ADR-0014 — added
+- [x] (suggestion) `gggs_tile.h:resetPixels()` invariant still claimed `data_` is freed after upload; camp#180 retains it, and that retention is the basis of ADR-0014's 2x byte model — corrected
+- [x] (suggestion) Test gaps: the cap-relative exemption bound, the zoom-out backdrop, the rescan-clears-report path, and the entire deferred schedule→`processEvents` path were uncovered; `writeStrip()`'s in-helper fatal assertion could let an upper-bound assertion pass spuriously — four tests added, helper returns bool
+
+### Not accepted
+- Freeing the CPU half of a tile when GL release is refused (Lens B): correct in principle once the renderer's GL-failed flag is latched, but it depends on a renderer internal the layer cannot observe. Reported instead; exposing the flag is a follow-up, recorded in ADR-0014.
+- Skipping the per-frame protection sweep on unmoved frames: the sweep is what keeps the LRU generations honest. Cost is now stated accurately in ADR-0014 and named as the first thing to profile alongside camp#198.
+
+### Clean
+Static analysis (cppcheck) reported nothing on the changed lines. Both adversarial passes independently cleared the worker/GUI-thread ordering contract, the destruction-with-pending-invocation path, re-entrancy, the repaint loop, and `TileResidency` itself (epoch arithmetic, iterator stability, the append-only precondition). Plan drift: none — every planned file changed, nothing outside the plan, and all seven plan-review must-fixes verified present in code.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -894,6 +894,16 @@ if(BUILD_TESTING)
     ${GDAL_LIBRARY}
   )
 
+  # [camp#195 / uma-ADR-0013 D4] TileResidency — the splice partition that makes
+  # current-frame protection structural. Pure C++ (no Qt/GL/GDAL): header-only
+  # type, so nothing to link but gtest itself.
+  ament_add_gtest(test_tile_residency
+    test/test_tile_residency.cpp
+  )
+  target_include_directories(test_tile_residency PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp_map
+  )
+
   # [camp#121] Live tile cache (Part B): warm-load + patch-apply/dequantize
   # (SonarLiveTile, GDAL) and the downtime-gap reconcile + prune timestamp-gate
   # (the node-boundary catalog conversion + TileCatalogReconciler). Headless: no

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -894,6 +894,26 @@ if(BUILD_TESTING)
     ${GDAL_LIBRARY}
   )
 
+  # [camp#195 / uma-ADR-0013 D4] GggsTileLayer viewport-scoped retention: a
+  # synthetic tile strip panned far wider than the residency budget must keep the
+  # resident count bounded while the visited count grows, without ever evicting
+  # the current viewport's working set. Headless/GL-free, same link surface as
+  # test_gggs_rescan.
+  ament_add_gtest(test_gggs_eviction
+    test/test_gggs_eviction.cpp
+  )
+  target_include_directories(test_gggs_eviction PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp_map
+  )
+  target_link_libraries(test_gggs_eviction
+    camp_map
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
+  )
+
   # [camp#195 / uma-ADR-0013 D4] TileResidency — the splice partition that makes
   # current-frame protection structural. Pure C++ (no Qt/GL/GDAL): header-only
   # type, so nothing to link but gtest itself.

--- a/docs/decisions/0010-bounded-eviction-overview-pyramid.md
+++ b/docs/decisions/0010-bounded-eviction-overview-pyramid.md
@@ -8,6 +8,15 @@ Amended by camp#171/#172 (world-store LOD step 4): D3 reframed as *convergence* 
 the uma shared fold engine (no geometry change); D2 on-demand reload implemented; D6
 reload-hysteresis added. See the "Consequences" memory-math and migration notes.
 
+Cross-reference (camp#195, no change to this decision):
+[ADR-0014](0014-gggs-viewport-scoped-residency.md) gives `GggsTileLayer` its own
+residency budget. It is a **sibling**, not an extension — same forces, different
+data contract — and it records where the two policies deliberately diverge: a
+GGGS tile is file-backed, so it is dropped and re-read on pan-back instead of
+being folded into a parent, and its budget is expressed in bytes converted to a
+tile count from the observed tile size. Both decisions implement
+`uma-ADR-0013` D4.
+
 Implements camp issue #160 (supersedes #153, bounded eviction alone). Part of the
 #154 camp resource self-monitoring umbrella. Extends
 [ADR-0006](0006-live-tile-cache-persistence.md) (live tile cache persistence): it

--- a/docs/decisions/0013-lod-level-selection-demand-driven-load.md
+++ b/docs/decisions/0013-lod-level-selection-demand-driven-load.md
@@ -140,7 +140,11 @@ The amended model: `selected_level_` is a **max threshold (ceiling)**.
   compilation/fold than the tile that nominally covers it. Two mitigations
   keep it honest today: the depth-at-cursor readout (camp#180,
   `getElevation()`) always samples **finest-covering-tile-first** independent
-  of what is drawn, so inspection is unaffected; and the auto-range fold
+  of what is drawn, so inspection is unaffected — since camp#195 that means
+  the finest covering tile *that is resident*, which under the viewport-scoped
+  budget ([ADR-0014](0014-gggs-viewport-scoped-residency.md)) is still the
+  finest one wherever the cursor is, because viewport tiles are structurally
+  protected from eviction; and the auto-range fold
   spans every composited level, so the coarse fill is colour-mapped on the
   same scale as the fine data rather than against a foreign range. If a QA
   workflow ever needs "show me only this level's own data", that is a

--- a/docs/decisions/0013-lod-level-selection-demand-driven-load.md
+++ b/docs/decisions/0013-lod-level-selection-demand-driven-load.md
@@ -6,6 +6,10 @@ Accepted (camp#103, the LOD half; the visible-region half is ADR-0011).
 Amended by camp#194: the selection is a **ceiling** (multi-level
 compositing), not an equality filter — see "Multi-level compositing",
 "Extent semantics", and "Auto-range across levels" below.
+Amended by camp#195: residency is **budgeted and viewport-scoped** —
+"levels ≤ the selection stay resident permanently" no longer holds. The
+residency policy itself moved to [ADR-0014](0014-gggs-viewport-scoped-residency.md);
+this ADR keeps the LOD selection and the demand-driven load.
 
 ## Context
 
@@ -79,9 +83,17 @@ zoom (camp#194).
 The amended model: `selected_level_` is a **max threshold (ceiling)**.
 
 - **Residency**: every available level ≤ the selection loads
-  (viewport-bounded) and stays resident **permanently** — it is part of the
-  composited picture, not a transient backdrop. Levels > the selection never
-  load.
+  (viewport-bounded) and is part of the composited picture, not a transient
+  backdrop. Levels > the selection never load.
+  *Amended by camp#195*: such a tile stays resident **while the viewport
+  selects it** — not permanently. A tile the view has panned away from is
+  released once the layer exceeds its residency budget, and re-read on
+  pan-back by this ADR's own demand-driven loader. The permanence claim was
+  never a decision, only the absence of any viewport-driven release path; it
+  is what made residency the union of every viewport ever visited. The budget,
+  the current-frame protection that makes "never evict what this frame
+  selected" structural, and the eviction ordering are
+  [ADR-0014](0014-gggs-viewport-scoped-residency.md).
 - **Render**: `itemsIntersecting()` draws the whole resident set in one
   ascending pass — coarse→fine painter's order, **no render-time level
   filter**. Fine overdraws coarse where both exist; coarse fills where fine
@@ -94,7 +106,12 @@ The amended model: `selected_level_` is a **max threshold (ceiling)**.
   finer-than-needed data to fill coarse zooms would reintroduce the
   store-bounded open this ADR exists to avoid; if it matters in practice
   (e.g. a chart ladder whose finest-only regions vanish at overview zooms),
-  the residency/coverage follow-up family is camp#195.
+  it needs its own issue. camp#195 settled the **residency** half of that
+  follow-up family ([ADR-0014](0014-gggs-viewport-scoped-residency.md)) and
+  deliberately did **not** touch this coverage half — a budget bounds what is
+  kept, it does not decide to load finer-than-selection data. The coverage
+  half is at least as likely to be answered store-side, by giving those
+  regions coarse coverage (uma-ADR-0010 D9), as display-side.
 - **Level-switch transitions** (the camp#103 field-verified no-blank-frame
   guarantee, both directions). Scope of "no blank frame": it is a guarantee
   about the *transition*, not about coverage — a region that has coverage at
@@ -128,7 +145,9 @@ The amended model: `selected_level_` is a **max threshold (ceiling)**.
   same scale as the fine data rather than against a foreign range. If a QA
   workflow ever needs "show me only this level's own data", that is a
   render-time opt-in (a composite-depth cap of 1), not a change to this
-  decision — it rides camp#195 alongside the overdraw mitigation.
+  decision — it rides **camp#198** alongside the overdraw mitigation.
+  (Re-routed from camp#195 by camp#195 itself: that issue became a residency
+  budget, which is a memory decision and touches nothing render-time.)
 - **Release**: `tilesReady()` releases only tiles at levels **finer than the
   selection** (CPU `resetPixels()` **paired with** GL `releaseGL()` — a
   CPU-only clear leaves a stale texture shadowing any re-load), and only once
@@ -136,6 +155,15 @@ The amended model: `selected_level_` is a **max threshold (ceiling)**.
   (`hasUnloadedVisibleTiles()`, which tests the same ≤-selection ceiling)
   with no worker running. That load-before-release gate is what carries the
   zoom-out no-blank guarantee.
+  *Amended by camp#195*: this is no longer the **only** release path. It
+  remains the level-switch release — the one that ends a zoom-out transition —
+  but a second, orthogonal path now releases **off-viewport** tiles at any
+  level when the layer exceeds its residency budget
+  ([ADR-0014](0014-gggs-viewport-scoped-residency.md)). The two share one
+  helper for the actual `resetPixels()`/`releaseGL()` pairing and one predicate
+  for camp#194's hole-coverage retention, so the rules cannot drift. This
+  release is keyed on the **viewport**, not the level: what the current frame
+  selected is structurally protected from it, at every level.
 
 A rapid multi-level zoom/pan sweep can transiently stack several
 finer-than-selection levels (each load aborted before the release condition
@@ -144,25 +172,42 @@ completed load — self-healing, and still far below the pre-#103 eager
 whole-store residency. If that transient ever matters in practice, a
 release-on-abort pass is the follow-up shape.
 
-**Residency bound (ADR-0010 cross-reference, camp#195)**: `GggsTileLayer` has
-no residency/eviction budget — camp ADR-0010 governs `SonarLiveCacheLayer`, a
-different class. Under compositing, multiple levels stay resident
-simultaneously at steady state, so the pre-existing unbounded-within-level
-growth multiplies across every level ≤ the selection. For the `chart` store
-this is genuinely bounded (a fixed native ladder, 54 tiles); for a derived
-`overviews/` pyramid the overhead is a bounded geometric series (~33% over
-the fine level alone). The classes to watch are **`reference`** (mixed-level
-imports: S-102 + fine imported grids vs coarse legacy priors) and
-**`draft`/`processed`** (uma ADR-0010 D9 generates overview pyramids over
-potentially large fine-level survey coverage) — `chart` is the one member of
-this family that is *not* the risk. Given the camp#153 `SonarLiveCacheLayer`
-OOM precedent for this accumulation shape, the eviction-bound follow-up is
-tracked as **camp#195**. Compositing also multiplies per-frame **overdraw**,
-not just memory: on a deep nested pyramid every resident level contributes a
-near-full-viewport quad at fine zoom (up to ~14 stacked quads for a full L13
-pyramid — a fill-rate cost that software-GL backends pay too). Mitigation
-(skip fully-covered coarse tiles, or a composite-depth cap) rides camp#195
-if pan latency regresses.
+**Residency bound (`camp-ADR-0010` / `camp-ADR-0014` cross-reference,
+camp#195 — RESOLVED)**: this paragraph originally recorded that
+`GggsTileLayer` had *no* residency/eviction budget, and reasoned about which
+store classes the unbounded growth would hurt first. That gap is now closed by
+[`camp-ADR-0014`](0014-gggs-viewport-scoped-residency.md) (camp#195): the layer
+has a byte budget with structural current-frame protection and viewport-scoped
+eviction, so residency is bounded by the viewport rather than by the union of
+every viewport ever visited.
+
+Two corrections to the original framing, both established while implementing
+camp#195 and worth keeping because they are easy to re-derive wrongly:
+
+- The accumulation was **never** a consequence of compositing. Before camp#194
+  the release gate was `level == selection → skip`, so the selected level was
+  already exempt from the only release path that existed; a single large
+  `draft`/`processed` layer had the full hazard on `jazzy`. camp#194's `≤`
+  gate widened the exemption to the coarser levels — a *bounded* addition
+  (~33% for a nested `overviews/` pyramid; 54 tiles total for the ENC chart
+  store) — it did not create the problem.
+- The store-class risk ranking still holds as written (`reference` and
+  `draft`/`processed` accumulate, `chart` is bounded by its fixed native
+  ladder), but it now describes how quickly a layer reaches its budget, not
+  whether it is bounded at all.
+
+`camp-ADR-0010` continues to govern `SonarLiveCacheLayer`, a different class
+with different forces; `camp-ADR-0014` records where the two policies
+deliberately diverge (drop-and-re-read vs fold-to-parent).
+
+Compositing also multiplies per-frame **overdraw**, not just memory: on a deep
+nested pyramid every resident level contributes a near-full-viewport quad at
+fine zoom (up to ~14 stacked quads for a full L13 pyramid — a fill-rate cost
+that software-GL backends pay too). The residency budget bounds this only
+indirectly, and it protects the current frame's whole working set — which is
+exactly the stack being overdrawn. Mitigation (skip fully-covered coarse tiles,
+or a composite-depth cap) therefore rides **camp#198**, not camp#195, if pan
+latency regresses.
 
 **Headless / no-selection defaults**: `selected_level_ == -1` disables the
 level ceiling everywhere (worker, range fold, release) and a null viewport

--- a/docs/decisions/0014-gggs-viewport-scoped-residency.md
+++ b/docs/decisions/0014-gggs-viewport-scoped-residency.md
@@ -14,6 +14,15 @@ here, and its "the only release path is the level switch" statement gains a
 second, viewport-keyed path. It does **not** change ADR-0013's LOD selection or
 its demand-driven load — this ADR governs only what is *kept*.
 
+*Amendment form*: the ADR-0013 passages this change touches are annotated in
+place (`*Amended by camp#195*`), which is the addendum shape the workspace's
+own ADR-0012 asks for. One passage — its "Residency bound" paragraph — was
+instead **rewritten**, because its central claim ("`GggsTileLayer` has no
+residency/eviction budget") became false wholesale rather than partially; the
+rewrite states what the paragraph originally recorded before correcting it, and
+camp's own ADR-0010 has the precedent (camp#171/#172 added a whole decision to
+an accepted ADR). Noted here so the divergence is recorded rather than assumed.
+
 Sibling, not parent: [ADR-0010](0010-bounded-eviction-overview-pyramid.md)
 answers the same forces for `SonarLiveCacheLayer`. The two layers face different
 data contracts, and where the answers diverge this ADR records why.
@@ -89,14 +98,31 @@ accessor an eviction pass gets — exposes the evictable partition alone. There 
 no accessor that yields a protected index as a candidate.
 
 The protected set is derived from **the loader's predicate**, not from the draw
-list: tiles intersecting the load viewport at a level ≤ the selection, plus the
-hole coverers of D5. This is not a stylistic choice. `cached_image_`
-short-circuits `itemsIntersecting()` on a static frame, so on exactly the frames
-an eviction is most likely to run, a draw-list-sourced protection would protect
-**nothing** and the live visible set would be evictable. Not-yet-loaded tiles are
-counted too: they are part of the working set the cap must accommodate.
-Terminally-failed tiles are not — they never become resident, so counting them
-would inflate the floor with memory nothing will ever occupy.
+list: tiles intersecting the load viewport at a level ≤ the selection. This is
+not a stylistic choice. `cached_image_` short-circuits `itemsIntersecting()` on a
+static frame, so on exactly the frames an eviction is most likely to run, a
+draw-list-sourced protection would protect **nothing** and the live visible set
+would be evictable. Not-yet-loaded tiles are counted: they are part of the
+working set the cap must accommodate. Terminally-failed tiles are not — they
+never become resident, so counting them would inflate the floor with memory
+nothing will ever occupy.
+
+Two classes of in-view tile **finer** than the selection are protected on top of
+the loader's set. Both are drawn, and neither can reload if dropped
+(`loadTilesWorker()` skips `level > selection`), so for both the "eviction is
+free because the reload path exists" premise fails:
+
+- **an already-resident finer tile.** `itemsIntersecting()` draws the whole
+  resident set with no level filter, so during a **zoom-out** these tiles are
+  the entire visible picture until the coarser selection finishes loading —
+  camp#103/#194's field-verified no-blank-frame guarantee, which the budget
+  would otherwise quietly undo under pressure. Protecting them leaks nothing:
+  `tilesReady()`'s level-switch release still drops them at the moment the
+  guarantee ends.
+- **a camp#194 hole coverer** (D5).
+
+The loader predicate is still the right *base*, for the `cached_image_` reason
+above; these two are additions to it, not a return to the draw list.
 
 Two placement rules follow, and both are load-bearing:
 
@@ -132,8 +158,11 @@ cool-down. A stable relax needs the *predicted* protected count at the finer
 level under a hysteresis factor, not a timer. Deferring is safe because the
 unbounded-pan accumulation — the actual OOM, and the camp#153 precedent — is
 fully fixed by the budget alone; the lever only addresses the narrower case
-where a single viewport is itself over budget, and D4's "never fail silently"
-is satisfied meanwhile by the floor plus the reported state.
+where a single viewport is itself over budget. camp#195's own requirement —
+"Report the degraded state; never fail silently" — is met meanwhile by the cap
+floor plus the reported state. (D4 itself puts it as "the display degrades
+visibly and predictably rather than churning"; the crisper phrasing is the
+issue's, not the ADR's.)
 
 ### D4 — Drop and re-read, not fold-to-parent
 
@@ -146,8 +175,12 @@ re-kick). `resetPixels()` + `releaseGL()` is therefore a complete release, and
 the reload path costs nothing to build.
 
 Building a CAMP-side pyramid instead would also manufacture a derived product
-for `chart`/`reference` — the store classes `uma-ADR-0010` D9 deliberately gives
-no overviews.
+for the two store classes `uma-ADR-0010` D9 deliberately does not generate one
+for: `chart` ("LOD arrives built-in — the scale ladder is a cartographer-curated
+pyramid … No pyramid generation") and `reference` ("as imported"). Only
+`draft`/`processed` get generated overviews there, and those are
+shallowest-preserving — a fidelity property a display-side fold would not
+reproduce.
 
 Cost, stated plainly: an evicted area **blanks** until its reload lands, rather
 than degrading to coarser coverage. Two things buy that back. On a real ladder
@@ -169,13 +202,22 @@ eviction pass:
 - **Outside the viewport** — a *last-resort* candidate, ordered behind every
   ordinary candidate.
 
-The asymmetry exists because such a tile is the one class for which "the reload
-path is free" is **false**: `loadTilesWorker()` skips `level > selection`, so an
-evicted hole coverer cannot come back on its own. It returns only when the
-operator zooms in past it, or when Rescan clears the underlying failure
-(ADR-0013's changed-file/failed-tile refresh). Releasing one therefore reports
-itself in the status line together with that recovery action ("coverage over
-failed tile(s) released — use Rescan") rather than losing coverage silently.
+The asymmetry exists because such a tile is one of the two classes for which
+"the reload path is free" is **false** (the other is D2's zoom-out backdrop):
+`loadTilesWorker()` skips `level > selection`, so an evicted hole coverer cannot
+come back on its own. It returns when the operator **zooms in** past it (the
+finer level becomes the selection, so the loader will read it again), or when
+the underlying failure is repaired and **Rescan** picks the repair up — note
+that Rescan alone does *not* reload the evicted finer tile; it helps by closing
+the hole a different way. The status line therefore names both actions
+("coverage over failed tile(s) released — zoom in or Rescan") rather than losing
+the coverage silently.
+
+That report is **live, not latched**: it is shown only while some tile is still
+failed (no failure, no hole, so the message is moot) and `rescan()` clears it
+outright, since Rescan is the operator's explicit retry and the flag must
+describe the current state rather than a past event. A message that survived the
+recovery it advertises would be its own kind of silent failure.
 
 *Alternative considered and rejected*: extending the loader's ceiling to admit
 finer tiles over a failed footprint would make them reloadable and remove the
@@ -203,7 +245,14 @@ traversed." Ranking a recently-traversed tile behind a never-seen one is the
 cheapest way to keep the track. The viewport centre is the clip's own centre,
 already computed every `paint()`; with CAMP's single MapView it is the painting
 view's centre (recovering the painting view under multiple views is camp#150).
-A null viewport — headless — degrades to pure LRU, as ADR-0010 does.
+A null viewport — headless, or a layer that has never painted — is *not*
+"LRU instead of distance": the protection predicate skips the viewport filter
+entirely, so every non-failed tile at a level ≤ the selection is protected, the
+cap floors at that whole set, and eviction is inert. That is deliberate — it is
+what keeps ADR-0013's "Headless / no-selection defaults" (load and render
+everything) true — and it is why the headless tests set an explicit test
+viewport. Only tiles finer than the selection remain candidates in that state,
+and with every distance 0 they order by generation, i.e. pure LRU.
 
 Tiles at the **coarsest available level** are exempt, the analogue of ADR-0010's
 protected apex: on a ladder that guarantees a zoom-out always has something to
@@ -213,9 +262,15 @@ prevent:
 - it applies only when the ladder has **more than one** level — on a
   single-level store every tile is at the coarsest level, and an unbounded
   exemption would make the budget a no-op;
-- at most `kCoarsestExemptCap` (64) such tiles are exempt, nearest-first. That
-  set grows with the area panned, so the surplus joins the last-resort tier
-  instead of accumulating.
+- at most `min(kCoarsestExemptCap, cap / 4)` such tiles are exempt,
+  nearest-first; the surplus — which is what grows with the area panned — joins
+  the last-resort tier instead of accumulating. The bound is relative to the cap
+  as well as absolute because a flat 64 can exceed the eviction target on a
+  small budget (64 against a ~57-tile target at the 512 MiB / 960×960 default),
+  and exempt tiles still count toward residency: the victim loop could then never
+  reach its target and would shed every ordinary candidate on every pass —
+  eviction/reload thrash. An exemption that can outgrow the target is a second,
+  unevictable budget, not a floor.
 
 `available_levels_` is rebuilt by `rescan()`, so the exemption is evaluated per
 pass and never cached.
@@ -228,11 +283,22 @@ reading. The pass itself must not run while the loader worker is iterating
 `tiles_`, so it checks `future_watcher_.isRunning()` — and when it finds the
 worker busy it **re-arms** on a short timer with the debounce still held.
 
-The re-arm is the whole point. A continuous pan re-kicks the loader at every
-step, so a pass that simply returned when it found the worker running would
-almost never fire during a sustained pan — precisely the scenario the budget
-exists for. Abort-and-join (what `loadTiles()` does before mutating `tiles_`)
-was rejected here: it would stall the GUI thread for a whole tile read, mid-pan.
+Not dropping the request is the whole point. A continuous pan re-kicks the
+loader at every step, so a pass that simply returned when it found the worker
+running would almost never fire during a sustained pan — precisely the scenario
+the budget exists for. Abort-and-join (what `loadTiles()` does before mutating
+`tiles_`) was rejected here: it would stall the GUI thread for a whole tile
+read, mid-pan.
+
+But a timer re-arm alone is a **blind resample**, not a rendezvous. During a
+sustained pan the idle window between one worker finishing and `paint()`
+re-kicking is about one event-loop turn inside a duty cycle dominated by tile
+reads, so a 100 ms retry lands in it only by luck — the budget could be starved
+for many seconds of continuous panning while residency grows. The deterministic
+rendezvous is `tilesReady()`: it runs on the GUI thread immediately after the
+worker's join and before any `paint()` can re-kick, so a pending pass is
+**drained there**. The timer stays as the backstop for the case where nothing
+completes.
 
 ### D8 — The auto-range is not recomputed on eviction
 
@@ -263,9 +329,32 @@ case that *does* invalidate a contribution — `rescan()` replacing a tile's fil
   nothing here accounts for the co-resident `SonarLiveCacheLayer` budget.
   Process-wide accounting is camp#155/#156; this is a known gap, not an
   oversight.
-- Eviction adds an O(resident) sort per pass, off the paint path and debounced.
-  The per-frame cost added to `paint()` is one O(tiles) protection sweep —
-  the same order as the existing `itemsIntersecting()` collect.
+- Eviction adds an O(n log n) candidate sort per pass, off the paint path and
+  debounced. `paint()` itself pays more than the protection sweep alone: the
+  sweep (with a `failedFootprints()` scan inside it), plus `residentTileCount()`
+  — each O(tiles), each with a `tileSceneRect()` geo→Mercator transform per
+  tile. `perTileResidentBytes()` is memoized against `tiles_.size()` so it is
+  not a third pass. This is real per-frame GUI-thread work on a
+  thousand-tile store, and it lands on frames that previously short-circuited on
+  `cached_image_`. Accepted for now — the sweep is what keeps the LRU generations
+  honest — but it is the first thing to profile if pan latency regresses
+  (alongside camp#198's overdraw).
+- If a GL context exists but refuses to become current, `releaseTiles()`
+  deliberately releases **nothing**, to keep the `resetPixels()`/`releaseGL()`
+  pairing invariant intact. `RasterGlRenderer` latches that failure without
+  destroying the context, so the condition can be permanent — the budget then
+  stops being enforced for the rest of the session. The layer reports that
+  state ("tile budget NOT enforced (GL context unavailable)") rather than
+  growing silently toward the camp#153 OOM. Freeing the CPU half alone would in
+  fact be safe once the renderer's GL-failed flag is latched (no new texture can
+  ever be uploaded, so nothing could shadow a re-load), but that reasoning
+  depends on a renderer internal the layer cannot currently observe; exposing it
+  is a follow-up, not a silent assumption.
+- A malformed `GggsTileLayers/max_resident_bytes` (`"512M"`, a stray quote)
+  converts to 0, which is the *disable* sentinel — a typo in the hand-edited
+  operator-station settings would silently restore the pre-camp#195 unbounded
+  behaviour. The layer detects the parse failure, warns, and falls back to the
+  default; only an explicit `0` disables.
 - **Coverage gap**: the headless tests exercise only the CPU half of the
   release. With no GL context `releaseGL()` is a no-op, so the texture half —
   the larger part of the 7.03 MiB — is not covered by an automated test. The

--- a/docs/decisions/0014-gggs-viewport-scoped-residency.md
+++ b/docs/decisions/0014-gggs-viewport-scoped-residency.md
@@ -1,0 +1,300 @@
+# ADR-0014: GGGS tile-layer viewport-scoped residency and budget
+
+## Status
+
+Accepted
+
+Implements camp issue #195. The display-side implementation of
+`uma-ADR-0013` **D4** ("Residency is budgeted, and pressure relaxes quality
+rather than thrashing") for `GggsTileLayer`.
+
+Amends [ADR-0013](0013-lod-level-selection-demand-driven-load.md): that ADR's
+"levels ≤ the selection stay resident permanently" residency rule is superseded
+here, and its "the only release path is the level switch" statement gains a
+second, viewport-keyed path. It does **not** change ADR-0013's LOD selection or
+its demand-driven load — this ADR governs only what is *kept*.
+
+Sibling, not parent: [ADR-0010](0010-bounded-eviction-overview-pyramid.md)
+answers the same forces for `SonarLiveCacheLayer`. The two layers face different
+data contracts, and where the answers diverge this ADR records why.
+
+**Citation convention** (from `uma-ADR-0013`): cross-repo ADR references are
+repo-qualified — `camp-ADR-00NN` / `uma-ADR-00NN`. Within this repo, relative
+links to sibling ADRs stay unqualified.
+
+## Context
+
+`GggsTileLayer` had exactly one code path that ever freed a tile: the release
+loop in `tilesReady()`, which fires after a level switch and frees only tiles at
+levels *finer* than the selection. **No release was ever driven by the
+viewport.** At a fixed zoom, every tile the view scrolled across stayed resident
+for the life of the session.
+
+Per-tile cost is high and deliberately so: `GggsTile::texture()` retains the CPU
+buffer past the GPU upload (camp#180 — the depth-at-cursor readout samples it),
+so a painted 960×960 tile holds a 3.52 MiB `std::vector<float>` **plus** a
+3.52 MiB R32F texture ≈ 7.03 MiB. A hundred panned-over tiles is ~700 MiB.
+
+The loader was already viewport-filtered on the way *in* (ADR-0013), which is
+the trap this ADR exists to name: **a viewport-filtered loader is not a
+residency bound.** Filtering what enters bounds the rate of growth, not the
+total; residency equalled the union of every viewport ever visited.
+
+`SonarLiveCacheLayer` had this identical shape and OOM'd the salmon operator
+station shortly after live data was enabled (camp#153), which is why ADR-0010
+exists. `GggsTileLayer` is the layer that never got the treatment. The Isles of
+Shoals work puts a 1 m Appledore MLLW grid into the `reference` layer, in front
+of an operator panning across it repeatedly during survey operations — the exact
+accumulating usage pattern.
+
+## Decision
+
+### D1 — A byte budget, converted to a tile count from the observed tile size
+
+`QSettings GggsTileLayers/max_resident_bytes`, default **512 MiB**, `0` disables
+eviction entirely (the pre-camp#195 behaviour). The key mirrors
+`LiveTileCache/max_vram_bytes`, whose default is the same 512 MiB, so the two
+co-resident working sets are expressed in the same units and are tunable
+together on the host (camp#117 / ADR-0006 D2: a default, never an un-changeable
+hardcode).
+
+`uma-ADR-0013` D4 explicitly blesses a **count** budget for fixed-size tiles and
+names GGGS's 960×960 as such a case. We keep the count *mechanics* — the cap,
+the protection, and the eviction loop all work in tiles — but derive the count
+from a byte target and the **observed** per-tile cost
+(`max(width × height) × 4 × 2` over the tile-set), because `width_`/`height_`
+come from GDAL: 960×960 is a store convention, not an invariant, and a hardcoded
+count would silently mis-size on any store that departs from it. The factor of
+two is the retained CPU buffer plus the GL texture.
+
+*Why 512 MiB is acceptable next to the live cache's own 512 MiB*: the camp#153
+OOM precedent is **salmon**'s hardware. The Shoals operator station is **pandy**,
+not salmon, and pandy has the headroom for both working sets. The number is a
+default for a machine we know, not a portable claim — which is exactly why it
+lives behind a settings key: it is expected to be tuned on the station during a
+rebuild day rather than in a rebuild of CAMP.
+
+The principled budget number is camp#155/#156 (ResourceMonitor: self-sampled
+footprint and GPU-byte accounting). This ADR deliberately does not block on
+them; the measured value wires in through the same seam later.
+
+### D2 — Current-frame protection is structural, and comes from the loader predicate
+
+`uma-ADR-0013` D4 requires "cannot evict what this frame selected" to be a
+property of the data structure rather than a checked condition. `TileResidency`
+(`raster/tile_residency.h`) is that structure: two `std::list<std::size_t>`
+partitions (protected / evictable) plus an iterator index and a frame epoch, so
+`beginFrame()` and `protect()` are O(1) splices and `candidates()` — the only
+accessor an eviction pass gets — exposes the evictable partition alone. There is
+no accessor that yields a protected index as a candidate.
+
+The protected set is derived from **the loader's predicate**, not from the draw
+list: tiles intersecting the load viewport at a level ≤ the selection, plus the
+hole coverers of D5. This is not a stylistic choice. `cached_image_`
+short-circuits `itemsIntersecting()` on a static frame, so on exactly the frames
+an eviction is most likely to run, a draw-list-sourced protection would protect
+**nothing** and the live visible set would be evictable. Not-yet-loaded tiles are
+counted too: they are part of the working set the cap must accommodate.
+Terminally-failed tiles are not — they never become resident, so counting them
+would inflate the floor with memory nothing will ever occupy.
+
+Two placement rules follow, and both are load-bearing:
+
+- In `paint()`, protection is refreshed **after** the load viewport is set and
+  **before** every remaining early return. `refreshProtection()` begins by
+  splicing the whole protected partition back into the evictable one, so a
+  return between "begin" and "protect" would leave the live visible set
+  evictable.
+- The eviction pass **re-derives** the protected set live before choosing
+  candidates (the `MapTiles`/camp#98 rule). The pass is queued and debounced, so
+  the protection captured at schedule time may be several pan steps stale, and a
+  tile that re-entered the view in between must never be evicted.
+
+### D3 — The cap is floored at the working set; over-budget is reported, not thrashed
+
+`cap = max(budget_tiles, protected_count)`.
+
+`uma-ADR-0013` D4: "the budget must exceed [the tiles selected this frame] or the
+system thrashes by construction". A hard ceiling that can fall below the current
+frame's own selection would evict what the layer is drawing, re-load it next
+frame, and evict it again. So when one viewport's working set alone exceeds the
+byte target, the layer **exceeds its budget deliberately** and says so in its
+status line ("over the tile budget — raise `GggsTileLayers/max_resident_bytes`
+or zoom in"). Eviction runs down to `max(protected_count, 0.75 × cap)`, the
+hysteresis analogue of ADR-0010 D6, so the next frame cannot immediately
+re-trigger it.
+
+D4's other half — *relax the quality target* (raise `τ`, select a coarser level)
+under this pressure — is **deferred to camp#197**. As originally specified it
+oscillated deterministically: degrade → the protected set shrinks ~4× → a
+cool-down relaxes it → the trigger fires again, with a period equal to the
+cool-down. A stable relax needs the *predicted* protected count at the finer
+level under a hysteresis factor, not a timer. Deferring is safe because the
+unbounded-pan accumulation — the actual OOM, and the camp#153 precedent — is
+fully fixed by the budget alone; the lever only addresses the narrower case
+where a single viewport is itself over budget, and D4's "never fail silently"
+is satisfied meanwhile by the floor plus the reported state.
+
+### D4 — Drop and re-read, not fold-to-parent
+
+ADR-0010 folds an evicted fine tile into its coarse parent before dropping it,
+because a live tile arrives **once** over ROS and its only durable copy is the
+cache on disk. A GGGS tile's source of truth *is* the file on disk, and
+ADR-0013's demand-driven loader already re-reads a tile when the viewport
+returns to it (`hasUnloadedVisibleTiles()` plus the moved-since-last-kick
+re-kick). `resetPixels()` + `releaseGL()` is therefore a complete release, and
+the reload path costs nothing to build.
+
+Building a CAMP-side pyramid instead would also manufacture a derived product
+for `chart`/`reference` — the store classes `uma-ADR-0010` D9 deliberately gives
+no overviews.
+
+Cost, stated plainly: an evicted area **blanks** until its reload lands, rather
+than degrading to coarser coverage. Two things buy that back. On a real ladder
+every level ≤ the selection is resident, so a panned-away area usually retains
+coarse coverage; and the coarsest available level is exempt from eviction (D6).
+On a single-level store neither applies and the blank stands — a deliberate
+trade, since the alternative is manufacturing data the store does not have.
+
+### D5 — camp#194 hole coverage: protected in view, last-resort out of view
+
+camp#194 established that a tile **finer** than the selection which intersects a
+`loadFailed()` tile at a level ≤ the selection is the *only usable coverage over
+that hole*, and must survive `tilesReady()`'s level-switch release. The budget
+must not silently undo that, so the same predicate (`coversHole()`, one helper
+shared by both release paths, so the two rules cannot drift) governs the
+eviction pass:
+
+- **In the viewport** — protected, exactly like a selected tile.
+- **Outside the viewport** — a *last-resort* candidate, ordered behind every
+  ordinary candidate.
+
+The asymmetry exists because such a tile is the one class for which "the reload
+path is free" is **false**: `loadTilesWorker()` skips `level > selection`, so an
+evicted hole coverer cannot come back on its own. It returns only when the
+operator zooms in past it, or when Rescan clears the underlying failure
+(ADR-0013's changed-file/failed-tile refresh). Releasing one therefore reports
+itself in the status line together with that recovery action ("coverage over
+failed tile(s) released — use Rescan") rather than losing coverage silently.
+
+*Alternative considered and rejected*: extending the loader's ceiling to admit
+finer tiles over a failed footprint would make them reloadable and remove the
+special case. But a failed **coarse** tile spans an enormous footprint, so at low
+zoom this would pull every fine tile in the viewport into the load — the
+store-bounded open ADR-0013 exists to avoid — and inflate the protected floor
+with it.
+
+### D6 — Hybrid eviction ordering, and a bounded coarsest-level exemption
+
+Candidates are ordered by, in priority:
+
+1. **last-resort tier** — out-of-view hole coverers (D5) and surplus
+   coarsest-level tiles go last;
+2. **staleness** — a tile not seen within the last ~120 paints goes before one
+   seen recently;
+3. **distance** — farthest from the viewport centre first;
+4. **LRU generation** — oldest last-visible first.
+
+Staleness sits above distance on purpose. ADR-0010's ordering is
+distance-primary with LRU only as a headless fallback, and `uma-ADR-0013` D4
+objects to exactly that: "LRU alone retains a useless working set after a
+viewpoint jump; distance-only ordering discards history along a path being
+traversed." Ranking a recently-traversed tile behind a never-seen one is the
+cheapest way to keep the track. The viewport centre is the clip's own centre,
+already computed every `paint()`; with CAMP's single MapView it is the painting
+view's centre (recovering the painting view under multiple views is camp#150).
+A null viewport — headless — degrades to pure LRU, as ADR-0010 does.
+
+Tiles at the **coarsest available level** are exempt, the analogue of ADR-0010's
+protected apex: on a ladder that guarantees a zoom-out always has something to
+draw. Two bounds keep the exemption from becoming the leak it is meant to
+prevent:
+
+- it applies only when the ladder has **more than one** level — on a
+  single-level store every tile is at the coarsest level, and an unbounded
+  exemption would make the budget a no-op;
+- at most `kCoarsestExemptCap` (64) such tiles are exempt, nearest-first. That
+  set grows with the area panned, so the surplus joins the last-resort tier
+  instead of accumulating.
+
+`available_levels_` is rebuilt by `rescan()`, so the exemption is evaluated per
+pass and never cached.
+
+### D7 — Deferred, debounced eviction that re-arms when the loader is busy
+
+`paint()` only *schedules* the pass (queued invocation, debounced by a pending
+flag): releasing a tile inside `paint()` would mutate the set the render pass is
+reading. The pass itself must not run while the loader worker is iterating
+`tiles_`, so it checks `future_watcher_.isRunning()` — and when it finds the
+worker busy it **re-arms** on a short timer with the debounce still held.
+
+The re-arm is the whole point. A continuous pan re-kicks the loader at every
+step, so a pass that simply returned when it found the worker running would
+almost never fire during a sustained pan — precisely the scenario the budget
+exists for. Abort-and-join (what `loadTiles()` does before mutating `tiles_`)
+was rejected here: it would stall the GUI thread for a whole tile read, mid-pan.
+
+### D8 — The auto-range is not recomputed on eviction
+
+`foldDataRange()` widens only, and ADR-0013 (as amended by camp#194) already
+established that a level switch must not reset it. Eviction is the same case,
+and more clearly so: an evicted tile's pixels are **unchanged on disk**, so the
+contribution it already made stays true. Re-deriving the range from a shrinking
+resident set would only make the colormap flicker as tiles come and go. The one
+case that *does* invalidate a contribution — `rescan()` replacing a tile's file
+— keeps its reset-and-recompute path, unchanged.
+
+## Consequences
+
+- Residency is bounded by the viewport rather than by the union of every
+  viewport ever visited. A pan of arbitrary length over a store of arbitrary
+  size stays within the budget, floored at whatever the current frame needs.
+- `getElevation()` (camp#180) returns NaN over an area the view has panned away
+  from and the budget has released. In practice the readout is unaffected: the
+  cursor is always inside the viewport, and viewport tiles are structurally
+  protected. Asserted in `test/test_gggs_elevation.cpp`.
+  Note for camp#197: raising `τ` under pressure would weaken ADR-0013's
+  "`getElevation()` samples finest-covering-tile-first" fidelity mitigation,
+  because the finest covering tile may no longer be resident. That interaction
+  belongs to whoever implements the lever.
+- An evicted area blanks briefly on pan-back until the re-read lands (D4). On a
+  ladder it usually shows coarse coverage instead.
+- The budget is **per layer**. N GGGS layers multiply the process footprint, and
+  nothing here accounts for the co-resident `SonarLiveCacheLayer` budget.
+  Process-wide accounting is camp#155/#156; this is a known gap, not an
+  oversight.
+- Eviction adds an O(resident) sort per pass, off the paint path and debounced.
+  The per-frame cost added to `paint()` is one O(tiles) protection sweep —
+  the same order as the existing `itemsIntersecting()` collect.
+- **Coverage gap**: the headless tests exercise only the CPU half of the
+  release. With no GL context `releaseGL()` is a no-op, so the texture half —
+  the larger part of the 7.03 MiB — is not covered by an automated test. The
+  pairing invariant it protects (`gggs_tile.h`: a CPU-only clear leaves a stale
+  texture shadowing any re-load) is enforced in one shared helper precisely
+  because it cannot be asserted here.
+- The reusable lesson, recorded because it was mis-diagnosed twice: **a
+  viewport-filtered loader is not a residency bound**, and multi-level
+  compositing did not cause this accumulation — it predated camp#194 and needed
+  no multi-level store.
+
+## Alternatives considered
+
+- **Fold-to-parent before dropping (ADR-0010's answer)** — rejected in D4: the
+  tiles are files, the reload path already exists, and a CAMP-side pyramid would
+  manufacture a derived product `uma-ADR-0010` D9 withholds.
+- **A fixed tile count (e.g. 64 tiles ≈ 450 MiB)** — rejected in D1: it hides a
+  960×960 assumption that GDAL does not guarantee, and it is not comparable to
+  the co-resident live-cache budget.
+- **A hard maximum cap with no floor** — rejected in D3: it is D4's "thrashes by
+  construction".
+- **The `τ` degrade lever in this change** — deferred to camp#197 in D3: as
+  specified it oscillates with a period equal to its cool-down.
+- **Per-kick loader volume cap** — rejected. The kick set is already
+  viewport-bounded (it *is* the protected set), and truncating a kick would
+  leave a stationary operator with a permanently incomplete picture: the re-kick
+  guard requires the selection or viewport to change before it will fire again,
+  and the load would settle with a cleared status over the gap.
+- **Recovering the painting view in `deriveViewportClip()`** — out of scope. The
+  eviction metric needs a view centre, and the clip's own centre already is the
+  painting view's centre under CAMP's single MapView. Multi-view recovery is
+  camp#150.

--- a/src/camp_map/raster/gggs_tile.h
+++ b/src/camp_map/raster/gggs_tile.h
@@ -148,10 +148,16 @@ public:
   /// so a later loadPixels() re-reads from scratch — the CPU half of releasing a
   /// tile when the LOD switches away from its level. Does NOT touch the GL
   /// texture. INVARIANT: every call site must pair this with releaseGL() under a
-  /// current context — after a texture() upload, data_ is already freed while
-  /// texture_ is non-null, so a CPU-only clear leaves a stale texture that
-  /// shadows any re-loaded pixels (texture() returns the old texture and never
-  /// consumes the new data_).
+  /// current context — texture() uploads from data_ exactly ONCE and then
+  /// returns the cached texture_ forever, so a CPU-only clear leaves a stale
+  /// texture that shadows any re-loaded pixels (texture() returns the old
+  /// texture and never consumes the new data_).
+  /// [camp#180] This used to read "data_ is already freed after the upload".
+  /// That stopped being true when camp#180 made texture() RETAIN the CPU copy
+  /// for the depth-at-cursor readout (gggs_tile.cpp): a painted tile now holds
+  /// BOTH copies, which is why camp-ADR-0014's residency budget charges
+  /// 2 x width x height x 4 per tile. The invariant above is unaffected — it
+  /// rests on the upload happening once, not on data_ being freed.
   void resetPixels();
 
   /// True once `loadPixels()` has read the band into CPU memory (or freed it into

--- a/src/camp_map/raster/gggs_tile_layer.cpp
+++ b/src/camp_map/raster/gggs_tile_layer.cpp
@@ -431,6 +431,12 @@ bool GggsTileLayer::rescan()
     foldDataRange(true);
     if(data_min_ <= data_max_)
       range_model_.update_auto(float(data_min_), float(data_max_));
+    // [camp#195 review] refreshFromFile() re-reads metadata, so a replacement
+    // file may carry different dimensions. perTileResidentBytes() is memoized
+    // on tiles_.size(), which a refresh does not change — invalidate it here or
+    // the byte budget keeps deriving its tile cap from the departed file's
+    // extent.
+    per_tile_bytes_count_ = std::size_t(-1);
     cached_image_ = QImage();
   }
   else if(!changed.empty())

--- a/src/camp_map/raster/gggs_tile_layer.cpp
+++ b/src/camp_map/raster/gggs_tile_layer.cpp
@@ -103,9 +103,26 @@ GggsTileLayer::GggsTileLayer(map::MapItem* parentItem, const QString& directory)
   // 512 MiB — the two working sets are co-resident, and the key exists so the
   // pair can be tuned on the operator station rather than in a rebuild.
   QSettings settings;
-  resident_budget_bytes_ = static_cast<std::size_t>(
+  bool budget_ok = false;
+  const qulonglong budget_value =
     settings.value("GggsTileLayers/max_resident_bytes",
-                   kDefaultResidentBudgetBytes).toULongLong());
+                   kDefaultResidentBudgetBytes).toULongLong(&budget_ok);
+  if(budget_ok)
+    resident_budget_bytes_ = static_cast<std::size_t>(budget_value);
+  else
+  {
+    // A malformed value ("512M", "512 MiB", a stray quote) converts to 0, which
+    // is the DISABLE sentinel — a typo in the hand-edited operator-station
+    // settings would otherwise silently restore the pre-#195 unbounded
+    // behaviour. Fall back to the default and say so.
+    qWarning().noquote()
+      << "[gggs" << directory_
+      << "] GggsTileLayers/max_resident_bytes is not a number ("
+      << settings.value("GggsTileLayers/max_resident_bytes").toString()
+      << ") - using the" << qulonglong(kDefaultResidentBudgetBytes)
+      << "byte default. Set it to 0 to disable eviction deliberately.";
+    resident_budget_bytes_ = static_cast<std::size_t>(kDefaultResidentBudgetBytes);
+  }
 
   // [camp#102] tilesReady() folds completed tiles' ranges + repaints on the GUI
   // thread when the async pixel load finishes.
@@ -448,6 +465,13 @@ bool GggsTileLayer::rescan()
     setPos(QPointF(scene_bounds_.left(), scene_bounds_.bottom()));
   }
 
+  // [camp#195] Rescan is the operator's explicit retry, and it is the action the
+  // released-hole-coverage status names. Clear that report here so it describes
+  // the CURRENT state rather than latching for the session: the load kicked
+  // below re-reads whatever the refreshed tile-set now admits, and the eviction
+  // pass will re-raise the flag if it has to release coverage again.
+  hole_coverage_released_ = false;
+
   if(load_started_)
   {
     cached_image_ = QImage();   // force a re-render once the new pixels arrive
@@ -714,21 +738,23 @@ void GggsTileLayer::updateStatus()
     setStatus("(no tiles)");
     return;
   }
-  if(loading_)
-  {
-    setStatus("(loading...)");
-    return;
-  }
   if(!load_started_)
   {
     setStatus("");   // nothing attempted yet — not "no data"
     return;
   }
   QStringList parts;
+  // [camp#195] "loading..." is a PART, not an early return. During a pan the
+  // loader is re-kicked at every step, so loading_ is true nearly all the time —
+  // exactly when the residency reports below matter most. An early return here
+  // would hide them until the operator stopped moving.
+  if(loading_)
+    parts << "loading...";
   // [camp#102] A crossed range after the fold means every loaded tile was
   // all-NoData (or failed to read): there is nothing to draw, and a clear status
-  // would leave a silently-blank enabled layer.
-  if(data_min_ > data_max_)
+  // would leave a silently-blank enabled layer. Not reportable mid-load, where
+  // a crossed range only means "nothing has folded yet".
+  if(!loading_ && data_min_ > data_max_)
     parts << "no data";
   // [camp#194] Terminally-unreadable tiles. Counted over the WHOLE tile-set (not
   // the visible/selected set) so the number does not flicker with the viewport.
@@ -738,8 +764,10 @@ void GggsTileLayer::updateStatus()
       ++failed;
   if(failed > 0)
     parts << QString("%1 tile(s) failed to load").arg(failed);
-  // [camp#195 / uma-ADR-0013 D4] "Report the degraded state; never fail
-  // silently." The cap is FLOORED at the current-frame working set, so when that
+  // [camp#195] "Report the degraded state; never fail silently" (the issue's
+  // ask 3; uma-ADR-0013 D4 puts the same requirement as "the display degrades
+  // visibly and predictably rather than churning").
+  // The cap is FLOORED at the current-frame working set, so when that
   // set alone exceeds the byte budget the layer does not evict what it is
   // drawing (that is D4's "thrashes by construction") — it exceeds the budget
   // and says so. Relaxing the quality target under this pressure — D4's tau
@@ -747,12 +775,20 @@ void GggsTileLayer::updateStatus()
   if(over_budget_)
     parts << "over the tile budget - raise GggsTileLayers/max_resident_bytes or zoom in";
   // [camp#195] An evicted camp#194 hole coverer cannot come back on its own:
-  // loadTilesWorker() skips levels finer than the selection, so the demand-driven
-  // reload that makes every other eviction free does not apply to this one class.
-  // Surface the loss with the operator's recovery action rather than losing the
-  // coverage silently.
-  if(hole_coverage_released_)
-    parts << "coverage over failed tile(s) released - use Rescan";
+  // loadTilesWorker() skips levels finer than the selection, so the
+  // demand-driven reload that makes every other eviction free does not apply to
+  // this one class. Surface the loss with the recovery actions that ACTUALLY
+  // work: zooming in re-selects the finer level so the loader will read it
+  // again, and Rescan helps only by repairing the failed tile itself (which
+  // closes the hole a different way).
+  // Gated on `failed > 0` so it is a live statement, not a latch: once no tile
+  // is failed there is no hole, and the message is moot. rescan() clears the
+  // flag outright for the operator's explicit retry.
+  if(hole_coverage_released_ && failed > 0)
+    parts << "coverage over failed tile(s) released - zoom in or Rescan";
+  // [camp#195] The budget cannot be enforced at all — see evictIfOverBudget().
+  if(eviction_blocked_)
+    parts << "tile budget NOT enforced (GL context unavailable)";
   setStatus(parts.isEmpty() ? QString() : "(" + parts.join("; ") + ")");
 }
 
@@ -769,16 +805,23 @@ std::size_t GggsTileLayer::perTileResidentBytes() const
 {
   // [camp#195] Observed, never assumed (see the header). The largest tile in the
   // set speaks so a non-uniform store cannot undercount the budget.
+  // Memoized against tiles_.size(): tile extents are immutable after their
+  // metadata read and tiles_ only ever GROWS (loadDirectory/rescan push_back),
+  // so the size is a sufficient cache key — and this is called from paint().
+  if(per_tile_bytes_count_ == tiles_.size())
+    return per_tile_bytes_;
   std::size_t max_pixels = 0;
   for(const auto& tile : tiles_)
     if(tile->valid())
       max_pixels = std::max(max_pixels, std::size_t(tile->width()) *
                                           std::size_t(tile->height()));
-  if(max_pixels == 0)
-    return 0;
   // CPU Float32 buffer + R32F texture of the same extent (gggs_tile.cpp: the CPU
-  // copy is deliberately retained past the GPU upload for camp#180).
-  return max_pixels * sizeof(float) * 2;
+  // copy is deliberately retained past the GPU upload for camp#180). A tile that
+  // loaded but never painted holds only the CPU half, so this is deliberately
+  // conservative — it charges the fully-displayed cost.
+  per_tile_bytes_ = (max_pixels == 0) ? 0 : max_pixels * sizeof(float) * 2;
+  per_tile_bytes_count_ = tiles_.size();
+  return per_tile_bytes_;
 }
 
 std::size_t GggsTileLayer::budgetTiles() const
@@ -810,11 +853,20 @@ std::size_t GggsTileLayer::refreshProtection()
     if(!load_viewport_.isNull() &&
        !tileSceneRect(tile).intersects(load_viewport_))
       continue;
-    // Levels finer than the selection are not part of the picture — EXCEPT a
-    // camp#194 hole coverer, which is the only usable coverage over a footprint
-    // whose selected-or-coarser tile failed to read.
+    // Levels finer than the selection are not in the LOADER's set — but two
+    // classes of in-view finer tile are nonetheless part of what this frame
+    // DRAWS, and neither can reload if dropped (loadTilesWorker skips
+    // level > selection), so both are protected:
+    //  - any finer tile that is already RESIDENT: itemsIntersecting() draws the
+    //    whole resident set with no level filter, so during a zoom-out these
+    //    tiles are the entire visible picture until the coarser selection
+    //    finishes loading (the camp#103/#194 no-blank-frame guarantee).
+    //    tilesReady()'s level-switch release drops them at the right moment, so
+    //    protecting them here leaks nothing;
+    //  - a camp#194 hole coverer, the only usable coverage over a footprint
+    //    whose selected-or-coarser tile failed to read.
     if(selected_level_ != -1 && tile.level() > selected_level_ &&
-       !coversHole(tile, holes))
+       !tile.pixelsLoaded() && !coversHole(tile, holes))
       continue;
     residency_.protect(i);
     tile_last_visible_gen_[i] = paint_generation_;
@@ -841,7 +893,11 @@ void GggsTileLayer::scheduleEvictionIfNeeded(std::size_t protected_count)
   if(residentTileCount() <= std::max(budget, protected_count))
     return;
   eviction_pending_ = true;
-  QMetaObject::invokeMethod(this, "evictIfOverBudget", Qt::QueuedConnection);
+  // Pointer-to-member overload, not the string form: a rename of the slot would
+  // otherwise fail at RUNTIME with a qWarning nobody reads, and the residency
+  // bound would silently stop existing.
+  QMetaObject::invokeMethod(this, &GggsTileLayer::evictIfOverBudget,
+                            Qt::QueuedConnection);
 }
 
 void GggsTileLayer::evictIfOverBudget()
@@ -852,7 +908,18 @@ void GggsTileLayer::evictIfOverBudget()
   Q_ASSERT(thread() == QThread::currentThread());
   eviction_pending_ = false;
   if(budgetTiles() == 0)
+  {
+    // Budget disabled (or no measurable tile yet). Clear any state the budget
+    // path had published so the layer cannot keep advertising a bound it is no
+    // longer enforcing.
+    if(over_budget_ || eviction_blocked_)
+    {
+      over_budget_ = false;
+      eviction_blocked_ = false;
+      updateStatus();
+    }
     return;
+  }
 
   // This mutates tiles the loader worker iterates, so it must not run
   // concurrently with it. RE-ARM rather than drop the request: a continuous pan
@@ -893,7 +960,9 @@ void GggsTileLayer::evictIfOverBudget()
 
   // Evict down to the hysteresis target so the next frame cannot immediately
   // re-trigger (the kReloadHysteresisFactor analogue), but never below the
-  // protected working set.
+  // protected working set. With protected_count == 0 (the viewport is entirely
+  // off this store's footprint) and a cap of 1, the target truncates to 0 and
+  // the whole layer is released — correct: nothing of it is on screen.
   const std::size_t target =
     std::max(protected_count, std::size_t(kEvictHysteresisFactor * double(cap)));
 
@@ -926,8 +995,13 @@ void GggsTileLayer::evictIfOverBudget()
     candidate.generation = tile_last_visible_gen_[index];
     candidate.distance =
       have_centre ? rectDistanceSquared(tileSceneRect(tile), centre) : 0.0;
+    // Generation 0 = never protected by any frame. That must classify as STALE:
+    // without the != 0 guard it reads as "recent" for the first
+    // kRecentGenerations paints of a session, inverting the very ordering the
+    // staleness key exists to provide.
     candidate.recent =
-      (paint_generation_ - candidate.generation) <= kRecentGenerations ? 1 : 0;
+      (candidate.generation != 0 &&
+       (paint_generation_ - candidate.generation) <= kRecentGenerations) ? 1 : 0;
     // An out-of-view camp#194 hole coverer is a LAST-RESORT candidate: unlike
     // every other tile it cannot reload on pan-back (loadTilesWorker skips
     // levels finer than the selection), so it is dropped only when nothing else
@@ -939,12 +1013,23 @@ void GggsTileLayer::evictIfOverBudget()
       candidates.push_back(candidate);
   }
 
-  // The zoom-out floor, BOUNDED: the nearest kCoarsestExemptCap coarsest-level
-  // tiles are exempt so a zoom-out always has something to draw; the surplus —
-  // which is what grows with the area panned — joins the last-resort tier
-  // rather than accumulating forever. On a single-level store there is no
-  // ladder and hence no exemption, so the budget is not a no-op there.
-  if(coarsest_tiles.size() > kCoarsestExemptCap)
+  // The zoom-out floor, BOUNDED: the nearest few coarsest-level tiles are
+  // exempt so a zoom-out always has something to draw; the surplus — which is
+  // what grows with the area panned — joins the last-resort tier rather than
+  // accumulating forever. On a single-level store there is no ladder and hence
+  // no exemption, so the budget is not a no-op there.
+  //
+  // The bound is relative to the CAP as well as absolute. A flat
+  // kCoarsestExemptCap can exceed the hysteresis target on a small budget (64
+  // exempt tiles against a ~57-tile target at the 512 MiB / 960x960 default),
+  // and since exempt tiles still count toward `resident` the victim loop could
+  // then never reach the target — it would evict every ordinary candidate on
+  // every pass, including tiles the next pan step immediately re-reads. Capping
+  // the exemption at a quarter of the cap keeps the floor a floor rather than a
+  // second, unevictable budget.
+  const std::size_t coarsest_exempt =
+    std::min(kCoarsestExemptCap, std::max<std::size_t>(1, cap / 4));
+  if(coarsest_tiles.size() > coarsest_exempt)
   {
     std::sort(coarsest_tiles.begin(), coarsest_tiles.end(),
               [](const Candidate& a, const Candidate& b)
@@ -953,7 +1038,7 @@ void GggsTileLayer::evictIfOverBudget()
                   return a.distance < b.distance;   // nearest kept
                 return a.generation > b.generation; // then freshest kept
               });
-    for(std::size_t k = kCoarsestExemptCap; k < coarsest_tiles.size(); ++k)
+    for(std::size_t k = coarsest_exempt; k < coarsest_tiles.size(); ++k)
     {
       Candidate surplus = coarsest_tiles[k];
       surplus.tier = 1;
@@ -993,10 +1078,21 @@ void GggsTileLayer::evictIfOverBudget()
   // what distinguishes eviction from rescan()'s file-replacement case.
   if(releaseTiles(victims))
   {
+    eviction_blocked_ = false;
     if(released_hole_coverage)
       hole_coverage_released_ = true;
     cached_image_ = QImage();
     update(boundingRect());
+  }
+  else if(!victims.empty())
+  {
+    // releaseTiles() refused: a GL context exists but would not become current.
+    // RasterGlRenderer latches that failure and never destroys the context, so
+    // this can be PERMANENT — every later pass would release nothing and the
+    // residency bound would quietly cease to exist, in a session that is
+    // already degraded. Report it instead of growing silently toward the
+    // camp#153 OOM.
+    eviction_blocked_ = true;
   }
   updateStatus();
 }
@@ -1047,8 +1143,11 @@ void GggsTileLayer::tilesReady()
     // rescan()'s changed-file refresh or a band switch); under-retention costs
     // the operator their data.
     // NOT a coverage/eviction policy: a region with NO coarse tile at all still
-    // releases and blanks per the documented residency rule (ADR-0013 "Render");
-    // that family is camp#195.
+    // releases and blanks per the documented residency rule (ADR-0013 "Render").
+    // [camp#195] That is the COVERAGE half of the old camp#195 family and is
+    // still unaddressed; camp#195 settled only the residency half (the budget
+    // below — ADR-0014), which bounds what is kept and never decides to load
+    // finer-than-selection data.
     const std::vector<QRectF> failed_rects = failedFootprints();
     std::vector<GggsTile*> victims;
     for(auto& tile : tiles_)
@@ -1079,6 +1178,16 @@ void GggsTileLayer::tilesReady()
   // would silently wipe an over-budget message written from paint().
   loading_ = false;
   updateStatus();
+  // [camp#195] Drain a pending residency pass HERE, the one deterministic
+  // rendezvous with the loader. The queued/timer pass bails whenever the worker
+  // is running, and during a continuous pan paint() re-kicks the loader as soon
+  // as it goes idle — so the idle window is about one event-loop turn inside a
+  // duty cycle dominated by tile reads, and a 100 ms resample lands in it only
+  // by luck. This slot runs on the GUI thread immediately after the worker's
+  // join and before any paint() can re-kick, so the pass always gets its turn.
+  // The timer stays as a backstop for the case where nothing completes.
+  if(eviction_pending_)
+    evictIfOverBudget();
   // [camp#142] Keep the Auto resolved range current with the freshly-folded
   // extents (a no-op while the operator holds a Manual override, so an incoming
   // tile never disturbs a pinned range). camp#138 coordination: this is the
@@ -1236,7 +1345,8 @@ QList<RasterFieldItem> GggsTileLayer::itemsIntersecting(const QRectF& clip_scene
   //    region whose only native level is finer than the selection does not
   //    load (levels > selection never load — the viewport-bounded tradeoff)
   //    and renders blank at coarser zooms even though sceneBounds() includes
-  //    its footprint; the residency/coverage follow-up family is camp#195;
+  //    its footprint (the coverage half of the old camp#195 family, still
+  //    unaddressed — camp#195 settled residency only, ADR-0014);
   //  - zoom-in: the stale coarser levels back the arriving selected level
   //    (unchanged from camp#103's progressive refinement);
   //  - zoom-out: the still-resident finer tiles draw ABOVE the coarse levels

--- a/src/camp_map/raster/gggs_tile_layer.cpp
+++ b/src/camp_map/raster/gggs_tile_layer.cpp
@@ -106,8 +106,7 @@ GggsTileLayer::GggsTileLayer(map::MapItem* parentItem, const QString& directory)
     setTransform(QTransform::fromScale(1.0, -1.0));
     setPos(QPointF(scene_bounds_.left(), scene_bounds_.bottom()));   // NW corner
   }
-  else
-    setStatus("(no tiles)");
+  updateStatus();
 }
 
 GggsTileLayer::~GggsTileLayer()
@@ -458,7 +457,8 @@ void GggsTileLayer::loadTiles()
   abort_flag_ = false;   // re-arm for the new job
   abort_flag_mutex_.unlock();
 
-  setStatus("(loading...)");
+  loading_ = true;
+  updateStatus();
   // [camp#103] Snapshot the demand-driven filter into value copies the worker
   // owns — paint() reassigns the live members every frame while the worker runs,
   // so member reads from the worker thread would race. Record the kick's filter
@@ -613,6 +613,110 @@ void GggsTileLayer::foldDataRange(bool reset)
   }
 }
 
+std::vector<QRectF> GggsTileLayer::failedFootprints() const
+{
+  // [camp#194/#195] Scene rects of the tiles at levels <= the selection whose
+  // read failed terminally — the holes in the composited picture. Shared by
+  // tilesReady()'s release gate and the residency budget's eviction pass so the
+  // "keep the only usable coverage over a hole" rule is stated once.
+  // With no selection (-1) there is no ceiling and no release/eviction level
+  // asymmetry to protect against, so the set is empty.
+  std::vector<QRectF> rects;
+  if(selected_level_ == -1)
+    return rects;
+  for(const auto& tile : tiles_)
+    if(tile->loadFailed() && tile->level() <= selected_level_)
+      rects.push_back(tileSceneRect(*tile));
+  return rects;
+}
+
+bool GggsTileLayer::coversHole(const GggsTile& tile,
+                               const std::vector<QRectF>& holes) const
+{
+  // [camp#194/#195] True if @p tile is FINER than the selection and overlaps a
+  // hole — i.e. it is the only usable coverage over a footprint whose
+  // selected-or-coarser tile failed to read. Tiles at or below the selection are
+  // not hole coverers: they ARE the picture (and the failed tile's own level).
+  if(holes.empty() || selected_level_ == -1 || tile.level() <= selected_level_)
+    return false;
+  const QRectF tile_rect = tileSceneRect(tile);
+  return std::any_of(holes.begin(), holes.end(),
+                     [&tile_rect](const QRectF& hole)
+                     { return hole.intersects(tile_rect); });
+}
+
+bool GggsTileLayer::releaseTiles(const std::vector<GggsTile*>& victims)
+{
+  // [camp#195] The single release path, extracted from tilesReady() and shared
+  // with the residency budget's evictIfOverBudget(). GUI thread only, and only
+  // with no loader worker running — both callers gate on that, because this
+  // mutates tiles the worker iterates.
+  //
+  // [camp#194] resetPixels()/releaseGL() pairing invariant (gggs_tile.h): a
+  // CPU-only clear on a tile that already uploaded its texture leaves a stale
+  // texture shadowing any re-load (texture() returns the old one and never
+  // consumes the new data_). With NO context yet (hasContext() == false) no tile
+  // can have a texture, so the CPU half alone IS the complete release — this is
+  // also the headless-test case. But if a context EXISTS and makeCurrent()
+  // FAILED, textures may well exist and we cannot free them, so release NOTHING
+  // rather than break the pairing: over-retention costs residency until the next
+  // successful pass, a broken pairing costs correctness. (The renderer has
+  // latched its GL-failed flag in that case anyway, so nothing is rendering.)
+  Q_ASSERT(thread() == QThread::currentThread());
+  if(victims.empty())
+    return false;
+  const bool have_context = renderer_.hasContext() && renderer_.makeCurrent();
+  if(renderer_.hasContext() && !have_context)
+    return false;
+  for(GggsTile* tile : victims)
+  {
+    if(have_context)
+      tile->releaseGL();
+    tile->resetPixels();
+  }
+  if(have_context)
+    renderer_.doneCurrent();
+  return true;
+}
+
+void GggsTileLayer::updateStatus()
+{
+  // [camp#195] THE status composer. Every condition the layer can report is
+  // assembled here from live state, so no writer can clobber another's message
+  // (tilesReady() previously rewrote the status unconditionally, which would
+  // have wiped the residency budget's over-budget report).
+  if(tiles_.empty())
+  {
+    setStatus("(no tiles)");
+    return;
+  }
+  if(loading_)
+  {
+    setStatus("(loading...)");
+    return;
+  }
+  if(!load_started_)
+  {
+    setStatus("");   // nothing attempted yet — not "no data"
+    return;
+  }
+  QStringList parts;
+  // [camp#102] A crossed range after the fold means every loaded tile was
+  // all-NoData (or failed to read): there is nothing to draw, and a clear status
+  // would leave a silently-blank enabled layer.
+  if(data_min_ > data_max_)
+    parts << "no data";
+  // [camp#194] Terminally-unreadable tiles. Counted over the WHOLE tile-set (not
+  // the visible/selected set) so the number does not flicker with the viewport.
+  int failed = 0;
+  for(const auto& tile : tiles_)
+    if(tile->loadFailed())
+      ++failed;
+  if(failed > 0)
+    parts << QString("%1 tile(s) failed to load").arg(failed);
+  setStatus(parts.isEmpty() ? QString() : "(" + parts.join("; ") + ")");
+}
+
 void GggsTileLayer::tilesReady()
 {
   // [camp#102] GUI thread, after the worker's join. Fold the freshly-loaded
@@ -661,11 +765,8 @@ void GggsTileLayer::tilesReady()
     // NOT a coverage/eviction policy: a region with NO coarse tile at all still
     // releases and blanks per the documented residency rule (ADR-0013 "Render");
     // that family is camp#195.
-    std::vector<QRectF> failed_rects;
-    for(const auto& tile : tiles_)
-      if(tile->loadFailed() && tile->level() <= selected_level_)
-        failed_rects.push_back(tileSceneRect(*tile));
-    bool have_context = false, context_tried = false;
+    const std::vector<QRectF> failed_rects = failedFootprints();
+    std::vector<GggsTile*> victims;
     for(auto& tile : tiles_)
     {
       // NOTE: this comparison carries NO -1 guard of its own, unlike every
@@ -679,64 +780,21 @@ void GggsTileLayer::tilesReady()
         continue;
       // [camp#194 review] Keep this finer tile if it is the only coverage over a
       // footprint whose selected-or-coarser tile failed to read (see above).
-      if(!failed_rects.empty())
-      {
-        const QRectF tile_rect = tileSceneRect(*tile);
-        const bool over_hole =
-          std::any_of(failed_rects.begin(), failed_rects.end(),
-                      [&tile_rect](const QRectF& hole)
-                      { return hole.intersects(tile_rect); });
-        if(over_hole)
-          continue;
-      }
-      if(!context_tried)
-      {
-        context_tried = true;
-        have_context = renderer_.hasContext() && renderer_.makeCurrent();
-        // [camp#194] resetPixels()/releaseGL() pairing invariant (gggs_tile.h):
-        // a CPU-only clear on a tile that already uploaded its texture leaves a
-        // stale texture shadowing any re-load (texture() returns the old one and
-        // never consumes the new data_). With NO context yet (hasContext() ==
-        // false) no tile can have a texture, so the CPU half alone IS the
-        // complete release. But if a context EXISTS and makeCurrent() FAILED,
-        // textures may well exist and we cannot free them — so skip the release
-        // entirely rather than breaking the pairing. Leaving the finer level
-        // resident is harmless (it is drawn under the compositing rules and
-        // released at the next successful pass), and the renderer has latched
-        // its GL-failed flag anyway, so nothing is being rendered meanwhile.
-        if(renderer_.hasContext() && !have_context)
-          break;
-      }
-      if(have_context)
-        tile->releaseGL();
-      tile->resetPixels();
+      // [camp#195] The hole predicate is shared with the residency budget's
+      // eviction pass (coversHole()) so the two retention rules cannot drift.
+      if(coversHole(*tile, failed_rects))
+        continue;
+      victims.push_back(tile.get());
     }
-    if(have_context)
-      renderer_.doneCurrent();
+    releaseTiles(victims);
   }
   cached_image_ = QImage();   // re-render now that pixels (and the range) exist
-  // [camp#194] Surface terminally-unreadable tiles. Now that loadFailed() tiles
-  // are excluded from hasUnloadedVisibleTiles(), the loader correctly goes idle
-  // with them missing — so without this the operator would see a settled,
-  // status-clear layer with silent holes in it. Count over the whole tile-set
-  // (not just the visible/selected set) so the number does not flicker with the
-  // viewport.
-  int failed = 0;
-  for(const auto& tile : tiles_)
-    if(tile->loadFailed())
-      ++failed;
-  // [camp#102] If the range is still crossed after the fold, every loaded tile was
-  // all-NoData (or failed to read): there is nothing to draw and clearing the
-  // status would leave a silently-blank enabled layer. Signal "(no data)" so the
-  // operator can tell an empty tile-set from one that simply hasn't loaded yet.
-  if(data_min_ > data_max_)
-    setStatus(failed > 0
-              ? QString("(no data; %1 tile(s) failed to load)").arg(failed)
-              : QString("(no data)"));
-  else if(failed > 0)
-    setStatus(QString("(%1 tile(s) failed to load)").arg(failed));
-  else
-    setStatus("");
+  // [camp#195] The load has settled; every status condition (failed tiles, no
+  // data, over budget, released hole coverage) is composed in ONE place —
+  // updateStatus(). This slot used to write setStatus() unconditionally, which
+  // would silently wipe an over-budget message written from paint().
+  loading_ = false;
+  updateStatus();
   // [camp#142] Keep the Auto resolved range current with the freshly-folded
   // extents (a no-op while the operator holds a Manual override, so an incoming
   // tile never disturbs a pinned range). camp#138 coordination: this is the

--- a/src/camp_map/raster/gggs_tile_layer.cpp
+++ b/src/camp_map/raster/gggs_tile_layer.cpp
@@ -17,6 +17,7 @@
 #include <QSet>
 #include <QThread>
 #include <QSettings>
+#include <QTimer>
 #include <QOpenGLTexture>
 #include <QPainter>
 #include <QTransform>
@@ -70,6 +71,18 @@ QRectF tileSceneRect(const camp::raster::GggsTile& tile)
   return QRectF(lo, hi).normalized();
 }
 
+// [camp#195] Squared distance from @p point to the nearest point of @p rect —
+// 0 while the point is inside. The eviction metric (farthest-from-the-viewport-
+// centre first), squared to avoid a sqrt in the sort comparator.
+double rectDistanceSquared(const QRectF& rect, const QPointF& point)
+{
+  const double dx = std::max({rect.left() - point.x(), 0.0,
+                              point.x() - rect.right()});
+  const double dy = std::max({rect.top() - point.y(), 0.0,
+                              point.y() - rect.bottom()});
+  return dx * dx + dy * dy;
+}
+
 }  // namespace
 
 GggsTileLayer::GggsTileLayer(map::MapItem* parentItem, const QString& directory):
@@ -83,6 +96,17 @@ GggsTileLayer::GggsTileLayer(map::MapItem* parentItem, const QString& directory)
   // which is path-agnostic, so the absolute path works unchanged.
   directory_(QDir(directory).absolutePath())
 {
+  // [camp#195 / uma-ADR-0013 D4] Resident tile-footprint budget for eviction.
+  // Default 512 MiB, operator-overridable (camp#117: a default, never an
+  // un-changeable hardcode); 0 disables eviction (the pre-#195 unbounded
+  // behaviour). Mirrors LiveTileCache/max_vram_bytes, whose default is the same
+  // 512 MiB — the two working sets are co-resident, and the key exists so the
+  // pair can be tuned on the operator station rather than in a rebuild.
+  QSettings settings;
+  resident_budget_bytes_ = static_cast<std::size_t>(
+    settings.value("GggsTileLayers/max_resident_bytes",
+                   kDefaultResidentBudgetBytes).toULongLong());
+
   // [camp#102] tilesReady() folds completed tiles' ranges + repaints on the GUI
   // thread when the async pixel load finishes.
   connect(&future_watcher_, &QFutureWatcher<void>::finished, this,
@@ -714,7 +738,267 @@ void GggsTileLayer::updateStatus()
       ++failed;
   if(failed > 0)
     parts << QString("%1 tile(s) failed to load").arg(failed);
+  // [camp#195 / uma-ADR-0013 D4] "Report the degraded state; never fail
+  // silently." The cap is FLOORED at the current-frame working set, so when that
+  // set alone exceeds the byte budget the layer does not evict what it is
+  // drawing (that is D4's "thrashes by construction") — it exceeds the budget
+  // and says so. Relaxing the quality target under this pressure — D4's tau
+  // lever — is camp#197.
+  if(over_budget_)
+    parts << "over the tile budget - raise GggsTileLayers/max_resident_bytes or zoom in";
+  // [camp#195] An evicted camp#194 hole coverer cannot come back on its own:
+  // loadTilesWorker() skips levels finer than the selection, so the demand-driven
+  // reload that makes every other eviction free does not apply to this one class.
+  // Surface the loss with the operator's recovery action rather than losing the
+  // coverage silently.
+  if(hole_coverage_released_)
+    parts << "coverage over failed tile(s) released - use Rescan";
   setStatus(parts.isEmpty() ? QString() : "(" + parts.join("; ") + ")");
+}
+
+std::size_t GggsTileLayer::residentTileCount() const
+{
+  std::size_t count = 0;
+  for(const auto& tile : tiles_)
+    if(tile->pixelsLoaded())
+      ++count;
+  return count;
+}
+
+std::size_t GggsTileLayer::perTileResidentBytes() const
+{
+  // [camp#195] Observed, never assumed (see the header). The largest tile in the
+  // set speaks so a non-uniform store cannot undercount the budget.
+  std::size_t max_pixels = 0;
+  for(const auto& tile : tiles_)
+    if(tile->valid())
+      max_pixels = std::max(max_pixels, std::size_t(tile->width()) *
+                                          std::size_t(tile->height()));
+  if(max_pixels == 0)
+    return 0;
+  // CPU Float32 buffer + R32F texture of the same extent (gggs_tile.cpp: the CPU
+  // copy is deliberately retained past the GPU upload for camp#180).
+  return max_pixels * sizeof(float) * 2;
+}
+
+std::size_t GggsTileLayer::budgetTiles() const
+{
+  const std::size_t per_tile = perTileResidentBytes();
+  if(resident_budget_bytes_ == 0 || per_tile == 0)
+    return 0;   // disabled, or nothing to measure yet
+  return std::max<std::size_t>(1, resident_budget_bytes_ / per_tile);
+}
+
+std::size_t GggsTileLayer::refreshProtection()
+{
+  // [camp#195 / uma-ADR-0013 D4] Re-derive the frame's protected working set.
+  // The predicate is the LOADER's, not the draw list's — see the header.
+  Q_ASSERT(thread() == QThread::currentThread());
+  residency_.sync(tiles_.size());
+  tile_last_visible_gen_.resize(tiles_.size(), 0);
+  residency_.beginFrame();
+  ++paint_generation_;
+
+  const std::vector<QRectF> holes = failedFootprints();
+  for(std::size_t i = 0; i < tiles_.size(); ++i)
+  {
+    const GggsTile& tile = *tiles_[i];
+    // A terminally-failed tile never becomes resident, so protecting it would
+    // inflate the cap floor with memory nothing will ever occupy.
+    if(tile.loadFailed())
+      continue;
+    if(!load_viewport_.isNull() &&
+       !tileSceneRect(tile).intersects(load_viewport_))
+      continue;
+    // Levels finer than the selection are not part of the picture — EXCEPT a
+    // camp#194 hole coverer, which is the only usable coverage over a footprint
+    // whose selected-or-coarser tile failed to read.
+    if(selected_level_ != -1 && tile.level() > selected_level_ &&
+       !coversHole(tile, holes))
+      continue;
+    residency_.protect(i);
+    tile_last_visible_gen_[i] = paint_generation_;
+  }
+  return residency_.protectedCount();
+}
+
+void GggsTileLayer::scheduleEvictionIfNeeded(std::size_t protected_count)
+{
+  // [camp#195] paint()'s half: publish the over-budget state and QUEUE the
+  // eviction. Nothing is released here — releasing a tile inside paint() would
+  // mutate the set the render pass reads.
+  const std::size_t budget = budgetTiles();
+  const bool over = (budget != 0 && protected_count > budget);
+  if(over != over_budget_)
+  {
+    over_budget_ = over;
+    updateStatus();
+  }
+  if(budget == 0 || eviction_pending_)
+    return;
+  // The cap is floored at the working set (D4), so a frame whose own selection
+  // exceeds the budget schedules nothing — there is nothing evictable to gain.
+  if(residentTileCount() <= std::max(budget, protected_count))
+    return;
+  eviction_pending_ = true;
+  QMetaObject::invokeMethod(this, "evictIfOverBudget", Qt::QueuedConnection);
+}
+
+void GggsTileLayer::evictIfOverBudget()
+{
+  // [camp#195 / uma-ADR-0013 D4] The eviction pass. GUI thread, off the event
+  // loop (or called directly by a headless test through
+  // refreshResidencyForTest()).
+  Q_ASSERT(thread() == QThread::currentThread());
+  eviction_pending_ = false;
+  if(budgetTiles() == 0)
+    return;
+
+  // This mutates tiles the loader worker iterates, so it must not run
+  // concurrently with it. RE-ARM rather than drop the request: a continuous pan
+  // re-kicks the loader every step, so a dropped request would mean the budget
+  // almost never fires in exactly the scenario it exists for. (Abort+join, what
+  // loadTiles() does, is rejected: a GUI-thread stall for a whole tile read,
+  // mid-pan.)
+  if(future_watcher_.isRunning())
+  {
+    eviction_pending_ = true;
+    QTimer::singleShot(kEvictionRetryMs, this, &GggsTileLayer::evictIfOverBudget);
+    return;
+  }
+
+  // Re-derive the protected set LIVE (the MapTiles/camp#98 rule): a tile that
+  // re-entered the view between scheduling and now must never be evicted, and
+  // the protection recorded at schedule time may be several pan steps stale.
+  const std::size_t protected_count = refreshProtection();
+  const std::size_t budget = budgetTiles();
+  over_budget_ = protected_count > budget;
+  const std::size_t cap = std::max(budget, protected_count);
+  const std::size_t resident = residentTileCount();
+  if(resident <= cap)
+  {
+    updateStatus();
+    return;
+  }
+
+  if(!eviction_warned_)
+  {
+    qWarning().noquote() << "[gggs" << directory_ << "] resident tile budget"
+                         << "exceeded (" << qulonglong(resident) << ">"
+                         << qulonglong(cap) << "tiles,"
+                         << qulonglong(perTileResidentBytes())
+                         << "bytes each) - evicting off-viewport tiles";
+    eviction_warned_ = true;
+  }
+
+  // Evict down to the hysteresis target so the next frame cannot immediately
+  // re-trigger (the kReloadHysteresisFactor analogue), but never below the
+  // protected working set.
+  const std::size_t target =
+    std::max(protected_count, std::size_t(kEvictHysteresisFactor * double(cap)));
+
+  const std::vector<QRectF> holes = failedFootprints();
+  const bool have_centre = !load_viewport_.isNull();
+  const QPointF centre = load_viewport_.center();
+  const bool have_ladder = available_levels_.size() > 1;
+  const int coarsest_level = have_ladder ? available_levels_.front() : -1;
+
+  struct Candidate
+  {
+    std::size_t index = 0;
+    int tier = 0;         // 0 = ordinary, 1 = last resort
+    int recent = 0;       // 0 = stale (evict first), 1 = seen recently
+    double distance = 0;  // squared, from the viewport centre
+    quint64 generation = 0;
+  };
+  std::vector<Candidate> candidates;
+  std::vector<Candidate> coarsest_tiles;
+  candidates.reserve(tiles_.size());
+  // residency_.candidates() is the evictable partition ONLY — the current
+  // frame's protected set is structurally unreachable from here (D4).
+  for(const std::size_t index : residency_.candidates())
+  {
+    const GggsTile& tile = *tiles_[index];
+    if(!tile.pixelsLoaded())
+      continue;   // nothing resident to free
+    Candidate candidate;
+    candidate.index = index;
+    candidate.generation = tile_last_visible_gen_[index];
+    candidate.distance =
+      have_centre ? rectDistanceSquared(tileSceneRect(tile), centre) : 0.0;
+    candidate.recent =
+      (paint_generation_ - candidate.generation) <= kRecentGenerations ? 1 : 0;
+    // An out-of-view camp#194 hole coverer is a LAST-RESORT candidate: unlike
+    // every other tile it cannot reload on pan-back (loadTilesWorker skips
+    // levels finer than the selection), so it is dropped only when nothing else
+    // can be, and its loss is reported (updateStatus).
+    candidate.tier = coversHole(tile, holes) ? 1 : 0;
+    if(have_ladder && tile.level() == coarsest_level)
+      coarsest_tiles.push_back(candidate);
+    else
+      candidates.push_back(candidate);
+  }
+
+  // The zoom-out floor, BOUNDED: the nearest kCoarsestExemptCap coarsest-level
+  // tiles are exempt so a zoom-out always has something to draw; the surplus —
+  // which is what grows with the area panned — joins the last-resort tier
+  // rather than accumulating forever. On a single-level store there is no
+  // ladder and hence no exemption, so the budget is not a no-op there.
+  if(coarsest_tiles.size() > kCoarsestExemptCap)
+  {
+    std::sort(coarsest_tiles.begin(), coarsest_tiles.end(),
+              [](const Candidate& a, const Candidate& b)
+              {
+                if(a.distance != b.distance)
+                  return a.distance < b.distance;   // nearest kept
+                return a.generation > b.generation; // then freshest kept
+              });
+    for(std::size_t k = kCoarsestExemptCap; k < coarsest_tiles.size(); ++k)
+    {
+      Candidate surplus = coarsest_tiles[k];
+      surplus.tier = 1;
+      candidates.push_back(surplus);
+    }
+  }
+
+  // Hybrid ordering (uma-ADR-0013 D4): last-resort tier last; then STALENESS,
+  // so a tile not seen for a while goes before one just traversed (D4's
+  // objection to distance-only is that it "discards history along a path being
+  // traversed"); then farthest-from-viewport first; then LRU generation.
+  std::sort(candidates.begin(), candidates.end(),
+            [](const Candidate& a, const Candidate& b)
+            {
+              if(a.tier != b.tier) return a.tier < b.tier;
+              if(a.recent != b.recent) return a.recent < b.recent;
+              if(a.distance != b.distance) return a.distance > b.distance;
+              return a.generation < b.generation;
+            });
+
+  std::vector<GggsTile*> victims;
+  bool released_hole_coverage = false;
+  for(const Candidate& candidate : candidates)
+  {
+    if(resident - victims.size() <= target)
+      break;
+    GggsTile* tile = tiles_[candidate.index].get();
+    victims.push_back(tile);
+    if(coversHole(*tile, holes))
+      released_hole_coverage = true;
+  }
+
+  // The auto-range is deliberately NOT recomputed here: the fold is
+  // widening-only (foldDataRange), so re-deriving it from a shrinking resident
+  // set would make the colormap flicker as tiles come and go. An evicted tile's
+  // contribution stays true — its pixels are unchanged on disk, which is exactly
+  // what distinguishes eviction from rescan()'s file-replacement case.
+  if(releaseTiles(victims))
+  {
+    if(released_hole_coverage)
+      hole_coverage_released_ = true;
+    cached_image_ = QImage();
+    update(boundingRect());
+  }
+  updateStatus();
 }
 
 void GggsTileLayer::tilesReady()
@@ -1044,6 +1328,19 @@ void GggsTileLayer::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QW
   //    re-kicking every frame, and kicking only when idle avoids the
   //    abort+join stall a pan storm would otherwise pay per frame).
   load_viewport_ = clip.scene;
+
+  // [camp#195 / uma-ADR-0013 D4] Protect this frame's working set and schedule
+  // the residency pass. Placement is load-bearing on both sides:
+  //  - AFTER load_viewport_ is set, because the protection predicate IS the
+  //    loader's filter (level <= selection, intersecting the load viewport);
+  //  - BEFORE every remaining early return (the crossed-range return below),
+  //    because refreshProtection() begins by splicing the whole protected
+  //    partition back into the evictable one — returning between beginFrame()
+  //    and protect() would leave the live visible set evictable.
+  // The tiles_.empty() return at the top of paint() is vacuous here: with no
+  // tiles there is nothing to protect and nothing to evict.
+  scheduleEvictionIfNeeded(refreshProtection());
+
   if(!load_started_)
   {
     load_started_ = true;

--- a/src/camp_map/raster/gggs_tile_layer.h
+++ b/src/camp_map/raster/gggs_tile_layer.h
@@ -199,6 +199,14 @@ public:
   /// paints, so it drives the pass directly.
   void refreshResidencyForTest() { evictIfOverBudget(); }
 
+  /// [camp#195] Test-only: run paint()'s HALF of the residency pass — protect
+  /// the current frame's set and SCHEDULE the eviction — without a
+  /// QGraphicsView. Exercises the debounce and the queued hop, so a test can
+  /// assert the deferred path converges after
+  /// `QCoreApplication::processEvents()` rather than only the synchronous
+  /// refreshResidencyForTest() shortcut.
+  void scheduleResidencyForTest() { scheduleEvictionIfNeeded(refreshProtection()); }
+
   /// [camp#103/#194] True if any tile at a level <= the selected level
   /// intersects @p viewport_scene (Web-Mercator scene rect) with its pixels
   /// not yet loaded — the pan/zoom re-kick condition for the demand-driven
@@ -360,12 +368,20 @@ private:
   /// [camp#195 / uma-ADR-0013 D4] Re-derive the current frame's protected
   /// working set into residency_ and return its size. The predicate is the
   /// LOADER's, not the draw list's: tiles intersecting load_viewport_ at a level
-  /// <= the selection (plus camp#194 hole coverers). It must not be the draw
-  /// list — `cached_image_` short-circuits itemsIntersecting() on a static
-  /// frame, so a draw-list-sourced protection would protect NOTHING on exactly
-  /// the frames eviction runs on. Not-yet-loaded tiles count: they are part of
-  /// the working set the cap must accommodate. loadFailed() tiles do not: they
-  /// never become resident, so they must not inflate the floor.
+  /// <= the selection. It must not be the draw list — `cached_image_`
+  /// short-circuits itemsIntersecting() on a static frame, so a
+  /// draw-list-sourced protection would protect NOTHING on exactly the frames
+  /// eviction runs on. Not-yet-loaded tiles count: they are part of the working
+  /// set the cap must accommodate. loadFailed() tiles do not: they never become
+  /// resident, so they must not inflate the floor.
+  ///
+  /// Two classes of in-view tile FINER than the selection are protected on top
+  /// of the loader's set, because both are drawn and neither can reload
+  /// (loadTilesWorker skips level > selection): an already-RESIDENT finer tile,
+  /// which during a zoom-out is the whole visible picture until the coarser
+  /// selection loads (the camp#103/#194 no-blank-frame guarantee — and
+  /// tilesReady()'s level-switch release still drops it at the right moment, so
+  /// this leaks nothing); and a camp#194 hole coverer.
   std::size_t refreshProtection();
   /// [camp#195] The budget expressed as a tile count: the byte budget divided by
   /// the OBSERVED per-tile resident cost. 0 means unbounded (budget disabled, or
@@ -484,6 +500,16 @@ private:
   bool eviction_warned_ = false;        // one qWarning per layer, not per pass
   bool over_budget_ = false;            // protected set alone exceeds the budget
   bool hole_coverage_released_ = false; // a camp#194 hole coverer was evicted
+  // Set when releaseTiles() refused because a live GL context would not become
+  // current. RasterGlRenderer latches that failure without destroying the
+  // context, so the condition can be permanent and the budget stops being
+  // enforced entirely — which the status must say rather than grow silently.
+  bool eviction_blocked_ = false;
+  // Memoized perTileResidentBytes(), keyed on tiles_.size(). Tile extents are
+  // immutable after their metadata read and tiles_ only ever grows, so the size
+  // is a sufficient key — and this is on the paint path.
+  mutable std::size_t per_tile_bytes_ = 0;
+  mutable std::size_t per_tile_bytes_count_ = std::size_t(-1);
 };
 
 }  // namespace raster

--- a/src/camp_map/raster/gggs_tile_layer.h
+++ b/src/camp_map/raster/gggs_tile_layer.h
@@ -298,6 +298,28 @@ private:
   /// spatial filter (both together = the pre-LOD "load everything" behavior the
   /// headless tests rely on).
   void loadTilesWorker(int level, QRectF viewport);
+  /// [camp#194/#195] Scene rects of the terminally-failed tiles at levels <= the
+  /// selection — the holes in the composited picture. Empty with no selection.
+  std::vector<QRectF> failedFootprints() const;
+  /// [camp#194/#195] True if @p tile is finer than the selection and overlaps
+  /// one of @p holes, i.e. it is the only usable coverage over a footprint whose
+  /// selected-or-coarser tile failed to read. Shared by tilesReady()'s release
+  /// gate and the residency budget's eviction pass so the two retention rules
+  /// cannot drift apart.
+  bool coversHole(const GggsTile& tile, const std::vector<QRectF>& holes) const;
+  /// [camp#195] The single tile-release path: `releaseGL()` + `resetPixels()`
+  /// under this layer's GL context, with the makeCurrent()-or-skip dance that
+  /// keeps the gggs_tile.h pairing invariant intact. GUI thread only, and only
+  /// with no loader worker running (it mutates tiles the worker iterates —
+  /// both callers gate on that). Returns true if anything was released; false
+  /// when there were no victims or a live context refused to become current
+  /// (in which case NOTHING is released, deliberately).
+  bool releaseTiles(const std::vector<GggsTile*>& victims);
+  /// [camp#195] THE status composer. Every condition the layer reports (no
+  /// tiles / loading / no data / failed tiles) is assembled here from live
+  /// state, so no writer can clobber another's message. Call this instead of
+  /// setStatus() — tilesReady() used to rewrite the status unconditionally.
+  void updateStatus();
 
   // [camp#134] Latitude tessellation moved into RasterGlRenderer (the shared warp).
   static constexpr int kMaxImageEdge = 4096;   // clamp the offscreen target
@@ -352,6 +374,11 @@ private:
   bool abort_flag_ = false;
   QMutex abort_flag_mutex_;
   bool load_started_ = false;  // first paint() kicks the load exactly once
+  // [camp#195] Load-in-flight flag feeding updateStatus()'s "(loading...)".
+  // A flag rather than future_watcher_.isRunning(): tilesReady() runs from the
+  // watcher's finished signal, where isRunning() is already false, and
+  // waitForLoad() calls tilesReady() directly after a join.
+  bool loading_ = false;
 
   // [camp#103] Last render, keyed by FBO size AND viewport clip: zoom changes the
   // size, pan changes the clip, so both re-render. (Pre-#103, pan reused the

--- a/src/camp_map/raster/gggs_tile_layer.h
+++ b/src/camp_map/raster/gggs_tile_layer.h
@@ -505,9 +505,11 @@ private:
   // context, so the condition can be permanent and the budget stops being
   // enforced entirely — which the status must say rather than grow silently.
   bool eviction_blocked_ = false;
-  // Memoized perTileResidentBytes(), keyed on tiles_.size(). Tile extents are
-  // immutable after their metadata read and tiles_ only ever grows, so the size
-  // is a sufficient key — and this is on the paint path.
+  // Memoized perTileResidentBytes(), keyed on tiles_.size() — this is on the
+  // paint path. tiles_ only ever grows, so the size covers every ADDED tile.
+  // It does NOT cover a refresh: [camp#194] GggsTile::refreshFromFile() re-reads
+  // metadata and a replacement file may carry different dimensions while the
+  // count stays put, so rescan() invalidates this explicitly after refreshing.
   mutable std::size_t per_tile_bytes_ = 0;
   mutable std::size_t per_tile_bytes_count_ = std::size_t(-1);
 };

--- a/src/camp_map/raster/gggs_tile_layer.h
+++ b/src/camp_map/raster/gggs_tile_layer.h
@@ -4,6 +4,7 @@
 #include "../map/layer.h"
 #include "raster_field_source.h"
 #include "raster_gl_renderer.h"
+#include "tile_residency.h"
 
 #include <marine_colormap/transfer.hpp>
 
@@ -178,6 +179,26 @@ public:
   /// [camp#103] Test-only: number of tiles at @p level whose pixels are loaded.
   int pixelsLoadedCount(int level) const;
 
+  /// [camp#195] Number of tiles currently holding pixels — the quantity the
+  /// residency budget bounds. Cheap (a flag test per tile); exposed for tests
+  /// and for diagnostics.
+  std::size_t residentTileCount() const;
+
+  /// [camp#195] Test-only: override the residency budget in BYTES (0 disables
+  /// eviction entirely — the pre-#195 behaviour). Mirrors
+  /// SonarLiveCacheLayer::setResidentBudgetForTest(); the production value comes
+  /// from `QSettings GggsTileLayers/max_resident_bytes`.
+  void setResidentBudgetBytesForTest(std::size_t bytes)
+  {
+    resident_budget_bytes_ = bytes;
+  }
+
+  /// [camp#195] Test-only: run the residency pass synchronously — the headless
+  /// analogue of paint()'s protect-then-schedule plus the queued
+  /// evictIfOverBudget() slot. A headless test has no event loop turn between
+  /// paints, so it drives the pass directly.
+  void refreshResidencyForTest() { evictIfOverBudget(); }
+
   /// [camp#103/#194] True if any tile at a level <= the selected level
   /// intersects @p viewport_scene (Web-Mercator scene rect) with its pixels
   /// not yet loaded — the pan/zoom re-kick condition for the demand-driven
@@ -249,6 +270,22 @@ private slots:
   /// [camp#102] Fold completed tiles' ranges into data_min_/data_max_, mark them
   /// pixelsLoaded(), invalidate the cache, and repaint.
   void tilesReady();
+  /// [camp#195 / uma-ADR-0013 D4] Deferred, debounced residency eviction.
+  /// paint() only SCHEDULES this (queued invocation + eviction_pending_):
+  /// releasing a tile inside paint() would mutate the set the render pass is
+  /// reading. Running from the event loop, it re-derives the protected working
+  /// set LIVE (a tile that re-entered the view since scheduling must never be
+  /// evicted — the MapTiles/camp#98 rule), computes the cap, and releases
+  /// candidates farthest/stalest-first down to the hysteresis target.
+  ///
+  /// It must not mutate tiles the loader worker is iterating, so it checks
+  /// `future_watcher_.isRunning()` — and when the worker IS busy it **re-arms**
+  /// on a short timer with the debounce still held, rather than dropping the
+  /// request. Dropping it would make the budget almost never fire during a
+  /// continuous pan (every pan step re-kicks the loader), which is precisely
+  /// the scenario the budget exists for. Abort+join (what loadTiles() does) is
+  /// rejected here: it would stall the GUI thread mid-pan for a whole tile read.
+  void evictIfOverBudget();
 
 private:
   /// [camp#108] The non-persisting band switch shared by setBand() (persists
@@ -320,6 +357,31 @@ private:
   /// state, so no writer can clobber another's message. Call this instead of
   /// setStatus() — tilesReady() used to rewrite the status unconditionally.
   void updateStatus();
+  /// [camp#195 / uma-ADR-0013 D4] Re-derive the current frame's protected
+  /// working set into residency_ and return its size. The predicate is the
+  /// LOADER's, not the draw list's: tiles intersecting load_viewport_ at a level
+  /// <= the selection (plus camp#194 hole coverers). It must not be the draw
+  /// list — `cached_image_` short-circuits itemsIntersecting() on a static
+  /// frame, so a draw-list-sourced protection would protect NOTHING on exactly
+  /// the frames eviction runs on. Not-yet-loaded tiles count: they are part of
+  /// the working set the cap must accommodate. loadFailed() tiles do not: they
+  /// never become resident, so they must not inflate the floor.
+  std::size_t refreshProtection();
+  /// [camp#195] The budget expressed as a tile count: the byte budget divided by
+  /// the OBSERVED per-tile resident cost. 0 means unbounded (budget disabled, or
+  /// no valid tile to measure yet).
+  std::size_t budgetTiles() const;
+  /// [camp#195] Bytes a loaded tile occupies, observed from the tile-set rather
+  /// than assumed: width_/height_ come from GDAL, so 960x960 is a store
+  /// convention, not a guarantee. A loaded tile holds its Float32 CPU buffer
+  /// (retained past the GPU upload for camp#180's cursor readout) and, once
+  /// painted, an R32F texture of the same size — so the displayed cost is
+  /// 2 x w x h x 4. The largest tile in the set speaks, so a non-uniform store
+  /// cannot undercount. 0 if no valid tile exists yet.
+  std::size_t perTileResidentBytes() const;
+  /// [camp#195] Update over_budget_ from @p protected_count and queue an
+  /// eviction pass when residency exceeds the cap. Called from paint().
+  void scheduleEvictionIfNeeded(std::size_t protected_count);
 
   // [camp#134] Latitude tessellation moved into RasterGlRenderer (the shared warp).
   static constexpr int kMaxImageEdge = 4096;   // clamp the offscreen target
@@ -387,6 +449,41 @@ private:
   QImage cached_image_;
   QSize cached_size_;
   QRectF cached_clip_;
+
+  // ---- [camp#195 / uma-ADR-0013 D4] Viewport-scoped retention -------------
+  // Default residency budget in BYTES. A byte target rather than a tile count
+  // because width_/height_ come from GDAL (960x960 is a store convention, not a
+  // guarantee) and because it is then directly comparable to the co-resident
+  // LiveTileCache/max_vram_bytes, which carries the same 512 MiB default.
+  // Operator-overridable via QSettings (camp#117: a default, never an
+  // un-changeable hardcode); 0 disables eviction (the pre-#195 behaviour).
+  static constexpr qulonglong kDefaultResidentBudgetBytes = 512ull * 1024 * 1024;
+  // Evict down to this fraction of the cap so the next frame cannot immediately
+  // re-trigger (the SonarLiveCacheLayer kReloadHysteresisFactor analogue).
+  static constexpr double kEvictHysteresisFactor = 0.75;
+  // The zoom-out floor: tiles at the coarsest available level are exempt (the
+  // kApexProtectLevel analogue) — but BOUNDED, because that set grows with the
+  // area panned. Beyond this many, the farthest coarsest tiles become
+  // last-resort candidates rather than exemptions. Only applies to a real
+  // ladder: on a single-level store every tile would otherwise be exempt and
+  // the budget would be a no-op.
+  static constexpr std::size_t kCoarsestExemptCap = 64;
+  // A tile seen within this many paints is "recent" and evicts after the stale
+  // ones — the staleness term that keeps distance from being the primary key
+  // (uma-ADR-0013 D4: distance-only "discards history along a path being
+  // traversed"). ~2 s of paints at typical repaint rates.
+  static constexpr quint64 kRecentGenerations = 120;
+  // Re-arm delay when the eviction pass finds the loader worker busy.
+  static constexpr int kEvictionRetryMs = 100;
+
+  TileResidency residency_;             // protected/evictable partition
+  std::vector<quint64> tile_last_visible_gen_;   // parallel to tiles_ (LRU key)
+  quint64 paint_generation_ = 0;        // bumped by refreshProtection()
+  std::size_t resident_budget_bytes_ = 0;   // 0 = eviction disabled
+  bool eviction_pending_ = false;       // debounces the queued eviction
+  bool eviction_warned_ = false;        // one qWarning per layer, not per pass
+  bool over_budget_ = false;            // protected set alone exceeds the budget
+  bool hole_coverage_released_ = false; // a camp#194 hole coverer was evicted
 };
 
 }  // namespace raster

--- a/src/camp_map/raster/tile_residency.h
+++ b/src/camp_map/raster/tile_residency.h
@@ -1,0 +1,119 @@
+#ifndef RASTER_TILE_RESIDENCY_H
+#define RASTER_TILE_RESIDENCY_H
+
+#include <cstddef>
+#include <cstdint>
+#include <list>
+#include <vector>
+
+namespace camp
+{
+namespace raster
+{
+
+/// [camp#195 / uma-ADR-0013 D4] Current-frame protection for a tile-indexed
+/// residency budget, as a **structural** property rather than a checked
+/// condition.
+///
+/// D4 requires that "tiles selected in the current frame are protected
+/// regardless of recency" be a property of the data structure — the sentinel-node
+/// list — so that an eviction pass literally cannot reach them, instead of an
+/// `if` a future edit can drop. This type is that structure, reduced to what a
+/// `std::vector`-indexed tile store needs: two `std::list<std::size_t>`
+/// partitions (protected / evictable) plus an index of iterators, so every
+/// operation is an O(1) splice and no iterator is ever invalidated.
+///
+/// Usage per frame:
+/// @code
+///   residency.sync(tiles.size());        // admit tiles appended since last frame
+///   residency.beginFrame();              // everything becomes evictable, O(1)
+///   for(i : tiles the frame selected)
+///     residency.protect(i);              // O(1) each, idempotent within a frame
+///   ...
+///   for(i : residency.candidates())      // CANNOT contain a protected index
+///     consider evicting tiles[i];
+/// @endcode
+///
+/// The eviction pass is handed `candidates()` — a const view of the evictable
+/// partition alone. There is no accessor that exposes the protected partition
+/// as eviction candidates, which is the guarantee: "cannot evict what this frame
+/// selected" holds by construction.
+///
+/// Indices are positions in the owner's tile vector and must be stable;
+/// `GggsTileLayer::tiles_` only ever grows (loadDirectory/rescan push_back), so
+/// `sync()` is append-only by design and asserts nothing about shrinking beyond
+/// ignoring it.
+///
+/// Deliberately Qt-free and GL-free so it can be unit-tested standalone
+/// (`test/test_tile_residency.cpp`).
+class TileResidency
+{
+public:
+  /// Admit indices `[size(), count)` as evictable. Append-only: a @p count below
+  /// the current size is ignored (the owner's tile vector never shrinks).
+  void sync(std::size_t count)
+  {
+    while(where_.size() < count)
+    {
+      const std::size_t index = where_.size();
+      where_.push_back(evictable_.insert(evictable_.end(), index));
+      protected_frame_.push_back(0);   // 0 != frame_ (which starts at 1)
+    }
+  }
+
+  /// Start a new frame: every protected index becomes a candidate again, in O(1)
+  /// (one whole-list splice), and the frame epoch advances so `protect()` treats
+  /// this frame's protections as fresh without touching the per-index vector.
+  void beginFrame()
+  {
+    evictable_.splice(evictable_.end(), protected_);
+    ++frame_;
+  }
+
+  /// Protect @p index for the current frame. O(1), idempotent within the frame.
+  /// Out-of-range indices are ignored (the caller syncs first).
+  void protect(std::size_t index)
+  {
+    if(index >= where_.size() || protected_frame_[index] == frame_)
+      return;
+    protected_.splice(protected_.end(), evictable_, where_[index]);
+    protected_frame_[index] = frame_;
+  }
+
+  /// True if @p index is protected in the current frame.
+  bool isProtected(std::size_t index) const
+  {
+    return index < where_.size() && protected_frame_[index] == frame_;
+  }
+
+  /// The evictable partition — the ONLY thing an eviction pass may consider.
+  /// Never contains an index protected in the current frame.
+  const std::list<std::size_t>& candidates() const { return evictable_; }
+
+  /// Number of indices protected in the current frame — the working set the
+  /// residency cap is floored at (uma-ADR-0013 D4: "the budget must exceed
+  /// [the current-frame set] or the system thrashes by construction").
+  std::size_t protectedCount() const { return protected_.size(); }
+
+  /// Number of indices admitted so far.
+  std::size_t size() const { return where_.size(); }
+
+private:
+  // The two partitions. An index lives in exactly one of them at all times; the
+  // iterator recorded in where_ stays valid across every splice (std::list
+  // splice preserves iterators), which is what makes protect() O(1).
+  std::list<std::size_t> protected_;
+  std::list<std::size_t> evictable_;
+  std::vector<std::list<std::size_t>::iterator> where_;
+
+  // Per-index frame epoch, so beginFrame() need not clear a flag vector: an
+  // index is protected iff its recorded epoch equals the current one. Starts at
+  // 1 so the 0 seeded by sync() means "never protected".
+  std::vector<std::uint64_t> protected_frame_;
+  std::uint64_t frame_ = 1;
+};
+
+}  // namespace raster
+}  // namespace camp
+
+#endif

--- a/test/test_gggs_elevation.cpp
+++ b/test/test_gggs_elevation.cpp
@@ -23,10 +23,12 @@
 
 #include <QApplication>
 #include <QGeoCoordinate>
+#include <QRectF>
 #include <QTemporaryDir>
 
 #include "map/map.h"
 #include "map/layer_list.h"
+#include "map_view/web_mercator.h"
 #include "raster/gggs_tile_layer.h"
 
 namespace
@@ -67,6 +69,16 @@ QString writeUniformTile(const QTemporaryDir& dir, const QString& name,
 QGeoCoordinate insidePoint(double lon0, double lat0)
 {
   return QGeoCoordinate(lat0 - 0.0008, lon0 + 0.0008);
+}
+
+// [camp#195] The Web-Mercator scene rect of the tile at (lon0, lat0) — the
+// load/paint viewport the residency budget protects.
+QRectF tileViewport(double lon0, double lat0)
+{
+  const QPointF lo = web_mercator::geoToMap(QGeoCoordinate(lat0 - 0.0016, lon0));
+  const QPointF hi =
+    web_mercator::geoToMap(QGeoCoordinate(lat0, lon0 + 0.0016));
+  return QRectF(lo, hi).normalized();
 }
 
 }  // namespace
@@ -122,6 +134,43 @@ TEST(GggsElevationTest, AllNoDataCoveringTileIsNaN)
   layer->waitForLoad();
 
   EXPECT_TRUE(std::isnan(layer->getElevation(insidePoint(-71.40, 43.00))));
+}
+
+// [camp#195] The residency budget's consequence for this readout, stated as a
+// test rather than only as prose in camp-ADR-0014: getElevation() answers from
+// the RESIDENT tile buffers, so a point in an area the view has panned away from
+// (and whose tile the budget released) reads NaN, while the point under the
+// current viewport still answers. That asymmetry is the reason the readout is
+// unaffected in practice — the cursor is always inside the viewport, and
+// viewport tiles are structurally protected from eviction.
+TEST(GggsElevationTest, ReadoutOverAnEvictedAreaIsNaN)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  // Two adjacent 0.0016-deg tiles at the same level.
+  ASSERT_FALSE(writeUniformTile(dir, "13_0_0.tif", -71.4000, 43.00, 10.0f).isEmpty());
+  ASSERT_FALSE(writeUniformTile(dir, "13_0_1.tif", -71.3984, 43.00, 20.0f).isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  // One tile's worth of budget: 16x16 Float32 CPU buffer + R32F texture.
+  layer->setResidentBudgetBytesForTest(16 * 16 * sizeof(float) * 2);
+
+  layer->setLodForTest(13, tileViewport(-71.4000, 43.00));
+  layer->waitForLoad();
+  layer->refreshResidencyForTest();
+  ASSERT_FLOAT_EQ(layer->getElevation(insidePoint(-71.4000, 43.00)), 10.0f);
+
+  // Pan to the neighbour: the first tile leaves the viewport and is released.
+  layer->setLodForTest(13, tileViewport(-71.3984, 43.00));
+  layer->waitForLoad();
+  layer->refreshResidencyForTest();
+
+  EXPECT_FLOAT_EQ(layer->getElevation(insidePoint(-71.3984, 43.00)), 20.0f)
+    << "the readout under the current viewport must still answer";
+  EXPECT_TRUE(std::isnan(layer->getElevation(insidePoint(-71.4000, 43.00))))
+    << "a readout over an evicted area must degrade to NaN, not to a stale value";
 }
 
 int main(int argc, char** argv)

--- a/test/test_gggs_eviction.cpp
+++ b/test/test_gggs_eviction.cpp
@@ -86,14 +86,18 @@ QString writeTile(const QTemporaryDir& dir, const QString& name, double lon0,
 }
 
 // A west-to-east strip of @p count level-13 tiles, tile k carrying value k+1 so
-// a sample identifies which tile answered.
-void writeStrip(const QTemporaryDir& dir, int count)
+// a sample identifies which tile answered. Returns false on the first failed
+// write: a gtest fatal assertion inside a helper aborts only the HELPER, so a
+// short strip would otherwise leak into the test as a confusing — or, for an
+// upper-bound assertion, a spuriously passing — result.
+bool writeStrip(const QTemporaryDir& dir, int count)
 {
   for(int k = 0; k < count; ++k)
-    ASSERT_FALSE(writeTile(dir, QString("13_0_%1.tif").arg(k),
-                           kLon0 + k * kTileSpan, kLat0, kCell, kTileEdge,
-                           float(k + 1))
-                   .isEmpty());
+    if(writeTile(dir, QString("13_0_%1.tif").arg(k), kLon0 + k * kTileSpan,
+                 kLat0, kCell, kTileEdge, float(k + 1))
+         .isEmpty())
+      return false;
+  return true;
 }
 
 // A point comfortably inside strip tile @p k.
@@ -134,7 +138,7 @@ TEST(GggsEvictionTest, PanAcrossStripStaysWithinBudget)
   QTemporaryDir dir;
   ASSERT_TRUE(dir.isValid());
   const int kTiles = 12;
-  writeStrip(dir, kTiles);
+  ASSERT_TRUE(writeStrip(dir, kTiles));
 
   camp::map::Map map;
   auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
@@ -167,7 +171,7 @@ TEST(GggsEvictionTest, PannedAwayAreaIsReleasedAndReadsNaN)
 {
   QTemporaryDir dir;
   ASSERT_TRUE(dir.isValid());
-  writeStrip(dir, 10);
+  ASSERT_TRUE(writeStrip(dir, 10));
 
   camp::map::Map map;
   auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
@@ -194,7 +198,7 @@ TEST(GggsEvictionTest, PanBackReloadsAnEvictedTile)
 {
   QTemporaryDir dir;
   ASSERT_TRUE(dir.isValid());
-  writeStrip(dir, 8);
+  ASSERT_TRUE(writeStrip(dir, 8));
 
   camp::map::Map map;
   auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
@@ -223,7 +227,7 @@ TEST(GggsEvictionTest, ZeroBudgetDisablesEviction)
   QTemporaryDir dir;
   ASSERT_TRUE(dir.isValid());
   const int kTiles = 8;
-  writeStrip(dir, kTiles);
+  ASSERT_TRUE(writeStrip(dir, kTiles));
 
   camp::map::Map map;
   auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
@@ -246,7 +250,7 @@ TEST(GggsEvictionTest, CoarsestLadderLevelIsExemptFromEviction)
 {
   QTemporaryDir dir;
   ASSERT_TRUE(dir.isValid());
-  writeStrip(dir, 10);
+  ASSERT_TRUE(writeStrip(dir, 10));
   // Level 0 tile spanning strip tiles 0..3 (4 x kTileSpan wide).
   ASSERT_FALSE(writeTile(dir, "0_0_0.tif", kLon0, kLat0, kCell * 4, kTileEdge,
                          500.0f)
@@ -280,7 +284,7 @@ TEST(GggsEvictionTest, InViewHoleCoverageIsProtected)
 {
   QTemporaryDir dir;
   ASSERT_TRUE(dir.isValid());
-  writeStrip(dir, 6);
+  ASSERT_TRUE(writeStrip(dir, 6));
   // A coarse (level 10) tile over strip tiles 0..3, which we then break.
   const QString coarse_path =
     writeTile(dir, "10_0_0.tif", kLon0, kLat0, kCell * 4, kTileEdge, 500.0f);
@@ -335,7 +339,7 @@ TEST(GggsEvictionTest, WorkingSetAboveBudgetFloorsTheCapAndReportsIt)
 {
   QTemporaryDir dir;
   ASSERT_TRUE(dir.isValid());
-  writeStrip(dir, 6);
+  ASSERT_TRUE(writeStrip(dir, 6));
 
   camp::map::Map map;
   auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
@@ -356,6 +360,162 @@ TEST(GggsEvictionTest, WorkingSetAboveBudgetFloorsTheCapAndReportsIt)
   panTo(layer, 0, 0);
   EXPECT_FALSE(layer->status().contains("over the tile budget"))
     << layer->status().toStdString();
+}
+
+// A repaired store clears the released-coverage report: the message names a
+// recovery action, so it must describe live state rather than latch for the
+// session. (The over-budget message's live-ness is asserted above; this is its
+// twin, and the asymmetry between them was a review finding.)
+TEST(GggsEvictionTest, RescanClearsTheReleasedCoverageReport)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  ASSERT_TRUE(writeStrip(dir, 6));
+  const QString coarse_path =
+    writeTile(dir, "10_0_0.tif", kLon0, kLat0, kCell * 4, kTileEdge, 500.0f);
+  ASSERT_FALSE(coarse_path.isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->setResidentBudgetBytesForTest(2 * kTileBytes);
+  {
+    QFile file(coarse_path);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly | QIODevice::Truncate));
+    ASSERT_TRUE(file.resize(0));
+  }
+
+  panTo(layer, 0, 3);
+  layer->setLodForTest(10, viewportOverTiles(0, 1));
+  layer->waitForLoad();
+  layer->refreshResidencyForTest();
+  ASSERT_TRUE(layer->status().contains("released")) << layer->status().toStdString();
+
+  // The producer writes a good tile back at the same path; Rescan is the
+  // operator's retry.
+  ASSERT_FALSE(
+    writeTile(dir, "10_0_0.tif", kLon0, kLat0, kCell * 4, kTileEdge, 500.0f)
+      .isEmpty());
+  EXPECT_TRUE(layer->rescan());
+  layer->waitForLoad();
+
+  EXPECT_FALSE(layer->status().contains("released"))
+    << "the released-coverage report survived the repair: "
+    << layer->status().toStdString();
+}
+
+// The zoom-out backdrop must be protected, not merely drawn. itemsIntersecting()
+// renders the whole resident set with no level filter, so during a zoom-out the
+// still-resident FINER tiles are the entire visible picture until the coarser
+// selection loads (camp#103/#194's no-blank-frame guarantee). They are outside
+// the loader's level ceiling, so a protection predicate that used the loader's
+// filter alone would leave exactly the on-screen picture evictable — and unlike
+// other evictions it could not reload, because loadTilesWorker() skips levels
+// finer than the selection.
+TEST(GggsEvictionTest, ZoomOutBackdropInViewIsProtected)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  ASSERT_TRUE(writeStrip(dir, 6));
+  // A coarse level-0 tile covering strip tiles 4..5 only — it is NOT under the
+  // viewport used below, so it cannot satisfy the assertion by itself.
+  ASSERT_FALSE(writeTile(dir, "0_0_0.tif", kLon0 + 4 * kTileSpan, kLat0,
+                         kCell * 2, kTileEdge, 500.0f)
+                 .isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->setResidentBudgetBytesForTest(2 * kTileBytes);
+
+  // Load fine tiles 0..3 at a fine selection.
+  panTo(layer, 0, 3);
+  ASSERT_FALSE(std::isnan(layer->getElevation(insideTile(0))));
+
+  // Zoom OUT to the coarse level over tiles 0..1 WITHOUT letting the coarse load
+  // settle (no waitForLoad): mid-transition, the resident fine tiles 0..1 are
+  // level > selection, in view, and the only thing on screen. Residency is over
+  // budget, so something must go — it must not be them.
+  layer->setLodForTest(0, viewportOverTiles(0, 1));
+  layer->refreshResidencyForTest();
+
+  EXPECT_FALSE(std::isnan(layer->getElevation(insideTile(0))))
+    << "the zoom-out backdrop under the viewport was evicted — the view would "
+       "blank for the whole coarse load";
+  EXPECT_FALSE(std::isnan(layer->getElevation(insideTile(1))))
+    << "the zoom-out backdrop under the viewport was evicted";
+}
+
+// The coarsest-level exemption is bounded relative to the cap, not just by a
+// flat count: an exemption that can exceed the eviction target would make the
+// victim loop unable to reach it, evicting every ordinary candidate on every
+// pass. Here the cap is small, so at most a couple of coarse tiles stay exempt
+// while the rest are demoted to last-resort candidates and eventually taken.
+TEST(GggsEvictionTest, CoarsestExemptionIsBoundedByTheCap)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  ASSERT_TRUE(writeStrip(dir, 12));
+  // Six level-5 tiles, each spanning two strip tiles, covering the whole strip.
+  for(int k = 0; k < 6; ++k)
+    ASSERT_FALSE(writeTile(dir, QString("5_0_%1.tif").arg(k),
+                           kLon0 + 2 * k * kTileSpan, kLat0, kCell * 2,
+                           kTileEdge, 500.0f + k)
+                   .isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  ASSERT_EQ(layer->availableLevels().size(), 2u);
+  layer->setResidentBudgetBytesForTest(4 * kTileBytes);
+
+  for(int k = 0; k + 1 < 12; ++k)
+    panTo(layer, k, k + 1);
+
+  EXPECT_GE(layer->pixelsLoadedCount(5), 1)
+    << "the zoom-out floor was eliminated entirely";
+  EXPECT_LT(layer->pixelsLoadedCount(5), 6)
+    << "every coarsest-level tile stayed exempt — the exemption grows with the "
+       "area panned and can exceed the eviction target";
+}
+
+// The deferred path, not just the synchronous shortcut the other tests use:
+// paint() PROTECTS and SCHEDULES, and the pass runs from the event loop. This
+// covers the eviction_pending_ debounce and the queued invocation — the
+// mechanism the budget actually runs on in the application.
+TEST(GggsEvictionTest, ScheduledEvictionConvergesThroughTheEventLoop)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const int kTiles = 8;
+  ASSERT_TRUE(writeStrip(dir, kTiles));
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->setResidentBudgetBytesForTest(3 * kTileBytes);
+
+  // Load the whole strip with no residency pass in between (no level filter, no
+  // viewport filter), so residency starts well over the budget.
+  layer->setLodForTest(-1, QRectF());
+  layer->waitForLoad();
+  ASSERT_EQ(layer->pixelsLoadedCount(13), kTiles);
+
+  // Now a "frame" over two tiles: protect + schedule only. Scheduling twice must
+  // not queue two passes (the debounce).
+  layer->setLodForTest(13, viewportOverTiles(0, 1));
+  layer->scheduleResidencyForTest();
+  layer->scheduleResidencyForTest();
+  EXPECT_EQ(layer->residentTileCount(), std::size_t(kTiles))
+    << "eviction ran inside the scheduling call — it must be deferred off the "
+       "paint path";
+
+  QCoreApplication::processEvents();
+
+  EXPECT_LE(layer->residentTileCount(), 3u)
+    << "the queued eviction pass never ran";
+  EXPECT_FALSE(std::isnan(layer->getElevation(insideTile(0))));
+  EXPECT_FALSE(std::isnan(layer->getElevation(insideTile(1))));
 }
 
 int main(int argc, char** argv)

--- a/test/test_gggs_eviction.cpp
+++ b/test/test_gggs_eviction.cpp
@@ -1,0 +1,372 @@
+// [camp#195 / uma-ADR-0013 D4] Headless tests for GggsTileLayer's
+// viewport-scoped retention and residency budget.
+//
+// The defect these guard is an OOM after prolonged panning: before camp#195 the
+// only code path that ever freed a GGGS tile was tilesReady()'s level-switch
+// release, so at a fixed zoom every tile ever scrolled across stayed resident
+// for the session. The portable assertion is a BOUNDED RESIDENT COUNT while the
+// visited count grows — the same shape as the in-repo
+// test/test_map_tiles_eviction.cpp (camp#98) and cube_bathymetry's
+// test_tile_eviction_rss.cpp.
+//
+// GL-free by construction (like test_gggs_rescan/test_gggs_elevation): the layer
+// is driven through setLodForTest() + waitForLoad() (pure GDAL RasterIO) and
+// refreshResidencyForTest(), never through paint(). Consequence, and a
+// deliberate coverage gap recorded in camp-ADR-0014: with no GL context
+// releaseTiles() exercises only the CPU half of the release (releaseGL() is a
+// no-op because no texture can exist), so the GL-texture half of the ~7 MiB
+// per-tile cost is not covered here.
+//
+// Residency is observed through getElevation() (a point sample of the resident
+// CPU buffer -> NaN once the tile is released) and pixelsLoadedCount()/
+// residentTileCount().
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include <gdal_priv.h>
+
+#include <QApplication>
+#include <QFile>
+#include <QGeoCoordinate>
+#include <QRectF>
+#include <QTemporaryDir>
+
+#include "map/map.h"
+#include "map/layer_list.h"
+#include "map_view/web_mercator.h"
+#include "raster/gggs_tile_layer.h"
+
+namespace
+{
+
+// Tile geometry: 16x16 cells of 0.0001 deg, so a tile spans 0.0016 deg.
+constexpr int kTileEdge = 16;
+constexpr double kCell = 0.0001;
+constexpr double kTileSpan = kCell * kTileEdge;   // 0.0016 deg
+constexpr double kLat0 = 43.0;                    // north edge of every tile
+constexpr double kLon0 = -71.4;                   // west edge of tile 0
+
+// Per-tile resident cost as the layer accounts it: the Float32 CPU buffer plus
+// an R32F texture of the same extent (gggs_tile.cpp retains the CPU copy past
+// the GPU upload for camp#180). Tests express their budget in these units so
+// they do not depend on the 960x960 production tile size.
+constexpr std::size_t kTileBytes =
+  std::size_t(kTileEdge) * kTileEdge * sizeof(float) * 2;
+
+// Write a north-up Float32 GeoTIFF filled with @p value (NoData 9999) at the
+// given NW corner. @p name carries the GGGS `<level>_<row>_<col>` convention.
+QString writeTile(const QTemporaryDir& dir, const QString& name, double lon0,
+                  double lat0, double cell, int edge, float value)
+{
+  if(GDALGetDriverCount() == 0)
+    GDALAllRegister();
+  const double geo[6] = {lon0, cell, 0.0, lat0, 0.0, -cell};
+  const QString path = dir.filePath(name);
+  GDALDriver* driver = GetGDALDriverManager()->GetDriverByName("GTiff");
+  EXPECT_NE(driver, nullptr);
+  if(!driver)
+    return QString();
+  GDALDataset* ds = driver->Create(path.toUtf8().constData(), edge, edge, 1,
+                                   GDT_Float32, nullptr);
+  EXPECT_NE(ds, nullptr);
+  if(!ds)
+    return QString();
+  ds->SetGeoTransform(const_cast<double*>(geo));
+  GDALRasterBand* band = ds->GetRasterBand(1);
+  band->SetNoDataValue(9999.0);
+  std::vector<float> samples(static_cast<size_t>(edge) * edge, value);
+  const CPLErr err = band->RasterIO(GF_Write, 0, 0, edge, edge, samples.data(),
+                                    edge, edge, GDT_Float32, 0, 0);
+  GDALClose(ds);
+  return err == CE_None ? path : QString();
+}
+
+// A west-to-east strip of @p count level-13 tiles, tile k carrying value k+1 so
+// a sample identifies which tile answered.
+void writeStrip(const QTemporaryDir& dir, int count)
+{
+  for(int k = 0; k < count; ++k)
+    ASSERT_FALSE(writeTile(dir, QString("13_0_%1.tif").arg(k),
+                           kLon0 + k * kTileSpan, kLat0, kCell, kTileEdge,
+                           float(k + 1))
+                   .isEmpty());
+}
+
+// A point comfortably inside strip tile @p k.
+QGeoCoordinate insideTile(int k)
+{
+  return QGeoCoordinate(kLat0 - kTileSpan / 2,
+                        kLon0 + k * kTileSpan + kTileSpan / 2);
+}
+
+// Web-Mercator scene rect spanning strip tiles [first, last] — the load/paint
+// viewport the layer filters and protects against.
+QRectF viewportOverTiles(int first, int last)
+{
+  const QPointF lo = web_mercator::geoToMap(
+    QGeoCoordinate(kLat0 - kTileSpan, kLon0 + first * kTileSpan));
+  const QPointF hi = web_mercator::geoToMap(
+    QGeoCoordinate(kLat0, kLon0 + (last + 1) * kTileSpan));
+  return QRectF(lo, hi).normalized();
+}
+
+// One pan step: move the viewport, let the demand-driven loader fill it, then
+// run the residency pass (paint() would schedule it; a headless test has no
+// event-loop turn, so it drives the pass directly).
+void panTo(camp::raster::GggsTileLayer* layer, int first, int last)
+{
+  layer->setLodForTest(13, viewportOverTiles(first, last));
+  layer->waitForLoad();
+  layer->refreshResidencyForTest();
+}
+
+}  // namespace
+
+// THE regression: panning a small viewport across a strip far wider than the
+// budget must keep residency bounded, while the visited footprint grows. Before
+// camp#195 every visited tile stayed resident for the session.
+TEST(GggsEvictionTest, PanAcrossStripStaysWithinBudget)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const int kTiles = 12;
+  writeStrip(dir, kTiles);
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->setResidentBudgetBytesForTest(4 * kTileBytes);   // 4 tiles
+
+  for(int k = 0; k + 1 < kTiles; ++k)
+  {
+    panTo(layer, k, k + 1);
+    EXPECT_LE(layer->residentTileCount(), 4u)
+      << "residency exceeded the budget at pan step " << k;
+    // The two tiles under the viewport are the current working set and must be
+    // present at every step — a budget that evicts what it is drawing thrashes.
+    EXPECT_FALSE(std::isnan(layer->getElevation(insideTile(k))))
+      << "an in-viewport tile was evicted at pan step " << k;
+    EXPECT_FALSE(std::isnan(layer->getElevation(insideTile(k + 1))))
+      << "an in-viewport tile was evicted at pan step " << k;
+  }
+
+  EXPECT_LT(layer->pixelsLoadedCount(13), kTiles)
+    << "every visited tile is still resident — nothing was ever evicted";
+}
+
+// The far end of the strip is released once the view has moved on, and the
+// released tile's depth-at-cursor readout degrades to NaN. This is the
+// consequence camp#195's plan named and camp-ADR-0014 records: getElevation()
+// answers over the resident set, and the cursor is always in the viewport, so
+// the tile under it is protected.
+TEST(GggsEvictionTest, PannedAwayAreaIsReleasedAndReadsNaN)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  writeStrip(dir, 10);
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->setResidentBudgetBytesForTest(3 * kTileBytes);
+
+  panTo(layer, 0, 1);
+  ASSERT_FALSE(std::isnan(layer->getElevation(insideTile(0))));
+
+  for(int k = 1; k + 1 < 10; ++k)
+    panTo(layer, k, k + 1);
+
+  EXPECT_TRUE(std::isnan(layer->getElevation(insideTile(0))))
+    << "the far end of the pan track is still resident";
+  EXPECT_FALSE(std::isnan(layer->getElevation(insideTile(9))))
+    << "the tile under the current viewport must never be evicted";
+}
+
+// Eviction is only affordable because the reload path is free: the tiles are
+// files on disk, and the existing demand-driven loader re-reads them when the
+// viewport comes back (which is why camp#195 drops rather than folding to a
+// parent, unlike camp-ADR-0010's SonarLiveCacheLayer).
+TEST(GggsEvictionTest, PanBackReloadsAnEvictedTile)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  writeStrip(dir, 8);
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->setResidentBudgetBytesForTest(3 * kTileBytes);
+
+  panTo(layer, 0, 1);
+  ASSERT_FLOAT_EQ(layer->getElevation(insideTile(0)), 1.0f);
+
+  for(int k = 1; k + 1 < 8; ++k)
+    panTo(layer, k, k + 1);
+  ASSERT_TRUE(std::isnan(layer->getElevation(insideTile(0))));
+
+  // Pan back over the released tile.
+  for(int k = 6; k >= 0; --k)
+    panTo(layer, k, k + 1);
+  EXPECT_FLOAT_EQ(layer->getElevation(insideTile(0)), 1.0f)
+    << "an evicted tile did not reload when the viewport returned to it";
+}
+
+// `GggsTileLayers/max_resident_bytes = 0` reproduces the pre-camp#195 behaviour
+// exactly — the escape hatch camp-ADR-0006 D2 / camp#117 require for any
+// operator-facing default.
+TEST(GggsEvictionTest, ZeroBudgetDisablesEviction)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const int kTiles = 8;
+  writeStrip(dir, kTiles);
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->setResidentBudgetBytesForTest(0);
+
+  for(int k = 0; k + 1 < kTiles; ++k)
+    panTo(layer, k, k + 1);
+
+  EXPECT_EQ(layer->pixelsLoadedCount(13), kTiles)
+    << "eviction ran with the budget disabled";
+}
+
+// The zoom-out floor: on a real ladder the coarsest available level is exempt,
+// so panning away from the region it covers does not leave a zoomed-out view
+// with nothing to draw. The coarse tile here covers only the WEST half of the
+// strip, so once the view is over the east half it is off-viewport and would
+// otherwise be the farthest, stalest candidate of all.
+TEST(GggsEvictionTest, CoarsestLadderLevelIsExemptFromEviction)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  writeStrip(dir, 10);
+  // Level 0 tile spanning strip tiles 0..3 (4 x kTileSpan wide).
+  ASSERT_FALSE(writeTile(dir, "0_0_0.tif", kLon0, kLat0, kCell * 4, kTileEdge,
+                         500.0f)
+                 .isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  ASSERT_EQ(layer->availableLevels().size(), 2u);
+  layer->setResidentBudgetBytesForTest(3 * kTileBytes);
+
+  panTo(layer, 0, 1);
+  ASSERT_EQ(layer->pixelsLoadedCount(0), 1) << "the coarse tile never loaded";
+
+  for(int k = 1; k + 1 < 10; ++k)
+    panTo(layer, k, k + 1);
+
+  EXPECT_EQ(layer->pixelsLoadedCount(0), 1)
+    << "the coarsest ladder level was evicted — a zoom-out would have nothing "
+       "to draw";
+  EXPECT_LE(layer->pixelsLoadedCount(13), 3)
+    << "the fine level is not bounded by the budget";
+}
+
+// camp#194's hole-coverage rule survives the budget: a finer tile that is the
+// only usable coverage over a footprint whose selected-or-coarser tile failed to
+// read must not be evicted out from under the operator while it is on screen. It
+// is doubly load-bearing here because such a tile cannot reload —
+// loadTilesWorker() skips levels finer than the selection.
+TEST(GggsEvictionTest, InViewHoleCoverageIsProtected)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  writeStrip(dir, 6);
+  // A coarse (level 10) tile over strip tiles 0..3, which we then break.
+  const QString coarse_path =
+    writeTile(dir, "10_0_0.tif", kLon0, kLat0, kCell * 4, kTileEdge, 500.0f);
+  ASSERT_FALSE(coarse_path.isEmpty());
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->setResidentBudgetBytesForTest(2 * kTileBytes);
+
+  // Break the coarse tile AFTER its metadata scan: it stays valid() but its
+  // pixels can never be read, so loadPixels() latches the sticky failure.
+  {
+    QFile file(coarse_path);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly | QIODevice::Truncate));
+    ASSERT_TRUE(file.resize(0));
+  }
+
+  // Load fine tiles 0..3 over the coarse footprint at a fine selection.
+  panTo(layer, 0, 3);
+  ASSERT_FLOAT_EQ(layer->getElevation(insideTile(0)), 1.0f);
+  ASSERT_TRUE(layer->status().contains("failed")) << layer->status().toStdString();
+
+  // Zoom OUT to the coarse level over tiles 0..1: the coarse tile is a hole, and
+  // the resident fine tiles are the only coverage over it. Tiles 0..1 are on
+  // screen; tiles 2..3 are not, and residency is over budget.
+  layer->setLodForTest(10, viewportOverTiles(0, 1));
+  layer->waitForLoad();
+  layer->refreshResidencyForTest();
+
+  EXPECT_FALSE(std::isnan(layer->getElevation(insideTile(0))))
+    << "the only coverage over a failed tile was evicted while on screen";
+  EXPECT_FALSE(std::isnan(layer->getElevation(insideTile(1))))
+    << "the only coverage over a failed tile was evicted while on screen";
+  EXPECT_LE(layer->residentTileCount(), 2u)
+    << "the off-screen hole coverage was exempted from the budget rather than "
+       "evicted last";
+  // An evicted hole coverer cannot reload (loadTilesWorker skips levels finer
+  // than the selection), so the loss must be reported with its recovery action
+  // rather than disappearing silently.
+  EXPECT_TRUE(layer->status().contains("Rescan"))
+    << "released hole coverage was not reported: "
+    << layer->status().toStdString();
+}
+
+// uma-ADR-0013 D4: "the budget must exceed [the current-frame set] or the system
+// thrashes by construction". When one viewport's own working set is larger than
+// the byte target, the cap is FLOORED at that set — the layer keeps drawing and
+// reports the over-budget state instead of evicting what it is rendering.
+// (Relaxing the quality target under this pressure is camp#197.)
+TEST(GggsEvictionTest, WorkingSetAboveBudgetFloorsTheCapAndReportsIt)
+{
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  writeStrip(dir, 6);
+
+  camp::map::Map map;
+  auto* layer = new camp::raster::GggsTileLayer(map.topLevelLayers(), dir.path());
+  ASSERT_TRUE(layer->valid());
+  layer->setResidentBudgetBytesForTest(kTileBytes);   // 1 tile
+
+  panTo(layer, 0, 3);   // four tiles in view, budget of one
+
+  EXPECT_GE(layer->residentTileCount(), 4u)
+    << "the visible working set was evicted — the cap is not floored at it";
+  for(int k = 0; k < 4; ++k)
+    EXPECT_FALSE(std::isnan(layer->getElevation(insideTile(k))));
+  EXPECT_TRUE(layer->status().contains("over the tile budget"))
+    << "the over-budget state was not reported: " << layer->status().toStdString();
+
+  // Zooming back to a set that fits clears the report — the status is composed
+  // from live state, not latched.
+  panTo(layer, 0, 0);
+  EXPECT_FALSE(layer->status().contains("over the tile budget"))
+    << layer->status().toStdString();
+}
+
+int main(int argc, char** argv)
+{
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QApplication app(argc, argv);
+  // [camp#117] A test org/app name keeps Map's ctor QSettings seed — and the
+  // layer's GggsTileLayers/max_resident_bytes read — out of the developer's real
+  // camp settings.
+  QCoreApplication::setOrganizationName("camp_test");
+  QCoreApplication::setApplicationName("test_gggs_eviction");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_tile_residency.cpp
+++ b/test/test_tile_residency.cpp
@@ -1,0 +1,159 @@
+// [camp#195 / uma-ADR-0013 D4] Unit tests for the TileResidency splice
+// partition — the structure that makes "cannot evict what this frame selected"
+// a property of the type rather than a checked condition.
+//
+// Pure: no Qt, no GL, no GDAL. The invariant under test is the one an eviction
+// pass depends on — candidates() never contains an index protected in the
+// current frame — plus the frame/epoch mechanics that let beginFrame() be O(1).
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "raster/tile_residency.h"
+
+namespace
+{
+
+std::vector<std::size_t> asVector(const camp::raster::TileResidency& residency)
+{
+  return std::vector<std::size_t>(residency.candidates().begin(),
+                                  residency.candidates().end());
+}
+
+bool contains(const std::vector<std::size_t>& v, std::size_t index)
+{
+  return std::find(v.begin(), v.end(), index) != v.end();
+}
+
+}  // namespace
+
+// Freshly synced tiles are all candidates: nothing is protected until a frame
+// selects it.
+TEST(TileResidencyTest, SyncAdmitsEverythingAsEvictable)
+{
+  camp::raster::TileResidency residency;
+  residency.sync(4);
+  EXPECT_EQ(residency.size(), 4u);
+  EXPECT_EQ(residency.protectedCount(), 0u);
+  EXPECT_EQ(asVector(residency).size(), 4u);
+}
+
+// The core guarantee: a protected index is absent from candidates(). This is
+// what the eviction pass relies on — it is handed candidates() and nothing else.
+TEST(TileResidencyTest, ProtectedIndexIsNeverACandidate)
+{
+  camp::raster::TileResidency residency;
+  residency.sync(5);
+  residency.beginFrame();
+  residency.protect(1);
+  residency.protect(3);
+
+  const std::vector<std::size_t> candidates = asVector(residency);
+  EXPECT_EQ(candidates.size(), 3u);
+  EXPECT_FALSE(contains(candidates, 1));
+  EXPECT_FALSE(contains(candidates, 3));
+  EXPECT_TRUE(contains(candidates, 0));
+  EXPECT_TRUE(contains(candidates, 2));
+  EXPECT_TRUE(contains(candidates, 4));
+  EXPECT_EQ(residency.protectedCount(), 2u);
+  EXPECT_TRUE(residency.isProtected(1));
+  EXPECT_FALSE(residency.isProtected(0));
+}
+
+// protect() is idempotent within a frame — paint() may protect the same tile
+// through more than one predicate (selected AND hole-covering), and a double
+// splice would corrupt the partition sizes.
+TEST(TileResidencyTest, RepeatedProtectWithinAFrameIsIdempotent)
+{
+  camp::raster::TileResidency residency;
+  residency.sync(3);
+  residency.beginFrame();
+  residency.protect(2);
+  residency.protect(2);
+  residency.protect(2);
+
+  EXPECT_EQ(residency.protectedCount(), 1u);
+  EXPECT_EQ(asVector(residency).size(), 2u);
+}
+
+// beginFrame() returns the WHOLE protected partition to the candidates, so a
+// tile the previous frame selected is evictable again once it leaves the view.
+TEST(TileResidencyTest, BeginFrameReleasesThePreviousFramesProtection)
+{
+  camp::raster::TileResidency residency;
+  residency.sync(4);
+  residency.beginFrame();
+  residency.protect(0);
+  residency.protect(1);
+  ASSERT_EQ(residency.protectedCount(), 2u);
+
+  residency.beginFrame();
+  EXPECT_EQ(residency.protectedCount(), 0u);
+  EXPECT_EQ(asVector(residency).size(), 4u);
+  EXPECT_FALSE(residency.isProtected(0));
+
+  // A new frame protects a different tile; the old ones stay candidates.
+  residency.protect(3);
+  const std::vector<std::size_t> candidates = asVector(residency);
+  EXPECT_TRUE(contains(candidates, 0));
+  EXPECT_TRUE(contains(candidates, 1));
+  EXPECT_FALSE(contains(candidates, 3));
+}
+
+// rescan() appends tiles mid-session; sync() must admit them without disturbing
+// the current frame's protection (the iterators of existing entries stay valid
+// across the append, which is why protect() can stay O(1)).
+TEST(TileResidencyTest, SyncAppendsWithoutDisturbingProtection)
+{
+  camp::raster::TileResidency residency;
+  residency.sync(2);
+  residency.beginFrame();
+  residency.protect(0);
+
+  residency.sync(5);   // rescan() found three more tiles
+  EXPECT_EQ(residency.size(), 5u);
+  EXPECT_EQ(residency.protectedCount(), 1u);
+  EXPECT_TRUE(residency.isProtected(0));
+
+  const std::vector<std::size_t> candidates = asVector(residency);
+  EXPECT_EQ(candidates.size(), 4u);
+  EXPECT_FALSE(contains(candidates, 0));
+  EXPECT_TRUE(contains(candidates, 4));
+
+  // The newly admitted tiles are protectable like any other.
+  residency.protect(4);
+  EXPECT_EQ(residency.protectedCount(), 2u);
+  EXPECT_FALSE(contains(asVector(residency), 4));
+}
+
+// sync() is append-only: the owner's tile vector never shrinks, and a smaller
+// count must not drop entries the frame may still be protecting.
+TEST(TileResidencyTest, SyncIgnoresShrink)
+{
+  camp::raster::TileResidency residency;
+  residency.sync(4);
+  residency.sync(2);
+  EXPECT_EQ(residency.size(), 4u);
+  EXPECT_EQ(asVector(residency).size(), 4u);
+}
+
+// Out-of-range protection is a no-op rather than undefined behaviour: the layer
+// syncs before protecting, but a stale index must never corrupt the partition.
+TEST(TileResidencyTest, OutOfRangeProtectIsIgnored)
+{
+  camp::raster::TileResidency residency;
+  residency.sync(2);
+  residency.beginFrame();
+  residency.protect(7);
+  EXPECT_EQ(residency.protectedCount(), 0u);
+  EXPECT_FALSE(residency.isProtected(7));
+  EXPECT_EQ(asVector(residency).size(), 2u);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Bounds `GggsTileLayer`'s tile residency to a viewport-scoped budget. Implements
`uma-ADR-0013` D4 for this layer.

Closes #195.

## Why

`GggsTileLayer` had exactly one code path that ever freed a tile — the release
loop in `tilesReady()`, which fires only after a level switch. There was **no
viewport-based release at all**: nothing freed a tile because the view panned
away from it. At a fixed zoom, every tile ever scrolled across stayed resident
for the life of the session, at ~7 MiB each (`GggsTile::texture()` retains the
CPU float vector past the GPU upload so camp#180's depth-at-cursor readout
works, so you pay CPU **and** R32F).

This predates multi-level compositing and needs only one large layer — it was
already true on `jazzy`. `SonarLiveCacheLayer` had the identical shape and
OOM'd an operator station (#153), which is why `camp-ADR-0010` exists;
`GggsTileLayer` is the layer that never got the treatment. The Isles of Shoals
work puts a 1 m Appledore grid in front of an operator who will pan it for
hours.

## What landed

- **`raster/tile_residency.h`** — a splice-partition type (protected/evictable
  list pair, iterator index, frame epoch). `candidates()` is the only accessor
  an eviction pass gets, so *cannot evict what this frame selected* is a
  property of the type rather than a condition someone has to remember to
  check. O(1) per operation.
- **Budget** — `QSettings GggsTileLayers/max_resident_bytes`, **512 MiB**
  default, `0` disables. The tile count is derived from the *observed* per-tile
  cost rather than hardcoded, because `width_`/`height_` come from GDAL and
  960x960 is a store convention, not a guarantee. The cap is floored at the
  protected set so the budget can never sit below the working set, with a
  non-silent over-budget status.
- **Eviction** — deferred and debounced off `paint()`; hybrid ordering
  (last-resort tier → staleness → distance → LRU); bounded coarsest-level
  exemption; camp#194's hole-coverage retention preserved through a predicate
  shared with `tilesReady()`.
- **Docs** — new `camp-ADR-0014`; `camp-ADR-0013` amended in all four places
  its residency claims went stale.

## Not in this PR, by decision

- The **degrade-under-pressure lever** is deferred to #197. Plan review
  demonstrated it oscillates with a period equal to its cool-down; a stable
  relax needs the predicted protected count at the finer level, not a frame
  counter. The budget alone fixes the unbounded-pan OOM.
- `deriveViewportClip()` is untouched — `clip.scene.center()` already gives the
  painting view's centre under CAMP's single MapView. Painting-view recovery
  stays with camp#150.
- `camp-ADR-0013`'s overdraw / composite-depth pointers were re-routed to #198
  so they no longer reference a decided issue.

## Review

Deep pre-push review (`--no-local`, no `--copilot`) found five must-fixes, all
fixed in `21751c2`. The significant one: `itemsIntersecting()` draws the whole
resident set with no level filter, so mid-zoom-out the in-view tiles *finer*
than the selection are the entire visible picture — and they cannot reload,
since the loader skips `level > selected_level_`. Protecting only the loader's
set would have silently undone camp#103/#194's field-verified no-blank-frame
guarantee. In-view resident finer tiles are now protected.

Also fixed: the coarsest-level exemption could exceed the eviction target
(64 exempt vs a ~57 target at the default), leaving the victim loop unable to
converge; the debounce re-arm was a blind resample that could starve the budget
for seconds during a sustained pan (it now drains from `tilesReady()`, the one
deterministic rendezvous with the worker); a latched GL `makeCurrent()` failure
that silently disabled the budget for the session; and a one-way status latch
that outlived the recovery it advertised.

## Known gap

Headless tests exercise only the CPU half of the release. The **GL texture
half** — the larger share of the ~7 MiB per tile — has no automated coverage.
Recorded in `camp-ADR-0014` rather than papered over. Worth watching real RSS
on the operator station during the next rebuild.

## Test plan

- `./ui_ws/build.sh camp` clean; `./ui_ws/test.sh camp` → **263 tests, 0
  failures**, 1 pre-existing GL-gated skip.
- New: `test/test_tile_residency.cpp` (splice-partition unit coverage),
  `test/test_gggs_eviction.cpp` (budget, protection, ordering, the deferred
  schedule→event-loop path).
- Field check owed on the operator station: pan a large layer and watch RSS
  settle rather than climb.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
