### PR TITLE
camp#199: use marine_colormap's rviz-exact costmap table in occupancy_grid

### DIFF
--- a/src/camp_map/ros/grids/occupancy_grid.cpp
+++ b/src/camp_map/ros/grids/occupancy_grid.cpp
@@ -1,4 +1,9 @@
 #include "occupancy_grid.h"
+
+#include <array>
+
+#include <marine_colormap/occupancy.hpp>
+
 #include "../../map_view/web_mercator.h"
 #include "../node.h"
 
@@ -28,6 +33,36 @@ OccupancyGrid::OccupancyGrid(MapItem* parent, Node* node, QString topic)
   setStatus("[nav_msgs/msg/OccupancyGrid]");
 }
 
+namespace
+{
+
+/// The shared rviz-exact costmap colours (marine_colormap#19), flattened to a
+/// 256-entry table indexed by `value + 128` so the per-cell cost is one array
+/// read rather than a walk of the lookup table's entries. Built once.
+///
+/// Alpha comes straight from the palette: free space is fully transparent and
+/// everything else opaque. Camp's own per-layer opacity control (the map tree's
+/// "opacity:" spin box, MapItem::setOpacity) provides see-through against the
+/// chart underneath — which is better than the alpha ramp this replaced, where
+/// opacity varied with cost and so encoded the same quantity twice.
+const std::array<QColor, 256>& costmapPalette()
+{
+  static const std::array<QColor, 256> palette = []
+  {
+    const auto table = marine_colormap::occupancy_costmap_table();
+    std::array<QColor, 256> colors;
+    for(int i = 0; i < 256; i++)
+    {
+      const auto c = table.lookup(static_cast<float>(i - 128));
+      colors[i] = QColor::fromRgbF(c.r, c.g, c.b, c.a);
+    }
+    return colors;
+  }();
+  return palette;
+}
+
+}  // namespace
+
 void OccupancyGrid::occupancyGridCallback(const nav_msgs::msg::OccupancyGrid &grid)
 {
   if(!process_future_.isRunning())
@@ -51,26 +86,21 @@ void OccupancyGrid::processOccupancyGrid(const nav_msgs::msg::OccupancyGrid &gri
     RCLCPP_WARN_STREAM(node_->node()->get_logger(), "Failed to transform occupancy grid origin: " << e.what());
     return;
   }
-  
+
   data.meters_per_pixel = grid.info.resolution;
+
+  const auto& palette = costmapPalette();
 
   for(uint32_t row = 0; row < grid.info.height; row++)
   {
-    // occupancy grid values are 0 to 100 percent or -1 for unknown
+    // occupancy grid values are 0 to 100 percent, -1 for unknown, and anything
+    // else illegal; the palette covers the whole int8 domain.
     auto row_start = row*grid.info.width;
     for(uint32_t col = 0; col < grid.info.width; col++)
     {
       auto value = grid.data[row_start+col];
-      QColor color;
-      if ( value == -1)
-        color = QColor(128, 128, 128, 128);
-      else if( value == 100)
-        color = QColor(255, 0, 255, 225);
-      else if( value == 99)
-        color = QColor(0, 255, 255, 225);
-      else
-        color = QColor(255*value/100.0, 0, 255*(100-value)/100.0, value+100);
-      data.grid_image.setPixelColor(QPoint(col, grid.info.height-1-row), color);
+      data.grid_image.setPixelColor(QPoint(col, grid.info.height-1-row),
+                                    palette[static_cast<uint8_t>(value + 128)]);
     }
   }
 

--- a/test/test_color_map.cpp
+++ b/test/test_color_map.cpp
@@ -53,10 +53,15 @@ std::string canonicalName(const QString& stored)
 
 // The colormap context menus are built from palette_names(): pin the full exposed
 // registry so a palette add/rename/reorder is a deliberate, visible change.
-TEST(Colormap, RegistryIsTheFullSix)
+//
+// Grew from six to eight when marine_colormap#15 added the two topo-bathy ramps.
+// That is exactly the deliberate, visible change this test exists to surface:
+// both now appear in every scalar layer's Colormap menu.
+TEST(Colormap, RegistryIsTheFullSet)
 {
   const std::vector<std::string> expected = {
-    "grayscale", "bronze", "thermal", "viridis", "turbo", "quality"};
+    "grayscale", "bronze", "thermal", "viridis", "turbo", "quality",
+    "oleron", "hypsometric"};
   EXPECT_EQ(marine_colormap::palette_names(), expected);
 }
 


### PR DESCRIPTION
Retires the last hand-rolled scalar ramp in camp. `occupancy_grid.cpp` now colours cells
from `marine_colormap::occupancy_costmap_table()` (rolker/marine_colormap#19), flattened
once into a 256-entry array indexed by `value + 128` so the per-cell cost is one array read.

## Correction to the issue

The issue claimed camp gave no distinct colour to lethal, inscribed or unknown. **Reading
the code, that was wrong** — it already special-cased −1, 99 and 100. The real differences
are narrower, but still worth closing:

- Values outside 0..100 and −1 **fell through to the cost-ramp expression** and produced
  nonsense colours. The shared table covers the whole `int8` domain, including the illegal
  bands.
- Unknown was mid-grey; rviz uses a blue-grey that reads as distinct from a mid-cost cell
  rather than as part of the ramp.
- Free space was painted **blue at alpha 100**, so it obscured the chart underneath. rviz
  renders it fully transparent, and now so does camp.

## Alpha is an intended visible change

The old code varied per-cell alpha with the cost value (`value + 100`), which encoded the
same quantity twice — once in hue, once in opacity — and left free space opaque.

Alpha now comes from the palette: transparent free space, opaque everywhere else.
See-through against the chart comes from **camp's existing per-layer opacity control** (the
map tree's "opacity:" spin box, `MapItem::setOpacity`), which is one clean operator control
instead of a ramp baked into every pixel.

This is the part most worth eyeballing before merge.

## Registry tripwire

`test/test_color_map.cpp` pins `palette_names()` "so a palette add/rename/reorder is a
deliberate, visible change". It was six; rolker/marine_colormap#15 made it eight. That is
exactly the change the tripwire exists to surface — **both topo-bathy ramps now appear in
every scalar layer's Colormap menu** — so the expectation is updated rather than loosened,
and the test renamed off the count.

## Test plan

263 tests pass, 0 failures. No new warnings in the changed file.

Colour correctness is covered upstream, where the table is asserted against a transcription
of rviz's `palette_builder.cpp`. camp's part is the index arithmetic, so no new camp test
was added rather than one that would only re-test the library.

**Manual verification still owed** — camp has no CI, and this is a rendering change. Needs
eyeballing against a live or bagged occupancy grid, particularly the free-space transparency
and the layer-opacity behaviour.

Closes #199.
