### PR TITLE
docs: correct the "datum service (#288)" shorthand — the datum library is marine_vertical_datum

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -163,6 +163,18 @@ coverage of the Map model's insert/remove/reorder paths).
   the Stores tab persist as flat `GggsTileLayers/dirs`.
 - **CI + pre-commit are configured** — GitHub Actions runs the colcon build +
   gtest suite on PRs; pre-commit hooks guard formatting/config hygiene.
+- **There is no "datum service", and #288 is not one.** Vertical-datum
+  resolution lives in the ROS-free `marine_vertical_datum` library in `core_ws`
+  (`datum_config.hpp` → `resolve_datum()` returning a `DatumResult` with
+  `chart_datum_z`; `vdatum_query.hpp` → `make_vdatum_query()`). uma-ADR-0010 **D6**
+  specifies it as a *library*, not a service, and names CAMP as an intended
+  consumer ("CAMP (display-time chart-datum readouts, operator-side)"); the issue
+  that did propose a service, `mru_transform#7`, is closed and D6 records it as
+  subsumed. `ros2_agent_workspace#288` is about *where the grids live on disk*
+  (`world/`), not who resolves a datum. Older comments and the issue-180 work-plan
+  files say "until the datum service (#288)" — that shorthand is wrong on both
+  counts and has twice led agents to propose building a `chart_datum_service`.
+  When CAMP needs chart datum, it **links the library** (camp#181).
 
 ## Instructions for Use
 

--- a/src/camp/autonomousvehicleproject.h
+++ b/src/camp/autonomousvehicleproject.h
@@ -83,8 +83,11 @@ public:
     // needs no bookkeeping and can't dangle) and consults only ENABLED
     // (Layers-tab-checked / isVisible()) stores, mirroring ADR-0003 §2's
     // enabled-layer contract for getDepth. Kept separate from getDepth() because
-    // store values are ellipsoidal heights, not chart-datum depths — distinct
-    // labels until the datum service (#288).
+    // store values are ellipsoidal heights, not chart-datum depths — hence the
+    // distinct labels. Reducing them to chart datum is not wired up yet; when it
+    // is, CAMP links the ROS-free marine_vertical_datum library (uma-ADR-0010 D6),
+    // which names CAMP as an intended consumer. Tracked by camp#181. There is no
+    // datum service and D6 says there should not be one.
     float getStoreElevation(QGeoCoordinate const &location) const;
     MissionItem *potentialParentItemFor(std::string const &childType);
 

--- a/src/camp/projectview.cpp
+++ b/src/camp/projectview.cpp
@@ -211,9 +211,11 @@ void ProjectView::mouseMoveEvent(QMouseEvent *event)
 
     // [camp#180] GGGS store layers report ellipsoidal up-positive elevation, not
     // chart-datum depth. Query stores first (they take precedence) and label the
-    // value distinctly so the operator can tell the two datums apart until the
-    // datum service (#288). Both labels can appear when a store and a depth chart
-    // overlap the cursor.
+    // value distinctly so the operator can tell the two datums apart. Chart-datum
+    // reduction is not wired up yet; when it is, it comes from linking the
+    // ROS-free marine_vertical_datum library (uma-ADR-0010 D6), not from a datum
+    // service — D6 deliberately specifies a library. Tracked by camp#181. Both
+    // labels can appear when a store and a depth chart overlap the cursor.
     const float elevation = m_project->getStoreElevation(llMouse);
     if(!std::isnan(elevation))
         posText += " Elev: " + QString::number(elevation) + " (ellipsoid)";


### PR DESCRIPTION
## Summary

Comment-only correction. Two comments in shipped CAMP source deferred chart-datum
reduction to "the datum service (#288)" — a phrase that is wrong on both counts and
has already misled planning twice.

**There is no datum service, and by design there should not be one.** uma-ADR-0010
**D6** specifies the datum machinery as a **ROS-free library in `core_ws`**, which
exists today as `marine_vertical_datum` (`resolve_datum() ->
std::optional<DatumResult>` carrying `chart_datum_z`; `make_vdatum_query()`). D6
names CAMP explicitly as an intended consumer — *"the S57 exporter (per-cell,
offline), CAMP (display-time chart-datum readouts, operator-side), and
`chart_datum_node` reduced to a thin transitional wrapper."* `mru_transform#7`
(VDatum service) is **CLOSED**, and D6 records it as subsumed.

**`#288` is not a datum service.** `ros2_agent_workspace#288` governs *where the
grids live on disk* (`world/`) — not who resolves a datum.

During camp#181 planning on 2026-08-22 this shorthand caused a first plan to
propose building a `chart_datum_service`, reinventing precisely what D6 replaced.

## Changes

- `src/camp/autonomousvehicleproject.h` — `getStoreElevation()` comment now says
  chart-datum reduction is not yet wired up, and that when it is, CAMP **links**
  `marine_vertical_datum` (uma-ADR-0010 D6). Tracked by camp#181.
- `src/camp/projectview.cpp` — same correction on the cursor-readout comment.
- `.agents/README.md` — new Common Pitfalls entry recording the correction, so the
  misreading cannot recur from the code comments alone.

Deliberately **not** changed: `.agent/work-plans/issue-180/{plan,progress}.md`
carry the same shorthand, but they are append-only historical records under
ADR-0013 and should keep saying what was believed at the time.

## Verification

Every factual claim in the new text was checked against source rather than
recalled:

| Claim | Verified against |
|---|---|
| `resolve_datum()` / `DatumResult::chart_datum_z` / `make_vdatum_query()` exist | `core_ws/src/unh_marine_autonomy/marine_vertical_datum/include/**` |
| D6 quote, verbatim | `unh_marine_autonomy/docs/decisions/0010-geospatial-world-model.md:281-288` |
| mru_transform#7 is closed and subsumed | `gh issue view` → CLOSED; ADR-0010:287-288 |
| `#288` is about `world/` data placement | issue title |

No behavior change — comments and a guide file only, so no test plan.

Part of #181

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 5 (1M context)`
