### PR TITLE
Grid layers: stop crashing on removal, stop rendering hidden layers, and keep empty live-coverage cells transparent

### DIFF
--- a/.agent/work-plans/issue-209/progress.md
+++ b/.agent/work-plans/issue-209/progress.md
@@ -1,0 +1,31 @@
+---
+issue: 209
+---
+
+# Issue #209 — CAMP segfaults when a costmap layer is removed
+
+## Local Review
+**Status**: complete
+**When**: 2026-08-24 14:45 -04:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**PR**: #210 at `2670cff`
+**Mode**: post-PR
+**Depth**: Deep (reason: concurrency/lifecycle + cross-thread teardown in a GUI/ROS boundary)
+**Must-fix**: 4 | **Suggestions**: 8
+**Round**: 1 | **Ship**: continue — a startup regression in `2670cff` leaves every grid layer blank until toggled
+
+### Findings
+- [ ] (must-fix) `visible_{false}` never receives an ItemVisibleHasChanged for a layer born visible, so every costmap and grid_map layer renders nothing until manually unchecked/rechecked — `src/camp_map/ros/grids/occupancy_grid.h:37`, `src/camp_map/ros/grids/grid_map.h:104`
+- [ ] (must-fix) Live-tile caches already on disk still carry the single-slot GeoTIFF sentinel; legacy finite empties fold into overviews and get re-stamped with a NaN tag, so the purple tile survives the fix — `src/camp_map/ros/live_coverage/sonar_live_tile.cpp:335`
+- [ ] (must-fix) `~OccupancyGrid` has no shutdown gate: `subscription_.reset()` does not stop an in-flight callback, which races `process_future_` and can launch a worker into the dying object — `src/camp_map/ros/grids/occupancy_grid.cpp:100`
+- [ ] (must-fix) `SonarLiveBand` header still documents NoData as the dequantized producer sentinel, the exact contract the branch inverted — `src/camp_map/ros/live_coverage/sonar_live_tile.h:28`
+- [ ] (suggestion) `grid.data[row_start + col]` is unbounded against a short payload — heap over-read — `src/camp_map/ros/grids/occupancy_grid.cpp:163`
+- [ ] (suggestion) `setColormap()` rasterises a hidden layer, bypassing the new gate — `src/camp_map/ros/grids/grid_map.cpp:252`
+- [ ] (suggestion) `visible_` is public in OccupancyGrid but private in GridMap; nothing external writes it — `src/camp_map/ros/grids/occupancy_grid.h:37`
+- [ ] (suggestion) `visible_` sits under the "guarded by mutex_" comment block though it is deliberately lock-free — `src/camp_map/ros/grids/grid_map.h:99`
+- [ ] (suggestion) New gtest target omits the include dirs / ament deps / Qt / GDAL links every sibling target carries; builds only via transitive propagation — `CMakeLists.txt:1047`
+- [ ] (suggestion) Indexed8 scanline padding bytes are never written (uninitialised memory crosses a queued signal) — `src/camp_map/ros/grids/occupancy_grid.cpp:161`
+- [ ] (suggestion) No test instantiates either grid layer; a mirror-vs-isVisible assertion would have caught the blocking finding — `test/`
+- [ ] (suggestion) A latched OccupancyGrid publisher would stay blank after a toggle (no cached message, no re-render on show); deployed costmaps republish, so latent only — `src/camp_map/ros/grids/occupancy_grid.cpp:113`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1044,6 +1044,13 @@ if(BUILD_TESTING)
     ${GDAL_LIBRARY}
   )
 
+  # [camp#208] Multi-band NoData must survive the GeoTIFF round trip, or empty
+  # cells come back drawable and a near-empty tile paints solid.
+  ament_add_gtest(test_sonar_live_tile_nodata
+    test/test_sonar_live_tile_nodata.cpp
+  )
+  target_link_libraries(test_sonar_live_tile_nodata camp_map_ros)
+
   # [camp#168] Spawned-source tracking clears on layer destruction so the live
   # coverage layer can be re-added after remove. White-box on the manager's
   # tracking seam; same offscreen harness (GL-free / ROS-free).

--- a/src/camp_map/ros/grids/grid_map.cpp
+++ b/src/camp_map/ros/grids/grid_map.cpp
@@ -33,6 +33,14 @@ GridMap::GridMap(MapItem* parent, Node* node, QString topic):
 
   subscription_ = node->node()->create_subscription<grid_map_msgs::msg::GridMap>(topic_, qos, std::bind(&GridMap::gridMapCallback, this, std::placeholders::_1));
   setStatus("[grid_map_msgs/msg/GridMap]");
+  // [camp#208] Seed the visibility mirror from real state. A QGraphicsItem is
+  // VISIBLE from construction, and setVisibleHelper() returns before
+  // itemChange() when the state is unchanged — so map::Layer::readSettings()'s
+  // setVisible(true) fires no event. Without this seed the mirror stays false
+  // for the whole life of any layer the operator never toggles, and the layer
+  // renders nothing while looking enabled. Parenting is complete here, so
+  // isVisible() is meaningful; this runs on the GUI thread.
+  visible_.store(isVisible(), std::memory_order_relaxed);
 }
 
 

--- a/src/camp_map/ros/grids/grid_map.cpp
+++ b/src/camp_map/ros/grids/grid_map.cpp
@@ -77,12 +77,30 @@ void GridMap::onProcessFinished()
     rendering_ = false;
 }
 
+QVariant GridMap::itemChange(GraphicsItemChange change, const QVariant& value)
+{
+  // [camp#208] Becoming visible is the only chance to draw a latched dataset that
+  // arrived while this layer was hidden — nothing will republish it.
+  if(change == ItemVisibleHasChanged && value.toBool())
+  {
+    QMutexLocker lock(&mutex_);
+    if(has_last_msg_)
+      requestRenderLocked();
+  }
+  return Layer::itemChange(change, value);
+}
+
 void GridMap::gridMapCallback(const grid_map_msgs::msg::GridMap &data)
 {
   QMutexLocker lock(&mutex_);
   last_msg_ = data;       // [camp#63] keep the latest for colormap re-render
   has_last_msg_ = true;
-  requestRenderLocked();
+  // [camp#208] Keep the message (a re-render on show or on a colormap change
+  // needs it) but do NOT rasterise for a layer the operator has switched off.
+  // The render is the expensive half: a grid-sized ARGB image plus its pixmap,
+  // held for as long as the layer exists. itemChange() above repaints on show.
+  if(isVisible())
+    requestRenderLocked();
 }
 
 void GridMap::processGridMap(grid_map_msgs::msg::GridMap data, std::string colormap_name)

--- a/src/camp_map/ros/grids/grid_map.cpp
+++ b/src/camp_map/ros/grids/grid_map.cpp
@@ -38,6 +38,13 @@ GridMap::GridMap(MapItem* parent, Node* node, QString topic):
 
 GridMap::~GridMap()
 {
+  // [camp#209] Drop the subscription FIRST. shutdown_ alone was not enough: a
+  // callback arriving after it was set could still take the mutex and reach
+  // requestRenderLocked(), launching a NEW worker bound to `this` that the
+  // captured `pending` future below does not cover. Resetting the subscription
+  // stops callbacks at the source.
+  subscription_.reset();
+
   // Stop the worker from relaunching, then wait for the in-flight render so it
   // can't touch this object after destruction.
   QFuture<void> pending;
@@ -59,6 +66,10 @@ void GridMap::startRenderLocked()
 
 void GridMap::requestRenderLocked()
 {
+  // [camp#209] Never start work once teardown has begun — belt to the
+  // subscription reset in the destructor.
+  if(shutdown_)
+    return;
   if(rendering_)
     render_pending_ = true;   // coalesce; onProcessFinished() will pick it up
   else
@@ -81,11 +92,17 @@ QVariant GridMap::itemChange(GraphicsItemChange change, const QVariant& value)
 {
   // [camp#208] Becoming visible is the only chance to draw a latched dataset that
   // arrived while this layer was hidden — nothing will republish it.
-  if(change == ItemVisibleHasChanged && value.toBool())
+  if(change == ItemVisibleHasChanged)
   {
-    QMutexLocker lock(&mutex_);
-    if(has_last_msg_)
-      requestRenderLocked();
+    const bool shown = value.toBool();
+    // [camp#208] Mirror for the ROS callback thread — see visible_.
+    visible_.store(shown, std::memory_order_relaxed);
+    if(shown)
+    {
+      QMutexLocker lock(&mutex_);
+      if(has_last_msg_)
+        requestRenderLocked();
+    }
   }
   return Layer::itemChange(change, value);
 }
@@ -99,7 +116,8 @@ void GridMap::gridMapCallback(const grid_map_msgs::msg::GridMap &data)
   // needs it) but do NOT rasterise for a layer the operator has switched off.
   // The render is the expensive half: a grid-sized ARGB image plus its pixmap,
   // held for as long as the layer exists. itemChange() above repaints on show.
-  if(isVisible())
+  // [camp#208] visible_ not isVisible(): this is the ROS callback thread.
+  if(visible_.load(std::memory_order_relaxed))
     requestRenderLocked();
 }
 

--- a/src/camp_map/ros/grids/grid_map.h
+++ b/src/camp_map/ros/grids/grid_map.h
@@ -49,6 +49,14 @@ public:
   void setColormap(const std::string& name);
 
 protected:
+  /// [camp#208] Render only while the layer is actually shown, and catch the
+  /// hidden->shown transition. A GridMap dataset (an S-57 chart layer, say) is
+  /// latched: it arrives once and is never republished, so unlike a costmap this
+  /// layer cannot rely on the next message to repaint it. Skipping work while
+  /// hidden therefore REQUIRES re-rendering on the transition, or an unchecked
+  /// layer would come back permanently blank.
+  QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
+
   void contextMenu(QMenu* menu) override;
   void readSettings() override;
   void writeSettings() override;

--- a/src/camp_map/ros/grids/grid_map.h
+++ b/src/camp_map/ros/grids/grid_map.h
@@ -3,6 +3,8 @@
 
 #include "../layer.h"
 #include "grid_map_msgs/msg/grid_map.hpp"
+#include <atomic>
+
 #include <QtConcurrent>
 #include <QMutex>
 #include <QImage>
@@ -97,6 +99,10 @@ private:
   // Guards every member below — they are touched from the ROS callback thread
   // (gridMapCallback), the UI thread (setColormap / readSettings), and the
   // QtConcurrent worker (onProcessFinished).
+  /// [camp#208] Visibility mirrored from the GUI thread (itemChange) so
+  /// gridMapCallback can test it without touching GUI-owned QGraphicsItem state.
+  std::atomic<bool> visible_{false};
+
   QMutex mutex_;
   QFuture<void> process_future_;
   bool rendering_ = false;       // a worker is active

--- a/src/camp_map/ros/grids/occupancy_grid.cpp
+++ b/src/camp_map/ros/grids/occupancy_grid.cpp
@@ -31,6 +31,14 @@ OccupancyGrid::OccupancyGrid(MapItem* parent, Node* node, QString topic)
       std::bind(&OccupancyGrid::occupancyGridCallback, this, std::placeholders::_1));
 
   setStatus("[nav_msgs/msg/OccupancyGrid]");
+  // [camp#208] Seed the visibility mirror from real state. A QGraphicsItem is
+  // VISIBLE from construction, and setVisibleHelper() returns before
+  // itemChange() when the state is unchanged — so map::Layer::readSettings()'s
+  // setVisible(true) fires no event. Without this seed the mirror stays false
+  // for the whole life of any layer the operator never toggles, and the layer
+  // renders nothing while looking enabled. Parenting is complete here, so
+  // isVisible() is meaningful; this runs on the GUI thread.
+  visible_.store(isVisible(), std::memory_order_relaxed);
 }
 
 namespace
@@ -97,6 +105,7 @@ OccupancyGrid::~OccupancyGrid()
   // [camp#209] Drop the subscription FIRST: otherwise an executor-thread callback
   // can still fire while we wait and enqueue a fresh render into the object being
   // destroyed.
+  shutdown_.store(true, std::memory_order_relaxed);
   subscription_.reset();
   process_future_.waitForFinished();
 }
@@ -110,6 +119,8 @@ void OccupancyGrid::occupancyGridCallback(const nav_msgs::msg::OccupancyGrid &gr
   // refreshes on the next publish after the layer is re-enabled.
   // [camp#208] Read the mirrored flag, NOT isVisible(): this runs on the ROS
   // executor thread and QGraphicsItem state belongs to the GUI thread.
+  if(shutdown_.load(std::memory_order_relaxed))
+    return;
   if(!visible_.load(std::memory_order_relaxed))
     return;
 

--- a/src/camp_map/ros/grids/occupancy_grid.cpp
+++ b/src/camp_map/ros/grids/occupancy_grid.cpp
@@ -61,10 +61,44 @@ const std::array<QColor, 256>& costmapPalette()
   return palette;
 }
 
+/// [camp#208] The same palette as a 256-entry ARGB table, for Format_Indexed8.
+/// One byte per cell instead of four: an occupancy grid IS single-byte data, so
+/// rendering it 32-bit made the image four times larger than the grid it draws.
+const QVector<QRgb>& costmapColorTable()
+{
+  static const QVector<QRgb> table = []
+  {
+    const auto& colors = costmapPalette();
+    QVector<QRgb> rgb(256);
+    for(int i = 0; i < 256; i++)
+      rgb[i] = colors[i].rgba();
+    return rgb;
+  }();
+  return table;
+}
+
 }  // namespace
+
+OccupancyGrid::~OccupancyGrid()
+{
+  // [camp#209] Wait for the in-flight render before this object goes away — the
+  // worker is bound to `this` and writes into it. Mirrors ~GridMap() and
+  // ~RasterLayer(); its absence here segfaulted camp when the layer was removed
+  // from the Layers tab mid-render. The render window is wide (a 5000x5000 grid
+  // is 25 million cells), so this is easy to hit, not a narrow race.
+  process_future_.waitForFinished();
+}
 
 void OccupancyGrid::occupancyGridCallback(const nav_msgs::msg::OccupancyGrid &grid)
 {
+  // [camp#208] Do no work for a layer the operator has switched off. Rendering
+  // costs a full-grid pass plus a grid-sized image and pixmap that stay resident,
+  // so an unchecked costmap was one of the largest consumers in the process — work
+  // nobody asked to see. Costmaps republish on their own timer, so the display
+  // refreshes on the next publish after the layer is re-enabled.
+  if(!isVisible())
+    return;
+
   if(!process_future_.isRunning())
   {
     process_future_ = QtConcurrent::run(this, &OccupancyGrid::processOccupancyGrid, grid);
@@ -74,7 +108,17 @@ void OccupancyGrid::occupancyGridCallback(const nav_msgs::msg::OccupancyGrid &gr
 void OccupancyGrid::processOccupancyGrid(const nav_msgs::msg::OccupancyGrid &grid)
 {
   OccupancyGridData data;
-  data.grid_image = QImage(grid.info.width, grid.info.height, QImage::Format_ARGB32);
+  // [camp#208] Indexed8, not ARGB32: a quarter of the memory for identical output,
+  // since the source is one signed byte per cell and the palette has 256 entries.
+  data.grid_image = QImage(grid.info.width, grid.info.height, QImage::Format_Indexed8);
+  if(data.grid_image.isNull())
+  {
+    RCLCPP_WARN_STREAM(node_->node()->get_logger(),
+                       "Failed to allocate " << grid.info.width << "x" << grid.info.height
+                       << " occupancy grid image");
+    return;
+  }
+  data.grid_image.setColorTable(costmapColorTable());
 
   try
   {
@@ -89,19 +133,20 @@ void OccupancyGrid::processOccupancyGrid(const nav_msgs::msg::OccupancyGrid &gri
 
   data.meters_per_pixel = grid.info.resolution;
 
-  const auto& palette = costmapPalette();
-
+  // [camp#208] Write whole rows through scanLine() rather than setPixelColor() per
+  // cell. The old form cost a virtual call plus a QColor conversion for every cell —
+  // 25 million of them on a 5000x5000 costmap, on every update. The palette index IS
+  // the pixel value in Indexed8, so the inner loop is a byte store.
+  //
+  // Occupancy values are 0..100 percent, -1 for unknown, and anything else illegal;
+  // the table covers the whole int8 domain, so no value can index out of range.
   for(uint32_t row = 0; row < grid.info.height; row++)
   {
-    // occupancy grid values are 0 to 100 percent, -1 for unknown, and anything
-    // else illegal; the palette covers the whole int8 domain.
-    auto row_start = row*grid.info.width;
+    const std::size_t row_start = std::size_t(row) * grid.info.width;
+    // Source row 0 is the grid's south edge; the image is north-up.
+    uchar* dest = data.grid_image.scanLine(int(grid.info.height - 1 - row));
     for(uint32_t col = 0; col < grid.info.width; col++)
-    {
-      auto value = grid.data[row_start+col];
-      data.grid_image.setPixelColor(QPoint(col, grid.info.height-1-row),
-                                    palette[static_cast<uint8_t>(value + 128)]);
-    }
+      dest[col] = static_cast<uchar>(grid.data[row_start + col] + 128);
   }
 
   emit occupancyGridUpdated(data);

--- a/src/camp_map/ros/grids/occupancy_grid.cpp
+++ b/src/camp_map/ros/grids/occupancy_grid.cpp
@@ -79,6 +79,14 @@ const QVector<QRgb>& costmapColorTable()
 
 }  // namespace
 
+QVariant OccupancyGrid::itemChange(GraphicsItemChange change, const QVariant& value)
+{
+  // [camp#208] GUI thread: mirror visibility for the ROS callback to read.
+  if(change == ItemVisibleHasChanged)
+    visible_.store(value.toBool(), std::memory_order_relaxed);
+  return Layer::itemChange(change, value);
+}
+
 OccupancyGrid::~OccupancyGrid()
 {
   // [camp#209] Wait for the in-flight render before this object goes away — the
@@ -86,6 +94,10 @@ OccupancyGrid::~OccupancyGrid()
   // ~RasterLayer(); its absence here segfaulted camp when the layer was removed
   // from the Layers tab mid-render. The render window is wide (a 5000x5000 grid
   // is 25 million cells), so this is easy to hit, not a narrow race.
+  // [camp#209] Drop the subscription FIRST: otherwise an executor-thread callback
+  // can still fire while we wait and enqueue a fresh render into the object being
+  // destroyed.
+  subscription_.reset();
   process_future_.waitForFinished();
 }
 
@@ -96,7 +108,9 @@ void OccupancyGrid::occupancyGridCallback(const nav_msgs::msg::OccupancyGrid &gr
   // so an unchecked costmap was one of the largest consumers in the process — work
   // nobody asked to see. Costmaps republish on their own timer, so the display
   // refreshes on the next publish after the layer is re-enabled.
-  if(!isVisible())
+  // [camp#208] Read the mirrored flag, NOT isVisible(): this runs on the ROS
+  // executor thread and QGraphicsItem state belongs to the GUI thread.
+  if(!visible_.load(std::memory_order_relaxed))
     return;
 
   if(!process_future_.isRunning())

--- a/src/camp_map/ros/grids/occupancy_grid.h
+++ b/src/camp_map/ros/grids/occupancy_grid.h
@@ -36,6 +36,13 @@ public:
   /// callback reads the atomic instead.
   std::atomic<bool> visible_{false};
 
+  /// [camp#209] Set before teardown so a callback already in flight when the
+  /// destructor runs cannot start a fresh render. subscription_.reset() alone is
+  /// not enough: rclcpp's executor holds its own strong reference across
+  /// dispatch, so reset() neither cancels nor joins an in-flight callback.
+  /// Mirrors the mutex_ + shutdown_ handshake GridMap already had.
+  std::atomic<bool> shutdown_{false};
+
   /// [camp#209] Joins the in-flight render worker before teardown. Without this,
   /// removing the layer while processOccupancyGrid() is running lets the worker
   /// write into a destroyed object (SIGSEGV). GridMap and RasterLayer already do

--- a/src/camp_map/ros/grids/occupancy_grid.h
+++ b/src/camp_map/ros/grids/occupancy_grid.h
@@ -5,6 +5,8 @@
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include <QtConcurrent>
 
+#include <atomic>
+
 namespace camp
 {
 namespace ros
@@ -26,11 +28,22 @@ class OccupancyGrid: public Layer
 public:
   OccupancyGrid(MapItem* parent, Node* node, QString topic);
 
+  /// [camp#208] Visibility as seen from the ROS callback thread.
+  ///
+  /// QGraphicsItem::isVisible() is GUI-thread-owned state, and
+  /// occupancyGridCallback runs on the ROS executor thread — reading it there is
+  /// a data race. itemChange() (GUI thread) mirrors it into this atomic, and the
+  /// callback reads the atomic instead.
+  std::atomic<bool> visible_{false};
+
   /// [camp#209] Joins the in-flight render worker before teardown. Without this,
   /// removing the layer while processOccupancyGrid() is running lets the worker
   /// write into a destroyed object (SIGSEGV). GridMap and RasterLayer already do
   /// this; OccupancyGrid was the one that did not.
   ~OccupancyGrid() override;
+
+protected:
+  QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
 
 signals:
   void occupancyGridUpdated(const OccupancyGridData &data);

--- a/src/camp_map/ros/grids/occupancy_grid.h
+++ b/src/camp_map/ros/grids/occupancy_grid.h
@@ -26,6 +26,12 @@ class OccupancyGrid: public Layer
 public:
   OccupancyGrid(MapItem* parent, Node* node, QString topic);
 
+  /// [camp#209] Joins the in-flight render worker before teardown. Without this,
+  /// removing the layer while processOccupancyGrid() is running lets the worker
+  /// write into a destroyed object (SIGSEGV). GridMap and RasterLayer already do
+  /// this; OccupancyGrid was the one that did not.
+  ~OccupancyGrid() override;
+
 signals:
   void occupancyGridUpdated(const OccupancyGridData &data);
 

--- a/src/camp_map/ros/live_coverage/sonar_live_tile.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_tile.cpp
@@ -93,10 +93,28 @@ void SonarLiveTile::applyPatch(const marine_interfaces::msg::SonarVisualizationT
     if(vb.data.size() != cell_count * width_bytes)
       continue;   // declared window doesn't match the payload length
 
-    // Dequantized NoData sentinel: the shader discards cells exactly equal to it
-    // (same contract as GggsTile's per-band NoData), and untouched cells outside
-    // any received window keep it so they stay transparent.
-    const float nodata_value = static_cast<float>(vb.nodata * vb.scale + vb.offset);
+    // [camp#208] NoData is normalised to NaN, NOT kept as the dequantized
+    // producer sentinel. Bands each carry their own sentinel on the wire
+    // (quantization needs an in-range integer), but GeoTIFF's TIFFTAG_GDAL_NODATA
+    // stores ONE value per dataset — so writing three different per-band
+    // sentinels silently kept only the last and applied it to every band. On
+    // reload the other bands then had no recognised NoData, their empty cells
+    // read back as real data, and a mostly-empty tile painted solid over the
+    // chart (an 8x8 degree apex tile covering New England, in the case that
+    // found this).
+    //
+    // NaN sidesteps the one-value limit entirely: every band's sentinel is the
+    // same value, so the tag cannot be lossy, and NaN needs no tag at all to be
+    // recognised. This is also what the world store already does
+    // (marine_bathymetry_store s102/convert.cpp writes SetNoDataValue(nan)), so
+    // this brings the live cache into line with that convention rather than
+    // inventing a second one.
+    //
+    // Consumers are unaffected: every reader here guards with
+    // `!std::isfinite(v) || (has_nodata && v == nodata)`, and the !isfinite
+    // clause catches NaN — an `== nodata` test alone never would, since NaN
+    // compares unequal to itself.
+    const float nodata_value = std::numeric_limits<float>::quiet_NaN();
 
     SonarLiveBand& band = bands_[vb.name];
     if(band.data.empty())
@@ -396,8 +414,11 @@ bool SonarLiveTile::writeToGeoTiff(const std::string& path) const
     const SonarLiveBand& band = it->second;
     GDALRasterBand* raster = out->GetRasterBand(band_index);
     raster->SetDescription(band.name.c_str());
+    // [camp#208] Always NaN, and the same for every band — see the normalisation
+    // comment in applyPatch(). Writing per-band sentinels here is what lost the
+    // transparency: GeoTIFF keeps only one.
     if(band.has_nodata)
-      raster->SetNoDataValue(static_cast<double>(band.nodata));
+      raster->SetNoDataValue(std::numeric_limits<double>::quiet_NaN());
     // Const buffer: GDAL's RasterIO takes a non-const void*, but GF_Write only
     // reads from it.
     std::vector<float> scratch(band.data);

--- a/src/camp_map/ros/live_coverage/sonar_live_tile.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_tile.cpp
@@ -332,6 +332,21 @@ std::optional<SonarLiveTile> SonarLiveTile::loadFromGeoTiff(const std::string& p
     band.name = (desc && desc[0] != '\0') ? desc : ("band" + std::to_string(b));
     int has_nodata = 0;
     const double nodata = raster->GetNoDataValue(&has_nodata);
+    // [camp#208] Reject tiles written before the NaN contract. Those files were
+    // written with a per-band sentinel, and GeoTIFF keeps only ONE, so the bands
+    // that lost the slot have FINITE "empty" cells that pass every
+    // !isfinite || == nodata guard — they would fold into the range and the
+    // pyramid as real data, and the next write would stamp a NaN tag over the
+    // garbage, making the file look repaired while the pixels stayed wrong.
+    //
+    // There is no way to recover which cells were empty, so the tile is dropped
+    // rather than trusted. Its disk copy is simply not loaded; the reconciler
+    // re-requests it from the producer, which sends current data.
+    if(has_nodata != 0 && std::isfinite(nodata))
+    {
+      GDALClose(dataset);
+      return std::nullopt;
+    }
     band.has_nodata = has_nodata != 0;
     band.nodata = static_cast<float>(nodata);
     band.data.resize(cells);

--- a/src/camp_map/ros/live_coverage/sonar_live_tile.h
+++ b/src/camp_map/ros/live_coverage/sonar_live_tile.h
@@ -26,8 +26,21 @@ namespace live_coverage
 /// [camp#121] One dequantized band of a live coverage tile, held in memory as
 /// Float32. The render path duplicates GggsTileLayer's, so the cell layout
 /// matches GggsTile: row-major, **north-up** (row 0 = north), `width*height`
-/// cells. NoData is the dequantized sentinel (`raw_nodata * scale + offset`);
-/// the duplicated shader discards cells exactly equal to it, as GggsTile's does.
+/// cells.
+///
+/// **NoData is NaN** (camp#208), not the dequantized producer sentinel. Bands
+/// each carry their own sentinel on the wire — quantization needs an in-range
+/// integer — but GeoTIFF's TIFFTAG_GDAL_NODATA holds ONE value per dataset, so
+/// writing three different ones kept only the last and made empty cells read
+/// back as real data on reload. Normalising every band to NaN makes that limit
+/// harmless, and matches what the world store already does
+/// (marine_bathymetry_store s102/convert.cpp writes SetNoDataValue(nan)).
+///
+/// Consequence for readers: an `== nodata` test can NEVER match, because NaN
+/// compares unequal to itself. Always guard with
+/// `!std::isfinite(v) || (has_nodata && v == nodata)` — the !isfinite clause is
+/// what catches NoData. The shader discards on `v != v` before its finite
+/// check, so the GPU path is covered too.
 struct SonarLiveBand
 {
   std::string name;          ///< "depth" | "uncertainty" | "backscatter" | ...

--- a/test/test_sonar_live_cache.cpp
+++ b/test/test_sonar_live_cache.cpp
@@ -11,6 +11,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 #include <algorithm>
 #include <cstdint>
 #include <vector>
@@ -127,9 +129,15 @@ TEST(SonarLiveCache, PatchApplyDequantize)
   EXPECT_FLOAT_EQ(band->data[northUpIndex(2, 2)], 2.0f);   // a plain base cell
   EXPECT_FLOAT_EQ(band->data[northUpIndex(0, 0)], 5.0f);   // the peak
 
-  // NoData cell: stored as the dequantized sentinel and excluded from the range.
-  EXPECT_FLOAT_EQ(band->data[northUpIndex(1, 1)], -327.68f);
+  // [camp#208] NoData cell: stored as NaN, not the dequantized producer sentinel,
+  // and excluded from the range. Bands each carry their own sentinel on the wire,
+  // but GeoTIFF holds ONE nodata value per dataset — writing three different ones
+  // kept only the last and made empty cells read back as real data on reload.
+  // Normalising to NaN makes that limit harmless. Consumers are unaffected: they
+  // guard with !isfinite(v) || v == nodata, and !isfinite catches NaN.
+  EXPECT_TRUE(std::isnan(band->data[northUpIndex(1, 1)]));
   EXPECT_TRUE(band->has_nodata);
+  EXPECT_TRUE(std::isnan(band->nodata));
   EXPECT_FLOAT_EQ(band->data_min, 2.0f);
   EXPECT_FLOAT_EQ(band->data_max, 5.0f);
 
@@ -325,7 +333,9 @@ TEST(SonarLiveCache, FoldChildPropagatesNoData)
   {
     if(v == 4.0f)
       ++written;
-    else if(pb->has_nodata && v == pb->nodata)
+    // [camp#208] The sentinel is NaN, so an equality test can never match it —
+    // count holes the way every consumer does, with the !isfinite guard.
+    else if(!std::isfinite(v) || (pb->has_nodata && v == pb->nodata))
       ++holes;
   }
   // (kEdge/2)^2 parent cells are in the child's quadrant; the all-NoData block is a

--- a/test/test_sonar_live_tile_nodata.cpp
+++ b/test/test_sonar_live_tile_nodata.cpp
@@ -1,0 +1,140 @@
+// [camp#208] Regression: a multi-band live tile must keep its empty cells
+// TRANSPARENT across a write/reload cycle.
+//
+// The bug this pins: bands each carry their own NoData sentinel on the wire
+// (quantization needs an in-range integer), and the cache writer set that
+// sentinel per band. GeoTIFF's TIFFTAG_GDAL_NODATA stores ONE value per
+// dataset, so only the last band's sentinel survived and was applied to all of
+// them. On reload the other bands had no recognised NoData, every untouched
+// cell read back as real data, and a mostly-empty tile painted solid over the
+// chart — an 8x8 degree apex tile covering New England, in the case that found
+// this.
+//
+// The fix normalises every band's sentinel to NaN, so one slot is enough. These
+// tests fail against the pre-fix writer: with distinct per-band sentinels, the
+// band whose value lost the race reports ~100% valid cells after reload.
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdint>
+
+#include <QDir>
+#include <QTemporaryDir>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_interfaces/msg/sonar_visualization_tile.hpp"
+#include "marine_interfaces/msg/visualization_band.hpp"
+
+#include "ros/live_coverage/sonar_live_tile.h"
+
+namespace mi = marine_interfaces::msg;
+using camp::ros::live_coverage::SonarLiveTile;
+using camp::ros::live_coverage::tileIndexFromGridIndex;
+
+namespace
+{
+
+constexpr int kEdge = 8;
+constexpr int kLevel = 10;
+
+/// One band, INT16-quantized, whose own NoData sentinel differs per band — the
+/// shape that broke the GeoTIFF round trip.
+mi::VisualizationBand makeBand(const std::string& name, double nodata, double scale,
+                               double offset, std::int16_t value, int covered_cells)
+{
+  mi::VisualizationBand band;
+  band.name = name;
+  band.dtype = mi::VisualizationBand::INT16;
+  band.scale = scale;
+  band.offset = offset;
+  band.nodata = nodata;
+  const auto nd = static_cast<std::int16_t>(nodata);
+  for(int i = 0; i < kEdge * kEdge; ++i)
+  {
+    const std::int16_t raw = (i < covered_cells) ? value : nd;
+    band.data.push_back(static_cast<std::uint8_t>(raw & 0xff));
+    band.data.push_back(static_cast<std::uint8_t>((raw >> 8) & 0xff));
+  }
+  return band;
+}
+
+/// Count cells a renderer would DRAW: finite, and not the band's NoData.
+std::size_t drawableCells(const SonarLiveTile& tile, const std::string& name)
+{
+  const auto* band = tile.band(name);
+  if(!band)
+    return 0;
+  std::size_t n = 0;
+  for(float v : band->data)
+    if(std::isfinite(v) && !(band->has_nodata && v == band->nodata))
+      ++n;
+  return n;
+}
+
+mi::SonarVisualizationTile makeThreeBandPatch(const gggs::GridIndex& grid, int covered)
+{
+  mi::SonarVisualizationTile msg;
+  msg.header.stamp.sec = 100;
+  msg.header.frame_id = "gggs";
+  msg.index = tileIndexFromGridIndex(grid);
+  msg.width = kEdge;
+  msg.height = kEdge;
+  msg.window_col = 0;
+  msg.window_row = 0;
+  msg.window_width = kEdge;
+  msg.window_height = kEdge;
+  // Three DIFFERENT sentinels — one GeoTIFF nodata slot cannot hold them all.
+  msg.bands.push_back(makeBand("backscatter", 200.0, 0.01, 0.0, 150, covered));
+  msg.bands.push_back(makeBand("depth", -32768.0, 0.01, 0.0, -1500, covered));
+  msg.bands.push_back(makeBand("uncertainty", 1275.0, 0.01, 0.0, 30, covered));
+  return msg;
+}
+
+}  // namespace
+
+TEST(SonarLiveTileNoData, EmptyCellsStayTransparentAcrossReload)
+{
+  const gggs::Level level(kLevel);
+  const gggs::GridIndex grid = level.gridIndex(43.0, -70.5);
+  constexpr int kCovered = 4;   // 4 of 64 cells carry real data
+
+  SonarLiveTile tile(grid, kEdge, kEdge);
+  tile.applyPatch(makeThreeBandPatch(grid, kCovered));
+
+  // Before writing: every band reports only the covered cells as drawable.
+  for(const char* name : {"backscatter", "depth", "uncertainty"})
+    EXPECT_EQ(drawableCells(tile, name), std::size_t(kCovered)) << name << " (in memory)";
+
+  QTemporaryDir dir;
+  ASSERT_TRUE(dir.isValid());
+  const std::string path = QDir(dir.path()).filePath("tile.tif").toStdString();
+  ASSERT_TRUE(tile.writeToGeoTiff(path));
+
+  const auto reloaded = SonarLiveTile::loadFromGeoTiff(path, level);
+  ASSERT_TRUE(reloaded.has_value());
+
+  // After reload: still only the covered cells. Pre-fix, the two bands whose
+  // sentinel lost the single GeoTIFF nodata slot reported all 64 as drawable,
+  // which is what painted an empty tile solid.
+  for(const char* name : {"backscatter", "depth", "uncertainty"})
+    EXPECT_EQ(drawableCells(*reloaded, name), std::size_t(kCovered))
+      << name << " (after reload) — empty cells must not become drawable";
+}
+
+TEST(SonarLiveTileNoData, SentinelIsNaNSoOneGeoTiffSlotSuffices)
+{
+  const gggs::Level level(kLevel);
+  const gggs::GridIndex grid = level.gridIndex(43.0, -70.5);
+
+  SonarLiveTile tile(grid, kEdge, kEdge);
+  tile.applyPatch(makeThreeBandPatch(grid, 4));
+
+  // Every band normalises to the SAME sentinel, which is what makes the
+  // one-value-per-dataset GeoTIFF limit harmless.
+  for(const char* name : {"backscatter", "depth", "uncertainty"})
+  {
+    const auto* band = tile.band(name);
+    ASSERT_NE(band, nullptr) << name;
+    EXPECT_TRUE(std::isnan(band->nodata)) << name << " sentinel should be NaN";
+  }
+}


### PR DESCRIPTION
## Summary

Four defects found while investigating the CAMP out-of-memory kill (#208). Three are memory or display; one is a crash. All were surfaced by operator use rather than by inspection — removing a layer, and a giant purple tile over the chart.

## 1. SIGSEGV when removing a costmap layer (#209)

`OccupancyGrid` dispatches its render to a worker bound to `this` via `QtConcurrent::run`, and **had no destructor**. Remove the layer mid-render and the worker writes into a destroyed object.

Both siblings already handle this — `~GridMap()` is documented as *"joins the in-flight render worker before teardown"* and `~RasterLayer()` calls `future_watcher_.waitForFinished()`. `OccupancyGrid` was simply missed. The window is wide, not narrow: a 5000×5000 costmap is 25 M cells per render.

## 2. Work done for layers the operator switched off (#208)

There was **no visibility gate anywhere** in either grid layer. CAMP auto-creates a layer for every `OccupancyGrid`/`GridMap` topic with a publisher (`GridManager::updateTopics`), which on the sim is **eleven layers**: one costmap plus ten S-57 chart datasets. Each rendered on arrival regardless of whether it was checked, and each holds a grid-sized image plus its pixmap for as long as the layer exists.

On the dev host an **unchecked** costmap layer was among the largest consumers in the process.

`GridMap` needed more than the costmap's gate: those datasets are **latched** — an S-57 chart layer publishes once and never again, so skipping the render while hidden would leave it permanently blank when re-enabled. A costmap self-heals on its next publish; this cannot. `itemChange(ItemVisibleHasChanged)` therefore re-renders from the retained message on the hidden→shown transition.

## 3. The costmap image was 4× larger than the data it draws (#208)

`Format_ARGB32` at grid resolution — 100 MB for a 5000×5000 grid whose source is one signed byte per cell. Now `Format_Indexed8` using the 256-entry table built from the palette **this file already had**; identical output, a quarter of the memory.

The fill also stopped being per-pixel: `setPixelColor()` cost a virtual call plus a `QColor` conversion for every one of those 25 million cells, on every update. Rows now go through `scanLine()`, where the palette index *is* the pixel value.

## 4. Live coverage painted empty cells opaque (#208) — the purple tile

A mostly-empty tile painted solid over the chart: an **8°×8° apex tile covering all of New England**, drawn opaque because its empty cells read back as real depths of −327.68 m.

Bands each carry their own NoData sentinel on the wire (quantization needs an in-range integer), and the cache writer called `SetNoDataValue()` **once per band**. GeoTIFF's `TIFFTAG_GDAL_NODATA` holds **one value per dataset**, so only the last band's sentinel survived and was applied to all three. CAMP logged this itself and it was mistaken for GDAL noise:

```
Warning 1: band 2: Setting nodata to -327.67999267578125 on band 2, but band 1
has nodata at 2.0039370059967041. The TIFFTAG_GDAL_NODATA only support one
value per dataset.
```

`gdalinfo` on the real tile shows the consequence exactly:

| band | stored NoData | content | valid |
|---|---|---|---|
| backscatter | 12.75 | constant 2.004 | **100%** |
| depth | 12.75 | constant −327.68 | **100%** |
| uncertainty | 12.75 | real data | **0.004%** |

Only `uncertainty` — whose sentinel won the race — knows it is nearly empty.

**Normalising every band to NaN** removes the failure mode rather than working around it: one slot is enough when all bands agree, and NaN needs no tag at all to be recognised. This also matches what the world store already does (`marine_bathymetry_store` `s102/convert.cpp` writes `SetNoDataValue(nan)`), so the live cache stops being the one place with its own convention.

**No consumer changes were needed** — every reader already guards with `!std::isfinite(v) || (has_nodata && v == nodata)`, and the `!isfinite` clause catches NaN.

## Test plan

**293 tests, 0 failures, 1 skipped** (pre-existing).

New `test_sonar_live_tile_nodata` builds a three-band tile with distinct wire sentinels, writes it, reloads it, and asserts only genuinely covered cells are drawable. **Negative-controlled**: with the fix reverted it fails on exactly `backscatter` and `depth` while `uncertainty` passes — reproducing the field asymmetry above rather than an approximation of it.

Two existing tests asserted the **old** contract and were updated, not bypassed:

- `PatchApplyDequantize` expected the empty cell to equal `-327.68`; it now asserts NaN, and that the band's `nodata` is NaN.
- `FoldChildPropagatesNoData` counted holes with `v == nodata`, which can never match NaN; it now uses the `!isfinite` guard — the same one every consumer already used, which is precisely why no production code needed changing.

### Not verified

**No GUI eyeball since these landed.** The riskiest path is the S-57 visibility transition: uncheck an S-57 layer and re-check it — it must come back, not stay blank. That is latched data with no republish, so a headless test cannot fully cover it.

### Deliberately out of scope

CAMP still auto-subscribes to every grid topic. Making that opt-in is the largest remaining memory lever and the operator's stated preference, but it changes what appears in the Layers tab and is not something to land the night before a survey. To be filed separately.

Closes #209
Part of #208
