### PR TITLE
fix: join the Polygon render worker in the destructor

### DIFF
--- a/.agent/work-plans/issue-213/progress.md
+++ b/.agent/work-plans/issue-213/progress.md
@@ -1,0 +1,31 @@
+---
+issue: 213
+---
+
+# Issue #213 — SIGSEGV risk: Polygon layer has no destructor, so its render worker outlives it (same defect as #209)
+
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-08-24 16:43 -04:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: changes-requested
+
+**Branch**: feature/issue-213 at `c97153c` (uncommitted working tree; HEAD == origin/jazzy)
+**Mode**: pre-push
+**Depth**: Light (26-line, 2-file diff) with the adversarial pass primed on the Deep concurrency/lifecycle lens
+**Must-fix**: 2 | **Suggestions**: 3
+**Round**: 1 | **Ship**: continue — a new `std::terminate` path in the destructor must be closed before push
+
+### Findings
+- [ ] (must-fix) Worker exception rethrown by `waitForFinished()` escapes the destructor (implicitly noexcept) -> `std::terminate`; `frameOriginInWebMercator` throws `tf2::TransformException` on TF cold start. Wrap the transform in try/catch as `occupancy_grid.cpp:148` and `grid_map.cpp:160` already do — `src/camp_map/ros/geometry/polygon.cpp:57` (join at `:41`)
+- [ ] (must-fix) `waitForFinished()` can steal-and-run the still-queued worker on the GUI thread inside the destructor, making `emit newPolygonData` a direct call so `updatePolygon()` mutates scene state during teardown and bypasses the new gate. Re-check `shutdown_` immediately before the emit — `src/camp_map/ros/geometry/polygon.cpp:63`
+- [ ] (suggestion) Gate narrows but does not close the launch window: a callback preempted after the `shutdown_` check can still assign `process_future_` after the join returned. Same residual as merged OccupancyGrid; recorded as the camp#212 `shared_ptr<CallbackState>` follow-up. GridMap's `mutex_` + `shutdown_` handshake (`grid_map.cpp:47`) closes it in ~15 lines if wanted tonight — `src/camp_map/ros/geometry/polygon.cpp:41`
+- [ ] (suggestion) `memory_order_relaxed` is functionally adequate (nothing is published through the flag), but the comments assert a store ordering relaxed does not provide; use seq_cst or soften the wording — `src/camp_map/ros/geometry/polygon.cpp:36`, `polygon.h:49`
+- [ ] (suggestion, pre-existing) The constructed `rclcpp::QoS qos(10); qos.durability_volatile();` is never passed to `create_subscription` (plain depth `10` is used), so the configured QoS is silently discarded — `src/camp_map/ros/geometry/polygon.cpp:24`
+
+### Verified clean
+- No cross-thread Qt access in `processPolygon`: it touches only `QPolygonF`/`QPointF`, and the TF cache is mutex-guarded in `ros::Layer`. No camp#208-style `isVisible()` race, so the absence of a `visible_` mirror and an `itemChange` override is correct — Polygon has no per-update rasterisation cost to gate.
+- Queued `newPolygonData` events pending at destruction are safe (`~QObject` removes posted events for the receiver).
+- Destructor runs on the GUI thread (`map/layer.cpp:70` `deleteLater()`); the join is short for polygon-sized work, so no meaningful UI stall.
+- Static analysis: no C++ linter is configured in camp's pre-commit; ament_cpplint findings on these files are pre-existing house-style divergences, none introduced by this diff.

--- a/.agent/work-plans/issue-213/progress.md
+++ b/.agent/work-plans/issue-213/progress.md
@@ -29,3 +29,25 @@ issue: 213
 - Queued `newPolygonData` events pending at destruction are safe (`~QObject` removes posted events for the receiver).
 - Destructor runs on the GUI thread (`map/layer.cpp:70` `deleteLater()`); the join is short for polygon-sized work, so no meaningful UI stall.
 - Static analysis: no C++ linter is configured in camp's pre-commit; ament_cpplint findings on these files are pre-existing house-style divergences, none introduced by this diff.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-08-24 19:22 -04:00
+**By**: Claude Code Agent (Claude Opus 5)
+
+**PR**: #214 at `1cbe25f`
+**Sources**: 2 (Copilot R1 @ `1cbe25f`, Local Review (Pre-Push) @ `c97153c`)
+**Cross-source confirmations**: 1
+**CI**: all-pass (build-and-test, copilot-pull-request-reviewer)
+
+### Findings
+- [ ] (cross-confirmed) `process_future_` is read/written from two threads without synchronization — the ROS executor thread calls `isRunning()` and assigns it in `polygonCallback`, while the GUI thread reads it in `~Polygon()`. That is a C++ data race (UB), and it leaves the launch window open: a callback already executing when `subscription_.reset()` returns can assign a NEW worker after the destructor captured/joined. Fix by mirroring `GridMap` (`grid_map.cpp:47-64`): add a `QMutex mutex_`, reset the subscription FIRST, then under the lock set `shutdown_` and copy `process_future_` into a local `pending`, and `waitForFinished()` on the copy OUTSIDE the lock. `polygonCallback` takes the same lock to check the gate and assign; `processPolygon`'s pre-emit re-check takes it too (no deadlock — the destructor releases the lock before joining) — `src/camp_map/ros/geometry/polygon.cpp:48`, `polygon.h:49`
+- [ ] (suggestion, pre-existing, Local Review) The constructed `rclcpp::QoS qos(10); qos.durability_volatile();` is never passed to `create_subscription` (plain depth `10` is used), so the configured QoS is silently discarded — `src/camp_map/ros/geometry/polygon.cpp:24`
+
+### Resolved this round
+- (must-fix, Local Review) Worker exception rethrown by `waitForFinished()` escaping the noexcept destructor -> `std::terminate`. Fixed in `1cbe25f`: `processPolygon` wraps the transform in try/catch and warns.
+- (must-fix, Local Review) `waitForFinished()` steal-and-run making the emit a direct call during teardown. Fixed in `1cbe25f`: `shutdown_` re-checked immediately before the emit.
+- (suggestion, Local Review) Comments overclaimed what `memory_order_relaxed` guarantees. Fixed in `1cbe25f`: wording softened to say the flag is advisory and the join is what synchronizes.
+
+### False positives
+- None. Copilot's single finding is valid and corroborates the pre-push review's own residual note.

--- a/src/camp_map/ros/geometry/polygon.cpp
+++ b/src/camp_map/ros/geometry/polygon.cpp
@@ -33,19 +33,33 @@ Polygon::Polygon(MapItem* parent, Node* node, QString topic):
 
 Polygon::~Polygon()
 {
-  // [camp#213] Order matters: raise the gate, stop new callbacks at the source,
-  // then wait for the render already running. Resetting the subscription alone
-  // does not close the window — the executor can already be inside a callback.
-  // The flag is advisory (the join is what actually synchronizes), so relaxed
-  // ordering is sufficient.
-  shutdown_.store(true, std::memory_order_relaxed);
+  // [camp#213] Stop callbacks at the source FIRST. Raising the gate alone does
+  // not close the window: a callback that already passed the gate check can
+  // still assign a NEW worker bound to `this`, which the future captured below
+  // would not cover.
   subscription_.reset();
-  process_future_.waitForFinished();
+
+  // Then, under the lock, close the gate and take a copy of whatever render is
+  // in flight. Joining the copy OUTSIDE the lock is what makes this safe against
+  // the steal-and-run case: waitForFinished() may run the worker on this very
+  // thread, and that worker takes mutex_ before its pre-emit check. Mirrors
+  // GridMap::~GridMap().
+  QFuture<void> pending;
+  {
+    QMutexLocker lock(&mutex_);
+    shutdown_ = true;
+    pending = process_future_;
+  }
+  pending.waitForFinished();
 }
 
 void Polygon::polygonCallback(const geometry_msgs::msg::PolygonStamped::SharedPtr data)
 {
-  if(shutdown_.load(std::memory_order_relaxed))
+  // [camp#213] Check the gate and assign the future under one lock, so the
+  // destructor cannot observe a half-updated process_future_ and cannot be
+  // raced past between the check and the launch.
+  QMutexLocker lock(&mutex_);
+  if(shutdown_)
     return;
   if(!process_future_.isRunning())
   {
@@ -81,8 +95,12 @@ void Polygon::processPolygon(const geometry_msgs::msg::PolygonStamped::SharedPtr
   // [camp#213] waitForFinished() may steal a still-queued runnable and run it on
   // the GUI thread inside ~Polygon(). The emit would then be a direct call into
   // updatePolygon(), parenting a new item to a dying layer. Re-check the gate.
-  if(shutdown_.load(std::memory_order_relaxed))
-    return;
+  // Safe to lock here: the destructor releases mutex_ before it joins.
+  {
+    QMutexLocker lock(&mutex_);
+    if(shutdown_)
+      return;
+  }
 
   emit newPolygonData(polygon_data);
 }

--- a/src/camp_map/ros/geometry/polygon.cpp
+++ b/src/camp_map/ros/geometry/polygon.cpp
@@ -31,8 +31,22 @@ Polygon::Polygon(MapItem* parent, Node* node, QString topic):
   setStatus("[geometry_msgs/msg/PolygonStamped]");
 }
 
+Polygon::~Polygon()
+{
+  // [camp#213] Order matters: raise the gate, stop new callbacks at the source,
+  // then wait for the render already running. Resetting the subscription alone
+  // does not close the window — the executor can already be inside a callback.
+  // The flag is advisory (the join is what actually synchronizes), so relaxed
+  // ordering is sufficient.
+  shutdown_.store(true, std::memory_order_relaxed);
+  subscription_.reset();
+  process_future_.waitForFinished();
+}
+
 void Polygon::polygonCallback(const geometry_msgs::msg::PolygonStamped::SharedPtr data)
 {
+  if(shutdown_.load(std::memory_order_relaxed))
+    return;
   if(!process_future_.isRunning())
   {
     process_future_ = QtConcurrent::run(this, &Polygon::processPolygon, data);
@@ -42,12 +56,34 @@ void Polygon::polygonCallback(const geometry_msgs::msg::PolygonStamped::SharedPt
 void Polygon::processPolygon(const geometry_msgs::msg::PolygonStamped::SharedPtr data)
 {
   PolygonData polygon_data;
-  polygon_data.position = frameOriginInWebMercator(data->header);
+
+  // [camp#213] The destructor joins this worker, and a destructor is implicitly
+  // noexcept — an escaping exception would be std::terminate(), not a crash we
+  // could diagnose. frameOriginInWebMercator() throws tf2::TransformException on
+  // a TF cold start, which is routine, so it must never leave this function.
+  // Matches the guards in OccupancyGrid::processGrid() and GridMap::render().
+  try
+  {
+    polygon_data.position = frameOriginInWebMercator(data->header);
+  }
+  catch(const std::exception& e)
+  {
+    RCLCPP_WARN_STREAM(node_->node()->get_logger(),
+        "Failed to transform polygon origin: " << e.what());
+    return;
+  }
 
   for(const auto& point: data->polygon.points)
   {
     polygon_data.polygon << QPointF(point.x, point.y);
   }
+
+  // [camp#213] waitForFinished() may steal a still-queued runnable and run it on
+  // the GUI thread inside ~Polygon(). The emit would then be a direct call into
+  // updatePolygon(), parenting a new item to a dying layer. Re-check the gate.
+  if(shutdown_.load(std::memory_order_relaxed))
+    return;
+
   emit newPolygonData(polygon_data);
 }
 

--- a/src/camp_map/ros/geometry/polygon.h
+++ b/src/camp_map/ros/geometry/polygon.h
@@ -5,6 +5,8 @@
 #include "geometry_msgs/msg/polygon_stamped.hpp"
 #include <QtConcurrent>
 
+#include <atomic>
+
 namespace camp
 {
 namespace ros
@@ -25,6 +27,12 @@ class Polygon: public Layer
 public:
   Polygon(MapItem* parent, Node* node, QString topic);
 
+  /// [camp#213] Joins the in-flight render worker before teardown. Without this,
+  /// removing the layer while processPolygon() runs lets a worker bound to `this`
+  /// write into a destroyed object (SIGSEGV) — the same defect fixed for
+  /// OccupancyGrid in camp#209.
+  ~Polygon() override;
+
 signals:
   void newPolygonData(PolygonData data);
 
@@ -37,6 +45,12 @@ private:
   rclcpp::Subscription<geometry_msgs::msg::PolygonStamped>::SharedPtr subscription_;
 
   QFuture<void> process_future_;
+
+  /// [camp#213] Set before teardown so a callback already dispatched when the
+  /// destructor runs cannot start a fresh render. subscription_.reset() alone is
+  /// not enough: rclcpp's executor holds its own strong reference across
+  /// dispatch, so reset() neither cancels nor joins an in-flight callback.
+  std::atomic<bool> shutdown_{false};
 
 };
 

--- a/src/camp_map/ros/geometry/polygon.h
+++ b/src/camp_map/ros/geometry/polygon.h
@@ -4,8 +4,7 @@
 #include "../layer.h"
 #include "geometry_msgs/msg/polygon_stamped.hpp"
 #include <QtConcurrent>
-
-#include <atomic>
+#include <QMutex>
 
 namespace camp
 {
@@ -44,13 +43,22 @@ private slots:
 private:
   rclcpp::Subscription<geometry_msgs::msg::PolygonStamped>::SharedPtr subscription_;
 
+  /// [camp#213] Guards process_future_ and shutdown_, which are both touched
+  /// from the ROS executor thread (polygonCallback) and the GUI thread
+  /// (~Polygon). Without it the future is read and assigned concurrently, which
+  /// is a data race, and the gate below can be passed by a callback that then
+  /// launches a worker the destructor has already joined past. Mirrors the
+  /// handshake in GridMap (grids/grid_map.h).
+  QMutex mutex_;
+
   QFuture<void> process_future_;
 
   /// [camp#213] Set before teardown so a callback already dispatched when the
   /// destructor runs cannot start a fresh render. subscription_.reset() alone is
   /// not enough: rclcpp's executor holds its own strong reference across
   /// dispatch, so reset() neither cancels nor joins an in-flight callback.
-  std::atomic<bool> shutdown_{false};
+  /// Guarded by mutex_.
+  bool shutdown_ = false;
 
 };
 


### PR DESCRIPTION
Removing a Polygon layer from the layer tree freed the object while its
`QtConcurrent` render worker was still running — the same defect fixed for
`OccupancyGrid` in #209/#210. The operator triggers it by unchecking a layer.

`~Polygon()` now raises a `shutdown_` gate, resets the subscription to stop new
callbacks at the source, then joins the running worker; `polygonCallback` checks
the gate before launching more work.

## Two hazards specific to joining in a destructor

Pre-push review caught both — neither is in the `OccupancyGrid` precedent as a
visible pattern, and the first is a regression the join itself introduces:

- **`waitForFinished()` rethrows the worker's stored exception**, and a
  destructor is implicitly `noexcept`. `frameOriginInWebMercator()` throws
  `tf2::TransformException` on a TF cold start — routine for a layer
  auto-created for a topic whose frame isn't in TF yet — so an unguarded join
  turns that into `std::terminate()`, strictly worse than the race being fixed.
  `processPolygon()` now catches and warns, matching
  `OccupancyGrid::processGrid()` and `GridMap::render()`.
- **`waitForFinished()` may steal a still-queued runnable** and run it on the
  GUI thread inside the destructor. The `emit` then becomes a direct call into
  `updatePolygon()`, parenting a new `QGraphicsPolygonItem` to a dying layer and
  defeating the gate. The gate is re-checked immediately before the `emit`.

## Deliberately not replicated

The visibility gate and `itemChange` mirror `OccupancyGrid` carries are omitted:
`processPolygon` is a short point loop with no rasterisation cost and touches no
GUI-thread-owned state, so there is no camp#208 race to mirror.

## Known residual

A callback preempted *after* passing the `shutdown_` check can still resume
after the join returns. This is the camp#212 residual and is present in the
merged `OccupancyGrid` fix too — `GridMap`'s `mutex_` + `shutdown_` handshake
closes it. Not fixed here to keep the pre-Shoals diff minimal; tracked in #212.

## Test plan

- `./ui_ws/build.sh camp` — builds clean (one pre-existing unused-variable
  warning in `geometry_manager.cpp`)
- `./ui_ws/test.sh camp` — **293 tests, 0 errors, 0 failures, 1 skipped**
- Runtime verification of layer removal is owed on the sim before the Shoals
  deployment.

Closes #213

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 5`
